### PR TITLE
Add docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Documentation
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Generate backend docs
+        working-directory: backend-libs/praxis-metadata-core
+        run: |
+          ./gradlew asciidoctor
+          test -d build/docs/asciidoc
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install frontend dependencies
+        working-directory: frontend-libs/praxis-metadata-core
+        run: npm ci
+
+      - name: Generate frontend docs
+        working-directory: frontend-libs/praxis-metadata-core
+        run: |
+          npx compodoc -p tsconfig.json -d documentation
+          test -d documentation
+
+      - name: Prepare docs folder
+        run: |
+          mkdir -p docs/backend docs/frontend
+          cp -r backend-libs/praxis-metadata-core/build/docs/asciidoc/. docs/backend/
+          cp -r frontend-libs/praxis-metadata-core/documentation/. docs/frontend/
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -16,3 +16,26 @@ The `praxis-metadata-core` library offers a comprehensive set of features to acc
 *   **Pagination and Sorting:** Offers out-of-the-box support for paginated responses and default entity sorting (configurable via `@DefaultSortColumn` annotation) through Spring Data Pageable.
 *   **Extensible Design:** Built with extensibility in mind, allowing developers to easily introduce custom UI components, validation logic, and other behaviors.
 *   **Spring Boot & OpenAPI Integration:** Seamlessly integrates with Spring Boot and leverages OpenAPI for API documentation and schema exposure, facilitating clear communication between backend and frontend systems.
+
+## Documentation
+
+This repository contains backend and frontend libraries. Documentation can be generated locally or published automatically via GitHub Actions.
+
+### Generating backend docs
+
+```bash
+cd backend-libs/praxis-metadata-core
+./gradlew asciidoctor
+```
+
+The HTML files will be placed in `build/docs/asciidoc`.
+
+### Generating frontend docs
+
+```bash
+cd frontend-libs/praxis-metadata-core
+npm ci
+npx compodoc -p tsconfig.json -d documentation
+```
+
+The generated site will be available in the `documentation` folder.


### PR DESCRIPTION
## Summary
- add CI workflow to generate backend docs via Asciidoctor and frontend docs via Compodoc
- deploy documentation automatically to `gh-pages`
- document local generation steps in README

## Testing
- `mvn --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548a2b7b1083288fae989a5365e599