### PR TITLE
Refactor HR module to use AbstractCrudController and BaseCrudService

### DIFF
--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
@@ -51,8 +51,6 @@ public abstract class AbstractCrudController<E, D extends GenericFilterDTO, ID> 
     // ------------------------------------------------------------------------
     public final String SCHEMAS_FILTERED_PATH = "/schemas/filtered";
 
-    protected final BaseCrudService<E, ID> service;
-
     /**
      * Retorna o serviço base (CRUD) que será usado internamente.
      */
@@ -88,11 +86,6 @@ public abstract class AbstractCrudController<E, D extends GenericFilterDTO, ID> 
      * (Opcional) Retorna o path base para fins de documentação ou links (se desejar).
      */
     protected abstract String getBasePath();
-
-
-    public AbstractCrudController() {
-        this.service = service;
-    }
 
     /**
      * Endpoint para filtrar entidades.

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/CargoController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/CargoController.java
@@ -2,97 +2,55 @@ package com.example.praxis.hr.controller;
 
 import com.example.praxis.hr.dto.CargoDTO;
 import com.example.praxis.hr.entity.Cargo;
-import com.example.praxis.hr.repository.CargoRepository;
+import com.example.praxis.hr.mapper.CargoMapper;
+import com.example.praxis.hr.service.CargoService;
+import org.praxisplatform.uischema.controller.base.AbstractCrudController;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/hr/cargos")
-public class CargoController {
+public class CargoController extends AbstractCrudController<Cargo, CargoDTO, Long> {
 
     @Autowired
-    private CargoRepository cargoRepository;
+    private CargoService cargoService;
 
-    // DTO to Entity
-    private Cargo toEntity(CargoDTO dto) {
-        Cargo entity = new Cargo();
-        // ID is typically not set from DTO for create, but needed for update
-        if (dto.getId() != null) {
-            entity.setId(dto.getId());
-        }
-        entity.setNome(dto.getNome());
-        entity.setNivel(dto.getNivel());
-        entity.setDescricao(dto.getDescricao());
-        entity.setSalarioMinimo(dto.getSalarioMinimo());
-        entity.setSalarioMaximo(dto.getSalarioMaximo());
-        return entity;
+    @Autowired
+    private CargoMapper cargoMapper;
+
+    @Override
+    protected CargoService getService() {
+        return cargoService;
     }
 
-    // Entity to DTO
-    private CargoDTO toDTO(Cargo entity) {
-        CargoDTO dto = new CargoDTO();
-        dto.setId(entity.getId());
-        dto.setNome(entity.getNome());
-        dto.setNivel(entity.getNivel());
-        dto.setDescricao(entity.getDescricao());
-        dto.setSalarioMinimo(entity.getSalarioMinimo());
-        dto.setSalarioMaximo(entity.getSalarioMaximo());
-        return dto;
+    @Override
+    protected CargoDTO toDto(Cargo entity) {
+        return cargoMapper.toDto(entity);
     }
 
-    @PostMapping
-    public ResponseEntity<CargoDTO> createCargo(@RequestBody CargoDTO cargoDTO) {
-        Cargo cargo = toEntity(cargoDTO);
-        // Ensure ID is not set for new entities to allow auto-generation
-        cargo.setId(null); 
-        Cargo savedCargo = cargoRepository.save(cargo);
-        return ResponseEntity.status(HttpStatus.CREATED).body(toDTO(savedCargo));
+    @Override
+    protected Cargo toEntity(CargoDTO dto) {
+        return cargoMapper.toEntity(dto);
     }
 
-    @GetMapping
-    public ResponseEntity<List<CargoDTO>> getAllCargos() {
-        List<CargoDTO> cargos = cargoRepository.findAll().stream()
-                .map(this::toDTO)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(cargos);
+    @Override
+    protected Class<? extends AbstractCrudController<Cargo, CargoDTO, Long>> getControllerClass() {
+        return CargoController.class;
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<CargoDTO> getCargoById(@PathVariable Long id) {
-        Optional<Cargo> cargoOptional = cargoRepository.findById(id);
-        return cargoOptional.map(cargo -> ResponseEntity.ok(toDTO(cargo)))
-                .orElseGet(() -> ResponseEntity.notFound().build());
+    @Override
+    protected Long getEntityId(Cargo entity) {
+        return entity.getId();
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<CargoDTO> updateCargo(@PathVariable Long id, @RequestBody CargoDTO cargoDTO) {
-        Optional<Cargo> cargoOptional = cargoRepository.findById(id);
-        if (!cargoOptional.isPresent()) {
-            return ResponseEntity.notFound().build();
-        }
-        Cargo existingCargo = cargoOptional.get();
-        existingCargo.setNome(cargoDTO.getNome());
-        existingCargo.setNivel(cargoDTO.getNivel());
-        existingCargo.setDescricao(cargoDTO.getDescricao());
-        existingCargo.setSalarioMinimo(cargoDTO.getSalarioMinimo());
-        existingCargo.setSalarioMaximo(cargoDTO.getSalarioMaximo());
-        
-        Cargo updatedCargo = cargoRepository.save(existingCargo);
-        return ResponseEntity.ok(toDTO(updatedCargo));
+    @Override
+    protected Long getDtoId(CargoDTO dto) {
+        return dto.getId();
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteCargo(@PathVariable Long id) {
-        if (!cargoRepository.existsById(id)) {
-            return ResponseEntity.notFound().build();
-        }
-        cargoRepository.deleteById(id);
-        return ResponseEntity.noContent().build();
+    @Override
+    protected String getBasePath() {
+        return "/api/hr/cargos";
     }
 }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/DepartamentoController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/DepartamentoController.java
@@ -2,104 +2,57 @@ package com.example.praxis.hr.controller;
 
 import com.example.praxis.hr.dto.DepartamentoDTO;
 import com.example.praxis.hr.entity.Departamento;
-import com.example.praxis.hr.entity.Funcionario;
-import com.example.praxis.hr.repository.DepartamentoRepository;
-import com.example.praxis.hr.repository.FuncionarioRepository;
+import com.example.praxis.hr.mapper.DepartamentoMapper;
+import com.example.praxis.hr.service.DepartamentoService;
+import org.praxisplatform.uischema.controller.base.AbstractCrudController;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/hr/departamentos")
-public class DepartamentoController {
+public class DepartamentoController extends AbstractCrudController<Departamento, DepartamentoDTO, Long> {
 
     @Autowired
-    private DepartamentoRepository departamentoRepository;
+    private DepartamentoService departamentoService;
 
     @Autowired
-    private FuncionarioRepository funcionarioRepository;
+    private DepartamentoMapper departamentoMapper;
 
-    // DTO to Entity
-    private Departamento toEntity(DepartamentoDTO dto) {
-        Departamento entity = new Departamento();
-        // ID is typically not set from DTO for create, but needed for update
-        if (dto.getId() != null) {
-            entity.setId(dto.getId());
-        }
-        entity.setNome(dto.getNome());
-        entity.setCodigo(dto.getCodigo());
-        if (dto.getResponsavelId() != null) {
-            funcionarioRepository.findById(dto.getResponsavelId()).ifPresent(entity::setResponsavel);
-        }
-        return entity;
+    @Override
+    protected DepartamentoService getService() {
+        return departamentoService;
     }
 
-    // Entity to DTO
-    private DepartamentoDTO toDTO(Departamento entity) {
-        DepartamentoDTO dto = new DepartamentoDTO();
-        dto.setId(entity.getId());
-        dto.setNome(entity.getNome());
-        dto.setCodigo(entity.getCodigo());
-        if (entity.getResponsavel() != null) {
-            dto.setResponsavelId(entity.getResponsavel().getId());
-        }
-        return dto;
+    @Override
+    protected DepartamentoDTO toDto(Departamento entity) {
+        return departamentoMapper.toDto(entity);
     }
 
-    @PostMapping
-    public ResponseEntity<DepartamentoDTO> createDepartamento(@RequestBody DepartamentoDTO departamentoDTO) {
-        Departamento departamento = toEntity(departamentoDTO);
-        // Ensure ID is not set for new entities to allow auto-generation
-        departamento.setId(null);
-        Departamento savedDepartamento = departamentoRepository.save(departamento);
-        return ResponseEntity.status(HttpStatus.CREATED).body(toDTO(savedDepartamento));
+    @Override
+    protected Departamento toEntity(DepartamentoDTO dto) {
+        // The mapper creates an entity with responsavel_id set if present.
+        // The DepartamentoService's save/update methods will handle fetching the actual Funcionario entity.
+        return departamentoMapper.toEntity(dto);
     }
 
-    @GetMapping
-    public ResponseEntity<List<DepartamentoDTO>> getAllDepartamentos() {
-        List<DepartamentoDTO> departamentos = departamentoRepository.findAll().stream()
-                .map(this::toDTO)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(departamentos);
+    @Override
+    protected Class<? extends AbstractCrudController<Departamento, DepartamentoDTO, Long>> getControllerClass() {
+        return DepartamentoController.class;
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<DepartamentoDTO> getDepartamentoById(@PathVariable Long id) {
-        Optional<Departamento> departamentoOptional = departamentoRepository.findById(id);
-        return departamentoOptional.map(departamento -> ResponseEntity.ok(toDTO(departamento)))
-                .orElseGet(() -> ResponseEntity.notFound().build());
+    @Override
+    protected Long getEntityId(Departamento entity) {
+        return entity.getId();
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<DepartamentoDTO> updateDepartamento(@PathVariable Long id, @RequestBody DepartamentoDTO departamentoDTO) {
-        Optional<Departamento> departamentoOptional = departamentoRepository.findById(id);
-        if (!departamentoOptional.isPresent()) {
-            return ResponseEntity.notFound().build();
-        }
-        Departamento existingDepartamento = departamentoOptional.get();
-        existingDepartamento.setNome(departamentoDTO.getNome());
-        existingDepartamento.setCodigo(departamentoDTO.getCodigo());
-        if (departamentoDTO.getResponsavelId() != null) {
-            funcionarioRepository.findById(departamentoDTO.getResponsavelId()).ifPresent(existingDepartamento::setResponsavel);
-        } else {
-            existingDepartamento.setResponsavel(null);
-        }
-        
-        Departamento updatedDepartamento = departamentoRepository.save(existingDepartamento);
-        return ResponseEntity.ok(toDTO(updatedDepartamento));
+    @Override
+    protected Long getDtoId(DepartamentoDTO dto) {
+        return dto.getId();
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteDepartamento(@PathVariable Long id) {
-        if (!departamentoRepository.existsById(id)) {
-            return ResponseEntity.notFound().build();
-        }
-        departamentoRepository.deleteById(id);
-        return ResponseEntity.noContent().build();
+    @Override
+    protected String getBasePath() {
+        return "/api/hr/departamentos";
     }
 }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/FuncionarioController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/FuncionarioController.java
@@ -18,10 +18,6 @@ package com.example.praxis.hr.controller;
         @Autowired
         private FuncionarioMapper funcionarioMapper;
 
-        public FuncionarioController() {
-            super(getService());
-        }
-
         @Override
         protected Funcionario toEntity(FuncionarioDTO dto) {
             return funcionarioMapper.toEntity(dto);

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/CargoDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/CargoDTO.java
@@ -2,10 +2,11 @@ package com.example.praxis.hr.dto;
 
 import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import org.praxisplatform.uischema.extension.annotation.UISchema;
+import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
 
 import java.math.BigDecimal;
 
-public class CargoDTO {
+public class CargoDTO extends GenericFilterDTO {
 
     @UISchema
     private Long id;

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/DepartamentoDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/DepartamentoDTO.java
@@ -2,8 +2,9 @@ package com.example.praxis.hr.dto;
 
 import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import org.praxisplatform.uischema.extension.annotation.UISchema;
+import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
 
-public class DepartamentoDTO {
+public class DepartamentoDTO extends GenericFilterDTO {
 
     @UISchema
     private Long id;

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/mapper/CargoMapper.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/mapper/CargoMapper.java
@@ -1,0 +1,54 @@
+package com.example.praxis.hr.mapper;
+
+import com.example.praxis.hr.dto.CargoDTO;
+import com.example.praxis.hr.entity.Cargo;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+import java.util.List;
+
+@Component
+public class CargoMapper {
+
+    public Cargo toEntity(CargoDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+        Cargo entity = new Cargo();
+        entity.setId(dto.getId()); // ID is mapped for updates
+        entity.setNome(dto.getNome());
+        entity.setNivel(dto.getNivel());
+        entity.setDescricao(dto.getDescricao());
+        entity.setSalarioMinimo(dto.getSalarioMinimo());
+        entity.setSalarioMaximo(dto.getSalarioMaximo());
+        return entity;
+    }
+
+    public CargoDTO toDto(Cargo entity) {
+        if (entity == null) {
+            return null;
+        }
+        CargoDTO dto = new CargoDTO();
+        dto.setId(entity.getId());
+        dto.setNome(entity.getNome());
+        dto.setNivel(entity.getNivel());
+        dto.setDescricao(entity.getDescricao());
+        dto.setSalarioMinimo(entity.getSalarioMinimo());
+        dto.setSalarioMaximo(entity.getSalarioMaximo());
+        return dto;
+    }
+
+    public List<CargoDTO> toDtoList(List<Cargo> entityList) {
+        if (entityList == null) {
+            return null;
+        }
+        return entityList.stream().map(this::toDto).collect(Collectors.toList());
+    }
+
+    public List<Cargo> toEntityList(List<CargoDTO> dtoList) {
+        if (dtoList == null) {
+            return null;
+        }
+        return dtoList.stream().map(this::toEntity).collect(Collectors.toList());
+    }
+}

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/mapper/DepartamentoMapper.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/mapper/DepartamentoMapper.java
@@ -1,0 +1,59 @@
+package com.example.praxis.hr.mapper;
+
+import com.example.praxis.hr.dto.DepartamentoDTO;
+import com.example.praxis.hr.entity.Departamento;
+import com.example.praxis.hr.entity.Funcionario;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+import java.util.List;
+
+@Component
+public class DepartamentoMapper {
+
+    public Departamento toEntity(DepartamentoDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+        Departamento entity = new Departamento();
+        entity.setId(dto.getId()); // ID is mapped for updates
+        entity.setNome(dto.getNome());
+        entity.setCodigo(dto.getCodigo());
+        if (dto.getResponsavelId() != null) {
+            Funcionario responsavel = new Funcionario();
+            responsavel.setId(dto.getResponsavelId());
+            entity.setResponsavel(responsavel); // Service layer will resolve this to a managed entity
+        } else {
+            entity.setResponsavel(null);
+        }
+        return entity;
+    }
+
+    public DepartamentoDTO toDto(Departamento entity) {
+        if (entity == null) {
+            return null;
+        }
+        DepartamentoDTO dto = new DepartamentoDTO();
+        dto.setId(entity.getId());
+        dto.setNome(entity.getNome());
+        dto.setCodigo(entity.getCodigo());
+        if (entity.getResponsavel() != null) {
+            dto.setResponsavelId(entity.getResponsavel().getId());
+        }
+        return dto;
+    }
+
+    public List<DepartamentoDTO> toDtoList(List<Departamento> entityList) {
+        if (entityList == null) {
+            return null;
+        }
+        return entityList.stream().map(this::toDto).collect(Collectors.toList());
+    }
+
+    public List<Departamento> toEntityList(List<DepartamentoDTO> dtoList) {
+        if (dtoList == null) {
+            return null;
+        }
+        return dtoList.stream().map(this::toEntity).collect(Collectors.toList());
+    }
+}

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/service/CargoService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/service/CargoService.java
@@ -1,0 +1,44 @@
+package com.example.praxis.hr.service;
+
+import com.example.praxis.hr.entity.Cargo;
+import com.example.praxis.hr.repository.CargoRepository;
+import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
+import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
+import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CargoService implements BaseCrudService<Cargo, Long> {
+
+    @Autowired
+    private CargoRepository cargoRepository;
+
+    @Override
+    public BaseCrudRepository<Cargo, Long> getRepository() {
+        return cargoRepository;
+    }
+
+    @Override
+    public GenericSpecificationsBuilder<Cargo> getSpecificationsBuilder() {
+        // Assuming default behavior is sufficient for now
+        return new GenericSpecificationsBuilder<>();
+    }
+
+    @Override
+    public Class<Cargo> getEntityClass() {
+        return Cargo.class;
+    }
+
+    @Override
+    public Cargo mergeUpdate(Cargo existing, Cargo payload) {
+        existing.setNome(payload.getNome());
+        existing.setNivel(payload.getNivel());
+        existing.setDescricao(payload.getDescricao());
+        existing.setSalarioMinimo(payload.getSalarioMinimo());
+        existing.setSalarioMaximo(payload.getSalarioMaximo());
+        return existing;
+    }
+
+    // No need to override save() unless specific pre-save logic for Cargo is required.
+}

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/service/DepartamentoService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/service/DepartamentoService.java
@@ -1,0 +1,68 @@
+package com.example.praxis.hr.service;
+
+import com.example.praxis.hr.entity.Departamento;
+import com.example.praxis.hr.entity.Funcionario;
+import com.example.praxis.hr.repository.DepartamentoRepository;
+import com.example.praxis.hr.repository.FuncionarioRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
+import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
+import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DepartamentoService implements BaseCrudService<Departamento, Long> {
+
+    @Autowired
+    private DepartamentoRepository departamentoRepository;
+
+    @Autowired
+    private FuncionarioRepository funcionarioRepository; // Needed to resolve responsavelId
+
+    @Override
+    public BaseCrudRepository<Departamento, Long> getRepository() {
+        return departamentoRepository;
+    }
+
+    @Override
+    public GenericSpecificationsBuilder<Departamento> getSpecificationsBuilder() {
+        return new GenericSpecificationsBuilder<>();
+    }
+
+    @Override
+    public Class<Departamento> getEntityClass() {
+        return Departamento.class;
+    }
+
+    private void resolveRelations(Departamento departamento) {
+        if (departamento.getResponsavel() != null && departamento.getResponsavel().getId() != null) {
+            Funcionario responsavel = funcionarioRepository.findById(departamento.getResponsavel().getId())
+                    .orElseThrow(() -> new EntityNotFoundException("Funcionário responsável não encontrado com ID: " + departamento.getResponsavel().getId()));
+            departamento.setResponsavel(responsavel);
+        } else {
+            departamento.setResponsavel(null); // Explicitly set to null if ID is not provided
+        }
+    }
+
+    @Override
+    @Transactional
+    public Departamento save(Departamento departamento) {
+        resolveRelations(departamento);
+        return departamentoRepository.save(departamento);
+    }
+
+    @Override
+    @Transactional
+    public Departamento mergeUpdate(Departamento existing, Departamento payload) {
+        existing.setNome(payload.getNome());
+        existing.setCodigo(payload.getCodigo());
+
+        // Set responsavel from payload for relation resolution
+        existing.setResponsavel(payload.getResponsavel());
+        resolveRelations(existing); // Resolve relations on the existing entity
+
+        return existing; // The save will be called by the default update method in BaseCrudService
+    }
+}

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/service/FuncionarioService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/service/FuncionarioService.java
@@ -41,7 +41,7 @@ public class FuncionarioService implements BaseCrudService<Funcionario, Long> {
      */
     @Override
     public Class<Funcionario> getEntityClass() {
-        return null;
+        return Funcionario.class; // Changed from null
     }
 
     @Override


### PR DESCRIPTION
This commit addresses the issue of ensuring that AbstractCrudController and BaseCrudService from the praxis-metadata-core library are fully implemented and functional in the praxis-backend-libs-sample-app example project.

Key changes include:

1.  **AbstractCrudController:**
    *   Removed the internal 'service' field and constructor to prevent NullPointerExceptions in subclasses during initialization. Subclasses now reliably provide the service instance via the getService() method.

2.  **Funcionario:**
    *   `FuncionarioController`: Constructor fixed.
    *   `FuncionarioService`: `getEntityClass()` now correctly returns `Funcionario.class`. The existing `save` and `mergeUpdate` methods were confirmed to correctly handle `Cargo` and `Departamento` relationships.

3.  **Cargo:**
    *   `CargoController`: Refactored to extend `AbstractCrudController`.
    *   `CargoService`: Created, implementing `BaseCrudService`. Includes a `mergeUpdate` method.
    *   `CargoMapper`: Created for `Cargo` <-> `CargoDTO` conversion.
    *   `CargoDTO`: Modified to extend `GenericFilterDTO`.

4.  **Departamento:**
    *   `DepartamentoController`: Refactored to extend `AbstractCrudController`.
    *   `DepartamentoService`: Created, implementing `BaseCrudService`. Includes `save` and `mergeUpdate` overrides to correctly handle the `responsavel` (Funcionario) relationship using `FuncionarioRepository`.
    *   `DepartamentoMapper`: Created for `Departamento` <-> `DepartamentoDTO` conversion.
    *   `DepartamentoDTO`: Modified to extend `GenericFilterDTO`.

All CRUD operations for Funcionario, Cargo, and Departamento should now be handled through the standardized library abstractions, including HATEOAS links and schema generation capabilities provided by AbstractCrudController.