### PR TITLE
Add schemaType validation and tests

### DIFF
--- a/backend-libs/praxis-metadata-core/README-UI.md.md
+++ b/backend-libs/praxis-metadata-core/README-UI.md.md
@@ -231,7 +231,14 @@ O `ApiDocsController` serve aos seguintes propósitos:
     *   `document` (String): **Opcional**. O nome do "documento" ou **grupo OpenAPI configurado** ao qual o `path` pertence (ex: `usuarios`, `produtos`, conforme definido em sua configuração de grupos OpenAPI). Se omitido, o controller tenta extraí-lo do primeiro segmento do `path`. (Veja a nota sobre Configuração de Grupos OpenAPI na seção "Funcionamento Interno Detalhado" para mais informações).
     *   `operation` (String): **Opcional**. A operação HTTP (verbo) do endpoint (ex: `get`, `post`, `put`). **Default:** `"get"`.
     *   `includeInternalSchemas` (boolean): **Opcional**. Se `true`, o controller tentará resolver recursivamente todas as referências `$ref` encontradas dentro do schema principal e seus sub-schemas. Se `false`, as referências `$ref` são mantidas como estão. **Default:** `false`.
+
     *   `schemaType` (String): **Opcional**. Indica se o schema retornado deve ser do tipo `response` (padrão) ou o schema do corpo de `request`.
+
+    **Exemplo:**
+
+    ```bash
+    curl -X GET "http://localhost:8080/schemas/filtered?path=/api/usuarios&operation=post&schemaType=request"
+    ```
 
 ### 4. Funcionamento Interno Detalhado
 

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/docs/ApiDocsController.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/docs/ApiDocsController.java
@@ -96,6 +96,10 @@ public class ApiDocsController {
             @RequestParam(required = false, defaultValue = "false") boolean includeInternalSchemas,
             @RequestParam(required = false, defaultValue = "response") String schemaType) {
 
+        if (!"response".equalsIgnoreCase(schemaType) && !"request".equalsIgnoreCase(schemaType)) {
+            throw new IllegalArgumentException("schemaType deve ser 'response' ou 'request'");
+        }
+
         // Verifica e define valores padrão para parâmetros opcionais
         if (document == null || document.trim().isEmpty()) {
             String resolved = openApiGroupResolver != null ? openApiGroupResolver.resolveGroup(path) : null;
@@ -253,7 +257,7 @@ public class ApiDocsController {
      * <p>
      * Caminho esperado no JSON: {@code requestBody -> content -> application/json -> schema -> $ref}
      */
-    private String findRequestSchema(JsonNode pathsNode) {
+    protected String findRequestSchema(JsonNode pathsNode) {
         JsonNode schemaNode = pathsNode
                 .path("requestBody")
                 .path("content")

--- a/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/controller/base/AbstractCrudControllerLinksTest.java
+++ b/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/controller/base/AbstractCrudControllerLinksTest.java
@@ -1,0 +1,92 @@
+package org.praxisplatform.uischema.controller.base;
+
+import org.junit.jupiter.api.Test;
+import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AbstractCrudControllerLinksTest.SimpleController.class)
+class AbstractCrudControllerLinksTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    SimpleService service;
+
+    @Test
+    void getAllIncludesSchemaTypeResponse() throws Exception {
+        when(service.findAll()).thenReturn(List.of(new SimpleEntity(1L)));
+
+        mockMvc.perform(get("/simple/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._links.schema.href").value(org.hamcrest.Matchers.containsString("schemaType=response")));
+    }
+
+    @Test
+    void filterIncludesSchemaTypeRequest() throws Exception {
+        Page<SimpleEntity> page = new PageImpl<>(Collections.emptyList());
+        when(service.filter(any(), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(post("/simple/filter").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._links.schema.href").value(org.hamcrest.Matchers.containsString("schemaType=request")));
+    }
+
+    // --- Support classes for the test ---
+
+    interface SimpleService extends org.praxisplatform.uischema.service.base.BaseCrudService<SimpleEntity, Long, SimpleFilterDTO> {}
+
+    static class SimpleEntity {
+        private Long id;
+        public SimpleEntity() {}
+        public SimpleEntity(Long id) { this.id = id; }
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+    }
+
+    static class SimpleDto {
+        private Long id;
+        public SimpleDto() {}
+        public SimpleDto(Long id) { this.id = id; }
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+    }
+
+    static class SimpleFilterDTO implements GenericFilterDTO {}
+
+    @org.springframework.web.bind.annotation.RestController
+    @org.springframework.web.bind.annotation.RequestMapping("/simple")
+    static class SimpleController extends AbstractCrudController<SimpleEntity, SimpleDto, SimpleFilterDTO, Long> {
+        @Autowired
+        SimpleService service;
+        @Override
+        protected SimpleService getService() { return service; }
+        @Override
+        protected SimpleDto toDto(SimpleEntity entity) { return new SimpleDto(entity.getId()); }
+        @Override
+        protected SimpleEntity toEntity(SimpleDto dto) { return new SimpleEntity(dto.getId()); }
+        @Override
+        protected Long getEntityId(SimpleEntity entity) { return entity.getId(); }
+        @Override
+        protected Long getDtoId(SimpleDto dto) { return dto.getId(); }
+        @Override
+        protected String getBasePath() { return "/simple"; }
+    }
+}

--- a/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/controller/docs/ApiDocsControllerTest.java
+++ b/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/controller/docs/ApiDocsControllerTest.java
@@ -1,0 +1,101 @@
+package org.praxisplatform.uischema.controller.docs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class ApiDocsControllerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private RestTemplate restTemplate;
+    private MockRestServiceServer server;
+    private ApiDocsController controller;
+    private String openApiDoc;
+
+    @BeforeEach
+    void setup() {
+        restTemplate = new RestTemplate();
+        server = MockRestServiceServer.createServer(restTemplate);
+        controller = new ApiDocsController();
+        ReflectionTestUtils.setField(controller, "restTemplate", restTemplate);
+        ReflectionTestUtils.setField(controller, "objectMapper", mapper);
+        ReflectionTestUtils.setField(controller, "OPEN_API_BASE_PATH", "/v3/api-docs");
+        openApiDoc = "{\n" +
+                "  \"paths\": {\n" +
+                "    \"/users\": {\n" +
+                "      \"post\": {\n" +
+                "        \"x-ui\": {\"responseSchema\": \"UserResponse\"},\n" +
+                "        \"requestBody\": {\n" +
+                "          \"content\": {\n" +
+                "            \"application/json\": {\n" +
+                "              \"schema\": {\"$ref\": \"#/components/schemas/UserRequest\"}\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"components\": {\n" +
+                "    \"schemas\": {\n" +
+                "      \"UserRequest\": {\n" +
+                "        \"type\": \"object\",\n" +
+                "        \"properties\": {\"name\": {\"type\": \"string\"}}\n" +
+                "      },\n" +
+                "      \"UserResponse\": {\n" +
+                "        \"type\": \"object\",\n" +
+                "        \"properties\": {\"email\": {\"type\": \"string\"}}\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+    }
+
+    @Test
+    void findRequestSchemaExtractsName() throws Exception {
+        String json = "{\"requestBody\":{\"content\":{\"application/json\":{\"schema\":{\"$ref\":\"#/components/schemas/TestDTO\"}}}}}";
+        JsonNode node = mapper.readTree(json);
+        assertEquals("TestDTO", controller.findRequestSchema(node));
+    }
+
+    @Test
+    void getFilteredSchemaSelectsSchemas() throws Exception {
+        server.expect(requestTo("http://localhost/v3/api-docs/test"))
+                .andRespond(withSuccess(openApiDoc, MediaType.APPLICATION_JSON));
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+
+        Map<String, Object> requestSchema = controller.getFilteredSchema("/users", "test", "post", false, "request");
+        assertTrue(((Map<?,?>) requestSchema.get("properties")).containsKey("name"));
+
+        server.reset();
+        server.expect(requestTo("http://localhost/v3/api-docs/test"))
+                .andRespond(withSuccess(openApiDoc, MediaType.APPLICATION_JSON));
+
+        Map<String, Object> responseSchema = controller.getFilteredSchema("/users", "test", "post", false, "response");
+        assertTrue(((Map<?,?>) responseSchema.get("properties")).containsKey("email"));
+
+        server.verify();
+    }
+
+    @Test
+    void invalidSchemaTypeThrowsException() {
+        server.expect(requestTo("http://localhost/v3/api-docs/test"))
+                .andRespond(withSuccess(openApiDoc, MediaType.APPLICATION_JSON));
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+        assertThrows(IllegalArgumentException.class,
+                () -> controller.getFilteredSchema("/users", "test", "post", false, "unknown"));
+    }
+}

--- a/examples/praxis-backend-libs-sample-app/README.md
+++ b/examples/praxis-backend-libs-sample-app/README.md
@@ -66,7 +66,7 @@ Você verá a interface do Swagger UI, que documenta os endpoints da API. Explor
 O `praxis-metadata-springdoc` expõe os metadados de UI enriquecidos através de um endpoint específico. Para visualizar o schema do `UserDTO` com as propriedades `x-ui` injetadas pelo Praxis, faça uma requisição GET para o seguinte endpoint (por exemplo, usando `curl` ou uma ferramenta como o Postman):
 
 ```bash
-curl -X GET "http://localhost:8080/schemas/filtered?path=/users&operation=post"
+curl -X GET "http://localhost:8080/schemas/filtered?path=/users&operation=post&schemaType=request"
 ```
 
 **O que esperar na resposta:**


### PR DESCRIPTION
## Summary
- validate `schemaType` parameter in `ApiDocsController`
- expose `findRequestSchema` for customization
- add unit tests for `ApiDocsController`
- add integration tests for `AbstractCrudController` links
- document usage of `schemaType` with example
- update sample README with schemaType parameter

## Testing
- `mvn -q -f backend-libs/praxis-metadata-core/pom.xml test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854586f08248328947c6f50c837de91