### PR TITLE
Configure praxis-sample-app for praxis-metadata-core

### DIFF
--- a/examples/praxis-backend-libs-sample-app/pom.xml
+++ b/examples/praxis-backend-libs-sample-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.2.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -17,7 +17,7 @@
     <description>Sample project for Praxis Backend Libs</description>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <praxis.version>1.0.0-SNAPSHOT</praxis.version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
     </properties>

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/MetadataCoreUser.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/MetadataCoreUser.java
@@ -1,0 +1,11 @@
+package com.example.praxis;
+
+import org.praxisplatform.metadata.core.annotations.PraxisEntity;
+
+public class MetadataCoreUser {
+
+    public static void main(String[] args) {
+        // Simple usage to ensure the class from the dependency can be resolved.
+        System.out.println("Successfully accessed PraxisEntity annotation: " + PraxisEntity.class.getSimpleName());
+    }
+}


### PR DESCRIPTION
- I've aligned Spring Boot parent to 3.2.5 and Java to 21 in praxis-sample-app's POM.
- I've also added MetadataCoreUser.java in praxis-sample-app to demonstrate usage of a class from praxis-metadata-core.

Note: You'll need to perform further building and testing of praxis-sample-app once praxis-metadata-core is built locally and other missing Praxis dependencies (praxis-bom, praxis-spring-boot-starter, etc.) are resolved.