### PR TITLE
Fix pageable order mapping

### DIFF
--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/filter/specification/GenericSpecificationsBuilder.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/filter/specification/GenericSpecificationsBuilder.java
@@ -80,7 +80,11 @@ public class GenericSpecificationsBuilder<E> {
         if (!sort.isSorted()) {
             return oldPageable;
         }
-        List<Sort.Order> orderList = sort.get().map(order -> {
+        // Spring Data's Sort exposes the orders through the {@code stream()} method.
+        // Using {@code get()} would fail to compile on newer versions where the
+        // method does not exist. The stream is then mapped to keep the original
+        // direction while replacing the property when a relation is configured.
+        List<Sort.Order> orderList = sort.stream().map(order -> {
             try {
                 Field field = filter.getClass().getDeclaredField(order.getProperty());
                 Filterable filterable = field.getAnnotation(Filterable.class);


### PR DESCRIPTION
## Summary
- use `Sort.stream()` when mapping pageable orders to avoid build errors

## Testing
- `javac -version`
- `mvn -q -pl backend-libs/praxis-metadata-core test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da7992bd083288edd157a906faa63