### PR TITLE
Add complete schemaType examples

### DIFF
--- a/backend-libs/praxis-metadata-core/README-UI.md.md
+++ b/backend-libs/praxis-metadata-core/README-UI.md.md
@@ -234,10 +234,14 @@ O `ApiDocsController` serve aos seguintes propósitos:
 
     *   `schemaType` (String): **Opcional**. Indica se o schema retornado deve ser do tipo `response` (padrão) ou o schema do corpo de `request`.
 
-    **Exemplo:**
+    **Exemplos:**
 
     ```bash
+    # Schema do corpo de requisição
     curl -X GET "http://localhost:8080/schemas/filtered?path=/api/usuarios&operation=post&schemaType=request"
+
+    # Schema de resposta
+    curl -X GET "http://localhost:8080/schemas/filtered?path=/api/usuarios&operation=post&schemaType=response"
     ```
 
 ### 4. Funcionamento Interno Detalhado

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
@@ -141,7 +141,11 @@ public abstract class AbstractCrudController<E, D, FD extends GenericFilterDTO, 
 
         Page<EntityModel<D>> entityModels = page.map(entity -> toEntityModel(toDto(entity)));
 
-        Links links = Links.of(linkToAll(), linkToUiSchema("/filter", "post", "request"));
+        Links links = Links.of(
+                linkToAll(),
+                linkToUiSchema("/filter", "post", "request"),
+                linkToUiSchema("/filter", "post", "response")
+        );
 
         var response = RestApiResponse.success(entityModels, links);
         return ResponseEntity.ok(response);

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/docs/ApiDocsController.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/docs/ApiDocsController.java
@@ -256,6 +256,10 @@ public class ApiDocsController {
      * Localiza o schema do corpo de requisição para a operação informada.
      * <p>
      * Caminho esperado no JSON: {@code requestBody -> content -> application/json -> schema -> $ref}
+     * <p>
+     * Declarado como {@code protected} para permitir que subclasses customizem a
+     * estratégia de descoberta, caso utilizem uma estrutura de documentação
+     * diferente.
      */
     protected String findRequestSchema(JsonNode pathsNode) {
         JsonNode schemaNode = pathsNode

--- a/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/controller/base/AbstractCrudControllerLinksTest.java
+++ b/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/controller/base/AbstractCrudControllerLinksTest.java
@@ -40,13 +40,14 @@ class AbstractCrudControllerLinksTest {
     }
 
     @Test
-    void filterIncludesSchemaTypeRequest() throws Exception {
+    void filterIncludesSchemaTypeRequestAndResponse() throws Exception {
         Page<SimpleEntity> page = new PageImpl<>(Collections.emptyList());
         when(service.filter(any(), any(Pageable.class))).thenReturn(page);
 
         mockMvc.perform(post("/simple/filter").contentType(MediaType.APPLICATION_JSON).content("{}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$._links.schema.href").value(org.hamcrest.Matchers.containsString("schemaType=request")));
+                .andExpect(jsonPath("$._links.schema..href", org.hamcrest.Matchers.hasItem(org.hamcrest.Matchers.containsString("schemaType=request"))))
+                .andExpect(jsonPath("$._links.schema..href", org.hamcrest.Matchers.hasItem(org.hamcrest.Matchers.containsString("schemaType=response"))));
     }
 
     // --- Support classes for the test ---

--- a/examples/praxis-backend-libs-sample-app/README.md
+++ b/examples/praxis-backend-libs-sample-app/README.md
@@ -66,7 +66,11 @@ Você verá a interface do Swagger UI, que documenta os endpoints da API. Explor
 O `praxis-metadata-springdoc` expõe os metadados de UI enriquecidos através de um endpoint específico. Para visualizar o schema do `UserDTO` com as propriedades `x-ui` injetadas pelo Praxis, faça uma requisição GET para o seguinte endpoint (por exemplo, usando `curl` ou uma ferramenta como o Postman):
 
 ```bash
+# Schema do corpo de requisição
 curl -X GET "http://localhost:8080/schemas/filtered?path=/users&operation=post&schemaType=request"
+
+# Schema de resposta
+curl -X GET "http://localhost:8080/schemas/filtered?path=/users&operation=post&schemaType=response"
 ```
 
 **O que esperar na resposta:**


### PR DESCRIPTION
## Summary
- document how to request response or request schemas
- show schemaType usage in the sample app docs
- expose both request and response schema links for filter endpoint
- clarify overridable `findRequestSchema`
- update tests for dual schema links

## Testing
- `mvn -q -pl backend-libs/praxis-metadata-core test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545f702c8c8328990c4673c0994f77