### PR TITLE
Refactor: Enhance POM configurations for backend libraries

### DIFF
--- a/backend-libs/praxis-bom/pom.xml
+++ b/backend-libs/praxis-bom/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>org.praxisplatform</groupId>
+    <artifactId>praxis-bom</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Praxis Bill of Materials (BOM)</name>
+    <description>BOM for Praxis framework libraries. Import this POM in your projects to manage Praxis library versions.</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <praxis.version>1.0.0-SNAPSHOT</praxis.version>
+        <!-- Add SCM info similar to other modules -->
+        <scm.connection>scm:git:https://github.com/your-organization/your-repository.git</scm.connection>
+        <scm.developerConnection>scm:git:ssh://git@github.com/your-organization/your-repository.git</scm.developerConnection>
+        <scm.url>https://github.com/your-organization/your-repository</scm.url>
+        <scm.tag>HEAD</scm.tag>
+    </properties>
+
+    <scm>
+        <connection>${scm.connection}</connection>
+        <developerConnection>${scm.developerConnection}</developerConnection>
+        <url>${scm.url}</url>
+        <tag>${scm.tag}</tag>
+    </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.praxisplatform</groupId>
+                <artifactId>praxis-metadata-core</artifactId>
+                <version>${praxis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.praxisplatform</groupId>
+                <artifactId>praxis-metadata-springdoc</artifactId>
+                <version>${praxis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.praxisplatform</groupId>
+                <artifactId>praxis-spring-boot-starter</artifactId>
+                <version>${praxis.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip> <!-- BOMs are not repackaged -->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/backend-libs/praxis-metadata-core/pom.xml
+++ b/backend-libs/praxis-metadata-core/pom.xml
@@ -15,7 +15,14 @@
 
     <name>Praxis Metadata Core</name>
     <description>Core definitions for the Praxis UI Metadata framework, including annotations and property interfaces.</description>
+    <scm>
+        <connection>scm:git:https://github.com/your-organization/your-repository.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/your-organization/your-repository.git</developerConnection>
+        <url>https://github.com/your-organization/your-repository</url>
+        <tag>HEAD</tag>
+    </scm>
     <properties>
+        <swagger-annotations.version>2.2.22</swagger-annotations.version>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -39,7 +46,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.2.22</version> </dependency>
+            <version>${swagger-annotations.version}</version> </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/backend-libs/praxis-metadata-springdoc/pom.xml
+++ b/backend-libs/praxis-metadata-springdoc/pom.xml
@@ -15,6 +15,12 @@
 
     <name>Praxis Metadata SpringDoc Integration</name>
     <description>SpringDoc/OpenAPI integration for the Praxis UI Metadata framework. Processes Praxis annotations to enrich API documentation.</description>
+    <scm>
+        <connection>scm:git:https://github.com/your-organization/your-repository.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/your-organization/your-repository.git</developerConnection>
+        <url>https://github.com/your-organization/your-repository</url>
+        <tag>HEAD</tag>
+    </scm>
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -42,13 +48,6 @@
         </dependency>
 
 
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId> </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId> </dependency>

--- a/backend-libs/praxis-spring-boot-starter/pom.xml
+++ b/backend-libs/praxis-spring-boot-starter/pom.xml
@@ -15,6 +15,12 @@
 
     <name>Praxis Spring Boot Starter</name>
     <description>Spring Boot starter for Praxis UI Metadata framework</description>
+    <scm>
+        <connection>scm:git:https://github.com/your-organization/your-repository.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/your-organization/your-repository.git</developerConnection>
+        <url>https://github.com/your-organization/your-repository</url>
+        <tag>HEAD</tag>
+    </scm>
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This commit introduces several improvements to the POM files for the `praxis-metadata-core`, `praxis-metadata-springdoc`, and `praxis-spring-boot-starter` libraries.

Key changes include:
- Standardized version management for `swagger-annotations` in `praxis-metadata-core` using a property.
- Optimized dependencies in `praxis-metadata-springdoc` by removing redundant Spring framework dependencies, relying on transitive dependencies from `spring-boot-starter-web`.
- Added SCM (Source Control Management) information to all three library POMs to aid build tools and documentation. (Note: Placeholder URLs are used and need to be updated).
- Introduced a new `praxis-bom` (Bill of Materials) module. This BOM will simplify version management for projects consuming these Praxis libraries in the future. It also includes placeholder SCM information.

These changes aim to improve maintainability, consistency, and prepare the project for future growth.