### PR TITLE
Fix docs build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ This repository contains backend and frontend libraries. Documentation can be ge
 
 ```bash
 cd backend-libs/praxis-metadata-core
-./gradlew asciidoctor
+../../mvnw javadoc:javadoc
 ```
 
-The HTML files will be placed in `build/docs/asciidoc`.
+The generated Javadoc will be placed in `target/site/apidocs`.
 
 ### Generating frontend docs
 

--- a/backend-libs/praxis-metadata-core/README.md
+++ b/backend-libs/praxis-metadata-core/README.md
@@ -234,7 +234,17 @@ To simplify the creation of RESTful services with UI metadata capabilities, the 
     *   This generic interface (often implemented by an abstract class or a concrete service) defines the standard contract for service-layer CRUD operations.
     *   Implementations typically interact with a `BaseCrudRepository`.
     *   It includes methods for `findAll`, `findById`, `save`, `update`, `deleteById`, and a `filter` method that takes a `@Filterable` DTO and `Pageable` information to return paginated and filtered results.
-    *   It also handles default sorting based on the `@DefaultSortColumn` annotation that can be placed on entity fields.
+*   It also handles default sorting based on the `@DefaultSortColumn` annotation that can be placed on entity fields.
+
+## Documentation
+
+Generate Javadoc for this module with Maven:
+
+```bash
+mvn -f backend-libs/praxis-metadata-core/pom.xml javadoc:javadoc
+```
+
+The HTML output will be created under `backend-libs/praxis-metadata-core/target/site/apidocs`.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- update root readme to describe how to generate docs with Maven
- add documentation section in `backend-libs/praxis-metadata-core` readme for generating Javadoc

## Testing
- `mvnw test` *(fails: Maven missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854964781048328b903688c70b04355