### PR TITLE
feat: Introduce dedicated DTO for filter operations in CRUD mechanism

### DIFF
--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
@@ -28,9 +28,10 @@ import java.util.List;
  *
  * @param <E>  Entidade (ex.: TipoTelefone)
  * @param <D>  DTO correspondente (ex.: TipoTelefoneDto)
+ * @param <FD> DTO de filtro correspondente (ex.: TipoTelefoneFilterDto)
  * @param <ID> Tipo do identificador (ex.: Long, String, etc.)
  */
-public abstract class AbstractCrudController<E, D extends GenericFilterDTO, ID> {
+public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, ID> {
 
     // ------------------------------------------------------------------------
     // Base Path do OpenAPI
@@ -70,7 +71,7 @@ public abstract class AbstractCrudController<E, D extends GenericFilterDTO, ID> 
      * Retorna a classe concreta do controller (ex.: TipoTelefoneController.class)
      * para uso no método methodOn(...) do HATEOAS.
      */
-    protected abstract Class<? extends AbstractCrudController<E, D, ID>> getControllerClass();
+    protected abstract Class<? extends AbstractCrudController<E, D, FD, ID>> getControllerClass();
 
     /**
      * Extrai o identificador (ex.: entity.getId()) para montar links e location.
@@ -105,7 +106,7 @@ public abstract class AbstractCrudController<E, D extends GenericFilterDTO, ID> 
                             required = true,
                             content = @Content(
                                     mediaType = "application/json",
-                                    schema = @Schema(implementation = GenericFilterDTO.class) // Substituir pelo DTO genérico
+                                    schema = @Schema(implementation = FD.class) // Substituir pelo DTO genérico
                             )
                     ),
                     @Parameter(
@@ -126,7 +127,7 @@ public abstract class AbstractCrudController<E, D extends GenericFilterDTO, ID> 
             }
     )
     public ResponseEntity<RestApiResponse<Page<EntityModel<D>>>> filter(
-            @RequestBody D filterDTO,
+            @RequestBody FD filterDTO,
             Pageable pageable
     ) {
         Page<E> page = getService().filter(filterDTO, pageable);

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/filter/specification/GenericSpecificationsBuilder.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/filter/specification/GenericSpecificationsBuilder.java
@@ -54,14 +54,14 @@ public class GenericSpecificationsBuilder<E> {
      * @return Um GenericSpecification que armazena uma Specification genérica para ser usada em repositórios
      * Spring Data JPA e um Pageable ajustado conforme o DTO de entrada.
      */
-    public GenericSpecification<E> buildSpecification(GenericFilterDTO filter, Pageable pageable) {
+    public <FDT extends GenericFilterDTO> GenericSpecification<E> buildSpecification(FDT filter, Pageable pageable) {
         return new GenericSpecification<>(
                 processSpecification(filter),
                 processPageable(filter, pageable)
         );
     }
 
-    private Specification<E> processSpecification(GenericFilterDTO filter) {
+    private <FDT extends GenericFilterDTO> Specification<E> processSpecification(FDT filter) {
         return (root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new ArrayList<>();
 
@@ -75,7 +75,7 @@ public class GenericSpecificationsBuilder<E> {
         };
     }
 
-    private Pageable processPageable(GenericFilterDTO filter, Pageable oldPageable) {
+    private <FDT extends GenericFilterDTO> Pageable processPageable(FDT filter, Pageable oldPageable) {
         Sort sort = oldPageable.getSort();
         if (!sort.isSorted()) {
             return oldPageable;
@@ -101,7 +101,7 @@ public class GenericSpecificationsBuilder<E> {
      * @param filter Instância do DTO de filtro.
      * @return Lista de campos anotados.
      */
-    private List<Field> getAnnotatedFields(GenericFilterDTO filter) {
+    private <FDT extends GenericFilterDTO> List<Field> getAnnotatedFields(FDT filter) {
         List<Field> annotatedFields = new ArrayList<>();
         for (Field field : filter.getClass().getDeclaredFields()) {
             if (field.isAnnotationPresent(Filterable.class)) {
@@ -127,7 +127,7 @@ public class GenericSpecificationsBuilder<E> {
      * @param criteriaBuilder Construtor de critérios JPA.
      * @param predicates      Lista de predicados a ser preenchida.
      */
-    private void processField(Field field, GenericFilterDTO filter, Root<E> root,
+    private <FDT extends GenericFilterDTO> void processField(Field field, FDT filter, Root<E> root,
                               CriteriaBuilder criteriaBuilder, List<Predicate> predicates) {
         try {
             field.setAccessible(true);

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/BaseCrudService.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/BaseCrudService.java
@@ -22,8 +22,9 @@ import java.util.List;
  *
  * @param <E>  Tipo da entidade
  * @param <ID> Tipo do identificador
+ * @param <FD> Tipo do DTO de filtro
  */
-public interface BaseCrudService<E, ID> {
+public interface BaseCrudService<E, ID, FD extends GenericFilterDTO> {
 
     BaseCrudRepository<E, ID> getRepository();
     GenericSpecificationsBuilder<E> getSpecificationsBuilder();
@@ -56,7 +57,7 @@ public interface BaseCrudService<E, ID> {
         return getRepository().findAll(sortedPageable);
     }
 
-    default Page<E> filter(GenericFilterDTO filterDTO, Pageable pageable) {
+    default Page<E> filter(FD filterDTO, Pageable pageable) {
         Pageable sortedPageable = pageable;
         if (!pageable.getSort().isSorted()) {
             sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), getDefaultSort());

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/FuncionarioController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/FuncionarioController.java
@@ -1,6 +1,7 @@
 package com.example.praxis.hr.controller;
 
     import com.example.praxis.hr.dto.FuncionarioDTO;
+    import com.example.praxis.hr.dto.FuncionarioFilterDTO;
     import com.example.praxis.hr.entity.Funcionario;
     import com.example.praxis.hr.mapper.FuncionarioMapper;
     import com.example.praxis.hr.service.FuncionarioService;
@@ -10,7 +11,7 @@ package com.example.praxis.hr.controller;
 
     @RestController
     @RequestMapping("/api/hr/funcionarios")
-    public class FuncionarioController extends AbstractCrudController<Funcionario, FuncionarioDTO, Long> {
+    public class FuncionarioController extends AbstractCrudController<Funcionario, FuncionarioDTO, FuncionarioFilterDTO, Long> {
 
         @Autowired
         private FuncionarioService funcionarioService;
@@ -34,7 +35,7 @@ package com.example.praxis.hr.controller;
         }
 
         @Override
-        protected Class<? extends AbstractCrudController<Funcionario, FuncionarioDTO, Long>> getControllerClass() {
+        protected Class<? extends AbstractCrudController<Funcionario, FuncionarioDTO, FuncionarioFilterDTO, Long>> getControllerClass() {
             return FuncionarioController.class;
         }
 

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/FuncionarioFilterDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/FuncionarioFilterDTO.java
@@ -1,0 +1,41 @@
+package com.example.praxis.hr.dto;
+
+import org.praxisplatform.uischema.filter.annotation.Filterable;
+import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
+
+public class FuncionarioFilterDTO implements GenericFilterDTO {
+
+    @Filterable(operation = Filterable.FilterOperation.LIKE)
+    private String nomeCompleto;
+
+    @Filterable(operation = Filterable.FilterOperation.EQUAL)
+    private String cpf;
+
+    @Filterable(operation = Filterable.FilterOperation.EQUAL, relation = "cargo.id")
+    private Long cargoId;
+
+    // Getters and Setters
+    public String getNomeCompleto() {
+        return nomeCompleto;
+    }
+
+    public void setNomeCompleto(String nomeCompleto) {
+        this.nomeCompleto = nomeCompleto;
+    }
+
+    public String getCpf() {
+        return cpf;
+    }
+
+    public void setCpf(String cpf) {
+        this.cpf = cpf;
+    }
+
+    public Long getCargoId() {
+        return cargoId;
+    }
+
+    public void setCargoId(Long cargoId) {
+        this.cargoId = cargoId;
+    }
+}

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/service/FuncionarioService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/service/FuncionarioService.java
@@ -1,5 +1,6 @@
 package com.example.praxis.hr.service;
 
+import com.example.praxis.hr.dto.FuncionarioFilterDTO;
 import com.example.praxis.hr.entity.Cargo;
 import com.example.praxis.hr.entity.Departamento;
 import com.example.praxis.hr.entity.Endereco;
@@ -15,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class FuncionarioService implements BaseCrudService<Funcionario, Long> {
+public class FuncionarioService implements BaseCrudService<Funcionario, Long, FuncionarioFilterDTO> {
 
     @Autowired
     private FuncionarioRepository funcionarioRepository;

--- a/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/hr/controller/FuncionarioControllerTest.java
+++ b/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/hr/controller/FuncionarioControllerTest.java
@@ -1,0 +1,91 @@
+package com.example.praxis.hr.controller;
+
+import com.example.praxis.hr.dto.FuncionarioDTO;
+import com.example.praxis.hr.dto.FuncionarioFilterDTO;
+import com.example.praxis.hr.entity.Funcionario;
+import com.example.praxis.hr.mapper.FuncionarioMapper;
+import com.example.praxis.hr.service.FuncionarioService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.praxisplatform.uischema.rest.response.RestApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
+
+@WebMvcTest(FuncionarioController.class)
+public class FuncionarioControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FuncionarioService funcionarioService;
+
+    @MockBean
+    private FuncionarioMapper funcionarioMapper;
+
+    @Autowired
+    private ObjectMapper objectMapper; // For converting DTO to JSON
+
+    @Test
+    public void whenFilterWithFuncionarioFilterDTO_thenReturnsOkAndFilteredResults() throws Exception {
+        FuncionarioFilterDTO filterDTO = new FuncionarioFilterDTO();
+        filterDTO.setNomeCompleto("Test User");
+
+        Funcionario mockFuncionario = new Funcionario();
+        mockFuncionario.setId(1L);
+        mockFuncionario.setNomeCompleto("Test User Name");
+        // ... other necessary fields for FuncionarioDTO conversion
+
+        List<Funcionario> mockList = Collections.singletonList(mockFuncionario);
+        PageImpl<Funcionario> funcionarioPage = new PageImpl<>(mockList, PageRequest.of(0, 10), 1);
+
+        FuncionarioDTO mockFuncionarioDTO = new FuncionarioDTO();
+        mockFuncionarioDTO.setId(1L);
+        mockFuncionarioDTO.setNomeCompleto("Test User Name");
+        // ... other fields if needed for the DTO
+
+        when(funcionarioMapper.toDto(any(Funcionario.class))).thenReturn(mockFuncionarioDTO);
+
+        when(funcionarioService.filter(any(FuncionarioFilterDTO.class), any(Pageable.class)))
+                .thenReturn(funcionarioPage);
+
+        // Mocking the DTO conversion that happens in AbstractCrudController
+        // This part is tricky as toDto is protected.
+        // A more robust test would involve an integration test or ensuring mapper is available.
+        // For this unit test, we'll focus on the endpoint and service call.
+        // The response assertion will be basic due to this.
+
+        MvcResult result = mockMvc.perform(post("/api/hr/funcionarios/filter")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(filterDTO))
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("SUCCESS")))
+                .andExpect(jsonPath("$.data.content", hasSize(1)))
+                // Example of asserting content - assuming FuncionarioDTO has 'nomeCompleto'
+                // and that the mapper correctly converts the mockFuncionario
+                .andExpect(jsonPath("$.data.content[0].dto.nomeCompleto", is("Test User Name")))
+                .andReturn();
+
+        // System.out.println(result.getResponse().getContentAsString());
+    }
+}


### PR DESCRIPTION
This change refactors the generic CRUD components (`AbstractCrudController`, `BaseCrudService`, `GenericSpecificationsBuilder`) to support the use of a separate DTO for filter operations, distinct from the DTO used for create, update, and response payloads.

Key changes:
- `AbstractCrudController` now takes an additional generic parameter `FD extends GenericFilterDTO` for the filter DTO. The `/filter` endpoint uses this `FD`.
- `BaseCrudService` is updated with the `FD` generic parameter, and its `filter` method now accepts this `FD`.
- `GenericSpecificationsBuilder`'s `buildSpecification` method and its helpers are made generic (`<FDT extends GenericFilterDTO>`) to work with any filter DTO.
- The sample `Funcionario` entity has been updated:
    - A new `FuncionarioFilterDTO` is created with specific filterable fields.
    - `FuncionarioController` and `FuncionarioService` are updated to use `FuncionarioFilterDTO` for filtering.
- A new test, `FuncionarioControllerTest`, has been added to verify the filtering functionality with `FuncionarioFilterDTO`.

This enhancement provides greater flexibility by allowing more tailored DTOs for filtering, potentially simplifying filter logic and reducing payload size for filter requests.