### PR TITLE
Fix duplicate README heading

### DIFF
--- a/examples/praxis-backend-libs-sample-app/README.md
+++ b/examples/praxis-backend-libs-sample-app/README.md
@@ -34,8 +34,6 @@ Você também pode executar apenas os testes com o comando:
 
 ## Como Executar a Aplicação
 
-## Como Executar a Aplicação
-
 Após construir o projeto, você pode executá-lo de duas maneiras:
 
 1.  **Usando o plugin Maven Spring Boot:**


### PR DESCRIPTION
## Summary
- remove repeated heading from sample app README

## Testing
- `grep -n "^## Como Executar a Aplicação" examples/praxis-backend-libs-sample-app/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68549ffe608c8328aad41dbdb5c11116