### PR TITLE
Add HR filter fields

### DIFF
--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/CargoFilterDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/CargoFilterDTO.java
@@ -1,8 +1,59 @@
 package com.example.praxis.hr.dto;
 
+import org.praxisplatform.uischema.extension.annotation.UISchema;
+import org.praxisplatform.uischema.filter.annotation.Filterable;
 import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
 
+import java.math.BigDecimal;
+import java.util.List;
+
 public class CargoFilterDTO implements GenericFilterDTO {
-    // No specific filterable fields for Cargo identified for now.
-    // If any are needed in the future, they can be added here.
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.LIKE)
+    private String nome;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.LIKE)
+    private String nivel;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.LIKE)
+    private String descricao;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.BETWEEN)
+    private List<BigDecimal> salario;
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getNivel() {
+        return nivel;
+    }
+
+    public void setNivel(String nivel) {
+        this.nivel = nivel;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public List<BigDecimal> getSalario() {
+        return salario;
+    }
+
+    public void setSalario(List<BigDecimal> salario) {
+        this.salario = salario;
+    }
 }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/DepartamentoFilterDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/DepartamentoFilterDTO.java
@@ -1,8 +1,44 @@
 package com.example.praxis.hr.dto;
 
+import org.praxisplatform.uischema.extension.annotation.UISchema;
+import org.praxisplatform.uischema.filter.annotation.Filterable;
 import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
 
 public class DepartamentoFilterDTO implements GenericFilterDTO {
-    // No specific filterable fields for Departamento identified for now.
-    // If any are needed in the future, they can be added here.
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.LIKE)
+    private String nome;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.LIKE)
+    private String codigo;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.EQUAL, relation = "responsavel.id")
+    private Long responsavelId;
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getCodigo() {
+        return codigo;
+    }
+
+    public void setCodigo(String codigo) {
+        this.codigo = codigo;
+    }
+
+    public Long getResponsavelId() {
+        return responsavelId;
+    }
+
+    public void setResponsavelId(Long responsavelId) {
+        this.responsavelId = responsavelId;
+    }
 }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/FuncionarioFilterDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/hr/dto/FuncionarioFilterDTO.java
@@ -4,6 +4,7 @@ import org.praxisplatform.uischema.filter.annotation.Filterable;
 import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
 import org.praxisplatform.uischema.extension.annotation.UISchema;
 import org.praxisplatform.uischema.FieldControlType;
+import com.example.praxis.common.config.ApiRouteDefinitions;
 import java.time.LocalDate;
 import java.math.BigDecimal;
 import java.util.List;
@@ -24,6 +25,13 @@ public class FuncionarioFilterDTO implements GenericFilterDTO {
             displayField = "nome")
     @Filterable(operation = Filterable.FilterOperation.EQUAL, relation = "cargo.id")
     private Long cargoId;
+
+    @UISchema(controlType = FieldControlType.SELECT,
+            endpoint = ApiRouteDefinitions.HR_DEPARTAMENTOS_PATH,
+            valueField = "id",
+            displayField = "nome")
+    @Filterable(operation = Filterable.FilterOperation.EQUAL, relation = "departamento.id")
+    private Long departamentoId;
 
     @UISchema
     @Filterable(operation = Filterable.FilterOperation.LIKE)
@@ -73,6 +81,10 @@ public class FuncionarioFilterDTO implements GenericFilterDTO {
     @Filterable(operation = Filterable.FilterOperation.LIKE, relation = "endereco.cep")
     private String cep;
 
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.EQUAL)
+    private Boolean ativo;
+
     // Getters and Setters
     public String getNomeCompleto() {
         return nomeCompleto;
@@ -96,6 +108,14 @@ public class FuncionarioFilterDTO implements GenericFilterDTO {
 
     public void setCargoId(Long cargoId) {
         this.cargoId = cargoId;
+    }
+
+    public Long getDepartamentoId() {
+        return departamentoId;
+    }
+
+    public void setDepartamentoId(Long departamentoId) {
+        this.departamentoId = departamentoId;
     }
 
     public String getEmail() {
@@ -192,5 +212,13 @@ public class FuncionarioFilterDTO implements GenericFilterDTO {
 
     public void setCep(String cep) {
         this.cep = cep;
+    }
+
+    public Boolean getAtivo() {
+        return ativo;
+    }
+
+    public void setAtivo(Boolean ativo) {
+        this.ativo = ativo;
     }
 }


### PR DESCRIPTION
## Summary
- expand `CargoFilterDTO` with salary and text fields
- add filtering fields to `DepartamentoFilterDTO`
- support department filtering and active flag in `FuncionarioFilterDTO`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685489e652648328b874cfbe1a38cf54