### PR TITLE
Add request schema support

### DIFF
--- a/backend-libs/praxis-metadata-core/README-UI.md.md
+++ b/backend-libs/praxis-metadata-core/README-UI.md.md
@@ -231,6 +231,7 @@ O `ApiDocsController` serve aos seguintes propósitos:
     *   `document` (String): **Opcional**. O nome do "documento" ou **grupo OpenAPI configurado** ao qual o `path` pertence (ex: `usuarios`, `produtos`, conforme definido em sua configuração de grupos OpenAPI). Se omitido, o controller tenta extraí-lo do primeiro segmento do `path`. (Veja a nota sobre Configuração de Grupos OpenAPI na seção "Funcionamento Interno Detalhado" para mais informações).
     *   `operation` (String): **Opcional**. A operação HTTP (verbo) do endpoint (ex: `get`, `post`, `put`). **Default:** `"get"`.
     *   `includeInternalSchemas` (boolean): **Opcional**. Se `true`, o controller tentará resolver recursivamente todas as referências `$ref` encontradas dentro do schema principal e seus sub-schemas. Se `false`, as referências `$ref` são mantidas como estão. **Default:** `false`.
+    *   `schemaType` (String): **Opcional**. Indica se o schema retornado deve ser do tipo `response` (padrão) ou o schema do corpo de `request`.
 
 ### 4. Funcionamento Interno Detalhado
 
@@ -500,8 +501,8 @@ Esses links são automaticamente adicionados aos objetos `EntityModel<D>` e `Res
 
 #### Integração com UI Schema (`linkToUiSchema`)
 
-Um método importante para a UI dinâmica é o `protected Link linkToUiSchema(String methodPath, String operation)`.
-*   **Propósito:** Gera um link HATEOAS que aponta para o endpoint `/schemas/filtered` (gerenciado pelo `ApiDocsController`). Este link inclui parâmetros (`path` e `operation`) que permitem ao `ApiDocsController` fornecer o schema OpenAPI filtrado e enriquecido com `x-ui` especificamente para uma operação (ex: o schema para o formulário de criação de `TipoTelefone`).
+Um método importante para a UI dinâmica é o `protected Link linkToUiSchema(String methodPath, String operation, String schemaType)`.
+*   **Propósito:** Gera um link HATEOAS que aponta para o endpoint `/schemas/filtered` (gerenciado pelo `ApiDocsController`). Este link inclui parâmetros (`path`, `operation` e `schemaType`) que permitem ao `ApiDocsController` fornecer o schema OpenAPI filtrado e enriquecido com `x-ui` especificamente para uma operação (ex: o schema para o formulário de criação de `TipoTelefone`).
 *   **Uso:** Os endpoints do `AbstractCrudController` (como `getAll`, `getById`, `create`, `update`) já utilizam `linkToUiSchema` para adicionar um link com `rel="schema"` às suas respostas. Isso permite que um cliente de UI descubra dinamicamente o schema necessário para renderizar, por exemplo, um formulário de edição para um item específico.
 
 Ao herdar do `AbstractCrudController`, os desenvolvedores obtêm uma base robusta e padronizada para suas APIs CRUD, com documentação, HATEOAS e integração com mecanismos de UI dinâmica já incorporados.

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
@@ -141,7 +141,7 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
 
         Page<EntityModel<D>> entityModels = page.map(entity -> toEntityModel(toDto(entity)));
 
-        Links links = Links.of(linkToAll(), linkToUiSchema("/filter", "post"));
+        Links links = Links.of(linkToAll(), linkToUiSchema("/filter", "post", "request"));
 
         var response = RestApiResponse.success(entityModels, links);
         return ResponseEntity.ok(response);
@@ -163,7 +163,7 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
 
         Links links = Links.of(
                 linkToFilter(),
-                linkToUiSchema("/all", "get")
+                linkToUiSchema("/all", "get", "response")
         );
 
         var response = RestApiResponse.success(entityModels, links);
@@ -208,7 +208,7 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
                 linkToFilter(),
                 linkToUpdate(id),
                 linkToDelete(id),
-                linkToUiSchema("/{id}", "get")
+                linkToUiSchema("/{id}", "get", "response")
         );
 
         var response = RestApiResponse.success(dto, links);
@@ -230,7 +230,7 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
                 linkToAll(),
                 linkToFilter(),
                 linkToDelete(newId),
-                linkToUiSchema("/", "post")
+                linkToUiSchema("/", "post", "request")
         );
 
         var response = RestApiResponse.success(savedDto, links);
@@ -275,7 +275,7 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
                 linkToFilter(),
                 linkToUpdate(id),
                 linkToDelete(id),
-                linkToUiSchema("/{id}", "put")
+                linkToUiSchema("/{id}", "put", "request")
         );
 
         var response = RestApiResponse.success(updatedDto, links);
@@ -338,7 +338,7 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
     )
     public ResponseEntity<Void> getSchema() {
         // Constrói o link para o endpoint de metadados
-        Link metadataLink = linkToUiSchema("/filter", "post");
+        Link metadataLink = linkToUiSchema("/filter", "post", "request");
 
         // Retorna um redirecionamento HTTP para o link montado
         return ResponseEntity.status(HttpStatus.FOUND)
@@ -431,7 +431,7 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
      * <p><strong>Exemplo de Uso:</strong></p>
      * <pre>{@code
      * // Gerar link para a operação GET no caminho "/dados-pessoa-fisica/all"
-     * Link docsLink = linkToUiSchema("/all", "get");
+     * Link docsLink = linkToUiSchema("/all", "get", "response");
      * }</pre>
      *
      * @param methodPath O caminho específico do método dentro da API para o qual a documentação do schema é necessária.
@@ -444,6 +444,7 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
      *                   </ul>
      * @param operation  A operação HTTP associada ao caminho fornecido. Deve ser um dos métodos válidos do HTTP, como
      *                   <code>"get"</code>, <code>"post"</code>, <code>"put"</code>, <code>"delete"</code>, etc.
+     * @param schemaType Tipo de schema desejado: <code>response</code> (padrão) ou <code>request</code>.
      *                   <p><strong>Exemplos:</strong></p>
      *                   <ul>
      *                       <li><code>"get"</code> para operações de leitura.</li>
@@ -458,13 +459,16 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
      * @see Link
      * @see UriComponentsBuilder
      */
-    protected Link linkToUiSchema(String methodPath, String operation) {
+    protected Link linkToUiSchema(String methodPath, String operation, String schemaType) {
         // Validação básica dos parâmetros
         if (methodPath == null || methodPath.trim().isEmpty()) {
             throw new IllegalArgumentException("O parâmetro 'methodPath' não pode ser nulo ou vazio.");
         }
         if (operation == null || operation.trim().isEmpty()) {
             throw new IllegalArgumentException("O parâmetro 'operation' não pode ser nulo ou vazio.");
+        }
+        if (schemaType == null || schemaType.trim().isEmpty()) {
+            schemaType = "response";
         }
 
         // Constrói o caminho completo combinando o path base com o método específico
@@ -480,6 +484,7 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
             String docsPath = UriComponentsBuilder.fromPath(CONTEXT_PATH + SCHEMAS_FILTERED_PATH)
                     .queryParam("path", fullPath)
                     .queryParam("operation", operation.toLowerCase())
+                    .queryParam("schemaType", schemaType.toLowerCase())
                     .build()
                     .toUriString();
 


### PR DESCRIPTION
## Summary
- support choosing response or request schemas in ApiDocsController
- extend linkToUiSchema to accept schema type
- generate links for request schemas in CRUD controllers
- document schemaType parameter and new linkToUiSchema signature

## Testing
- `mvn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854222f86488328b1918ec02ccbb5c8