### PR TITLE
Refactor: Unify UI metadata processing in CustomOpenApiResolver

### DIFF
--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/util/OpenApiUiUtils.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/util/OpenApiUiUtils.java
@@ -138,6 +138,60 @@ public class OpenApiUiUtils {
         }
     }
 
+    public static void populateUiGroup(Map<String, Object> xUiMap, String group) {
+        if (group != null && !group.isEmpty() && !xUiMap.containsKey(FieldConfigProperties.GROUP.getValue())) {
+            xUiMap.put(FieldConfigProperties.GROUP.getValue(), group);
+        }
+    }
+
+    public static void populateUiOrder(Map<String, Object> xUiMap, int order) {
+        if (order != 0 && !xUiMap.containsKey(FieldConfigProperties.ORDER.getValue())) {
+            xUiMap.put(FieldConfigProperties.ORDER.getValue(), String.valueOf(order));
+        }
+    }
+
+    public static void populateUiWidth(Map<String, Object> xUiMap, String width) {
+        if (width != null && !width.isEmpty() && !xUiMap.containsKey(FieldConfigProperties.WIDTH.getValue())) {
+            xUiMap.put(FieldConfigProperties.WIDTH.getValue(), width);
+        }
+    }
+
+    public static void populateUiIcon(Map<String, Object> xUiMap, String icon) {
+        if (icon != null && !icon.isEmpty() && !xUiMap.containsKey(FieldConfigProperties.ICON.getValue())) {
+            xUiMap.put(FieldConfigProperties.ICON.getValue(), icon);
+        }
+    }
+
+    public static void populateUiDisabled(Map<String, Object> xUiMap, boolean disabled) {
+        if (disabled && !xUiMap.containsKey(FieldConfigProperties.DISABLED.getValue())) {
+            xUiMap.put(FieldConfigProperties.DISABLED.getValue(), Boolean.TRUE);
+        }
+    }
+
+    public static void populateUiHidden(Map<String, Object> xUiMap, boolean hidden) {
+        if (hidden && !xUiMap.containsKey(FieldConfigProperties.HIDDEN.getValue())) {
+            xUiMap.put(FieldConfigProperties.HIDDEN.getValue(), Boolean.TRUE);
+        }
+    }
+
+    public static void populateUiEditable(Map<String, Object> xUiMap, boolean editable) {
+        if (!editable && !xUiMap.containsKey(FieldConfigProperties.EDITABLE.getValue())) {
+            xUiMap.put(FieldConfigProperties.EDITABLE.getValue(), Boolean.FALSE);
+        }
+    }
+
+    public static void populateUiSortable(Map<String, Object> xUiMap, boolean sortable) {
+        if (!sortable && !xUiMap.containsKey(FieldConfigProperties.SORTABLE.getValue())) {
+            xUiMap.put(FieldConfigProperties.SORTABLE.getValue(), Boolean.FALSE);
+        }
+    }
+
+    public static void populateUiFilterable(Map<String, Object> xUiMap, boolean filterable) {
+        if (filterable && !xUiMap.containsKey(FieldConfigProperties.FILTERABLE.getValue())) {
+            xUiMap.put(FieldConfigProperties.FILTERABLE.getValue(), Boolean.TRUE);
+        }
+    }
+
     public static void populateUiHelpText(Map<String, Object> xUiMap, String description) {
         if (description != null && !description.isEmpty() && !xUiMap.containsKey(FieldConfigProperties.HELP_TEXT.getValue())) {
             xUiMap.put(FieldConfigProperties.HELP_TEXT.getValue(), description);


### PR DESCRIPTION
This commit refactors the UI metadata processing logic to centralize it within the CustomOpenApiResolver and leverage utility methods in OpenApiUiUtils.

Key changes:

- Added new utility methods to OpenApiUiUtils for handling common UI properties from the UISchema annotation, such as group, order, width, icon, disabled, hidden, editable, sortable, and filterable.
- Modified the `processAnnotationDynamically` method in CustomOpenApiResolver to:
    - Utilize the new utility methods from OpenApiUiUtils.
    - Correctly handle Enum type properties defined in UISchema by converting them to their appropriate string values (e.g., using `getValue()` or `name()`).
- Ensured that all properties defined in the UISchema annotation are processed and added to the `x-ui` extension map.
- Removed the need for any separate or special handling of UI properties, effectively unifying the logic within CustomOpenApiResolver.

This refactoring improves code maintainability, reduces duplication, and makes the UI metadata processing more robust and easier to extend.