### PR TITLE
Add reflection-based DTO annotation tests

### DIFF
--- a/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/hr/dto/DtoAnnotationTest.java
+++ b/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/hr/dto/DtoAnnotationTest.java
@@ -1,0 +1,124 @@
+package com.example.praxis.hr.dto;
+
+import org.junit.Test;
+import org.praxisplatform.uischema.extension.annotation.UISchema;
+import org.praxisplatform.uischema.filter.annotation.Filterable;
+import org.praxisplatform.uischema.filter.annotation.Filterable.FilterOperation;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class DtoAnnotationTest {
+
+    @Test
+    public void testSimpleDtosHaveGettersAndUiSchema() {
+        List<Class<?>> dtos = Arrays.asList(
+                CargoDTO.class,
+                DepartamentoDTO.class,
+                DependenteDTO.class,
+                EnderecoDTO.class,
+                EventoFolhaDTO.class,
+                FeriasAfastamentoDTO.class,
+                FolhaPagamentoDTO.class,
+                FuncionarioDTO.class
+        );
+
+        for (Class<?> dto : dtos) {
+            for (Field field : dto.getDeclaredFields()) {
+                assertTrue(dto.getSimpleName() + "." + field.getName() + " should have @UISchema",
+                        field.isAnnotationPresent(UISchema.class));
+                assertGetterExists(dto, field);
+            }
+        }
+    }
+
+    @Test
+    public void testCargoFilterDtoAnnotations() {
+        Map<String, Expectation> expected = new HashMap<>();
+        expected.put("nome", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("nivel", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("descricao", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("salario", new Expectation(FilterOperation.BETWEEN, ""));
+        validateFilterDto(CargoFilterDTO.class, expected);
+    }
+
+    @Test
+    public void testDepartamentoFilterDtoAnnotations() {
+        Map<String, Expectation> expected = new HashMap<>();
+        expected.put("nome", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("codigo", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("responsavelId", new Expectation(FilterOperation.EQUAL, "responsavel.id"));
+        validateFilterDto(DepartamentoFilterDTO.class, expected);
+    }
+
+    @Test
+    public void testFuncionarioFilterDtoAnnotations() {
+        Map<String, Expectation> expected = new LinkedHashMap<>();
+        expected.put("nomeCompleto", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("cpf", new Expectation(FilterOperation.EQUAL, ""));
+        expected.put("cargoId", new Expectation(FilterOperation.EQUAL, "cargo.id"));
+        expected.put("departamentoId", new Expectation(FilterOperation.EQUAL, "departamento.id"));
+        expected.put("email", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("telefone", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("dataNascimento", new Expectation(FilterOperation.BETWEEN, ""));
+        expected.put("salario", new Expectation(FilterOperation.BETWEEN, ""));
+        expected.put("dataAdmissao", new Expectation(FilterOperation.BETWEEN, ""));
+        expected.put("logradouro", new Expectation(FilterOperation.LIKE, "endereco.logradouro"));
+        expected.put("numero", new Expectation(FilterOperation.LIKE, "endereco.numero"));
+        expected.put("complemento", new Expectation(FilterOperation.LIKE, "endereco.complemento"));
+        expected.put("bairro", new Expectation(FilterOperation.LIKE, "endereco.bairro"));
+        expected.put("cidade", new Expectation(FilterOperation.LIKE, "endereco.cidade"));
+        expected.put("estado", new Expectation(FilterOperation.LIKE, "endereco.estado"));
+        expected.put("cep", new Expectation(FilterOperation.LIKE, "endereco.cep"));
+        expected.put("ativo", new Expectation(FilterOperation.EQUAL, ""));
+        validateFilterDto(FuncionarioFilterDTO.class, expected);
+    }
+
+    private void validateFilterDto(Class<?> clazz, Map<String, Expectation> expectations) {
+        for (Field field : clazz.getDeclaredFields()) {
+            assertTrue(clazz.getSimpleName() + "." + field.getName() + " should have @UISchema",
+                    field.isAnnotationPresent(UISchema.class));
+            assertTrue(clazz.getSimpleName() + "." + field.getName() + " should have @Filterable",
+                    field.isAnnotationPresent(Filterable.class));
+            Filterable annotation = field.getAnnotation(Filterable.class);
+            Expectation exp = expectations.get(field.getName());
+            assertNotNull("Unexpected field " + field.getName(), exp);
+            assertEquals(exp.operation, annotation.operation());
+            assertEquals(exp.relation, annotation.relation());
+            assertGetterExists(clazz, field);
+        }
+    }
+
+    private void assertGetterExists(Class<?> clazz, Field field) {
+        String name = field.getName();
+        String capital = Character.toUpperCase(name.charAt(0)) + name.substring(1);
+        List<String> methods = new ArrayList<>();
+        methods.add("get" + capital);
+        if (field.getType() == boolean.class) {
+            methods.add("is" + capital);
+        }
+
+        boolean found = false;
+        for (String m : methods) {
+            try {
+                clazz.getDeclaredMethod(m);
+                found = true;
+                break;
+            } catch (NoSuchMethodException ignored) {
+            }
+        }
+        assertTrue("Getter not found for field " + name + " in " + clazz.getSimpleName(), found);
+    }
+
+    private static class Expectation {
+        final FilterOperation operation;
+        final String relation;
+
+        Expectation(FilterOperation operation, String relation) {
+            this.operation = operation;
+            this.relation = relation;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add reflection-based tests for DTO getters and annotations

## Testing
- `./mvnw -f examples/praxis-backend-libs-sample-app/pom.xml test` *(fails: Maven is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854919935c88328ae9ec62194f31c3e