### PR TITLE
Fix crud base classes

### DIFF
--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
@@ -70,8 +70,15 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
     /**
      * Retorna a classe concreta do controller (ex.: TipoTelefoneController.class)
      * para uso no método methodOn(...) do HATEOAS.
+     *
+     * <p>Fornece uma implementação padrão baseada em {@link #getClass()},
+     * mas pode ser sobrescrito caso o comportamento padrão não seja
+     * adequado.</p>
      */
-    protected abstract Class<? extends AbstractCrudController<E, D, FD, ID>> getControllerClass();
+    @SuppressWarnings("unchecked")
+    protected Class<? extends AbstractCrudController<E, D, FD, ID>> getControllerClass() {
+        return (Class<? extends AbstractCrudController<E, D, FD, ID>>) getClass();
+    }
 
     /**
      * Extrai o identificador (ex.: entity.getId()) para montar links e location.

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/BaseCrudService.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/BaseCrudService.java
@@ -92,7 +92,7 @@ public interface BaseCrudService<E, ID, FD extends GenericFilterDTO> {
     }
 
     default EntityNotFoundException getNotFoundException() {
-        return new EntityNotFoundException("Registro não encontrado");
+        return new EntityNotFoundException("Registro não encontrado");
     }
 
     // Helper method to get all fields from class and its superclasses

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/CargoController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/CargoController.java
@@ -35,10 +35,6 @@ public class CargoController extends AbstractCrudController<Cargo, com.example.p
         return cargoMapper.toEntity(dto);
     }
 
-    @Override
-    protected Class<? extends AbstractCrudController<Cargo, com.example.praxis.hr.dto.CargoDTO, com.example.praxis.hr.dto.CargoFilterDTO, Long>> getControllerClass() {
-        return CargoController.class;
-    }
 
     @Override
     protected Long getEntityId(Cargo entity) {

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/DepartamentoController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/DepartamentoController.java
@@ -37,10 +37,6 @@ public class DepartamentoController extends AbstractCrudController<Departamento,
         return departamentoMapper.toEntity(dto);
     }
 
-    @Override
-    protected Class<? extends AbstractCrudController<Departamento, com.example.praxis.hr.dto.DepartamentoDTO, com.example.praxis.hr.dto.DepartamentoFilterDTO, Long>> getControllerClass() {
-        return DepartamentoController.class;
-    }
 
     @Override
     protected Long getEntityId(Departamento entity) {

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/FuncionarioController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/controller/FuncionarioController.java
@@ -34,10 +34,6 @@ package com.example.praxis.hr.controller;
             return funcionarioService;
         }
 
-        @Override
-        protected Class<? extends AbstractCrudController<Funcionario, FuncionarioDTO, FuncionarioFilterDTO, Long>> getControllerClass() {
-            return FuncionarioController.class;
-        }
 
         @Override
         protected Long getEntityId(Funcionario entity) {


### PR DESCRIPTION
## Summary
- fix PT-BR accent in BaseCrudService's not-found message
- provide a default implementation for `getControllerClass` in `AbstractCrudController`
- rely on new default method in sample controllers

## Testing
- `mvn -q -pl examples/praxis-backend-libs-sample-app test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684db0ed966c8328a8178daf13342637