### PR TITLE
Add HR payroll endpoints and DTO mappings

### DIFF
--- a/examples/praxis-backend-libs-sample-app/README.md
+++ b/examples/praxis-backend-libs-sample-app/README.md
@@ -122,6 +122,9 @@ O módulo HR expõe APIs REST para interagir com suas entidades. Os endpoints pr
 *   Funcionários: `/api/human-resources/funcionarios`
 *   Cargos: `/api/human-resources/cargos`
 *   Departamentos: `/api/human-resources/departamentos`
+*   Folhas de Pagamento: `/api/human-resources/folhas-pagamento`
+*   Eventos de Folha: `/api/human-resources/eventos-folha`
+*   Férias/Afastamentos: `/api/human-resources/ferias-afastamentos`
 
 ### Configuração do Banco de Dados
 

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/ApiRouteDefinitions.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/ApiRouteDefinitions.java
@@ -22,6 +22,21 @@ public class ApiRouteDefinitions {
     public static final String HR_FUNCIONARIOS_GROUP = "funcionarios";
     public static final String HR_FUNCIONARIOS_TAG = "HR - Funcionarios";
 
+    // HR Folhas de Pagamento
+    public static final String HR_FOLHAS_PAGAMENTO_PATH = "/api/human-resources/folhas-pagamento";
+    public static final String HR_FOLHAS_PAGAMENTO_GROUP = "folhas-pagamento";
+    public static final String HR_FOLHAS_PAGAMENTO_TAG = "HR - Folhas Pagamento";
+
+    // HR Eventos de Folha
+    public static final String HR_EVENTOS_FOLHA_PATH = "/api/human-resources/eventos-folha";
+    public static final String HR_EVENTOS_FOLHA_GROUP = "eventos-folha";
+    public static final String HR_EVENTOS_FOLHA_TAG = "HR - Eventos Folha";
+
+    // HR Férias/Afastamentos
+    public static final String HR_FERIAS_AFASTAMENTOS_PATH = "/api/human-resources/ferias-afastamentos";
+    public static final String HR_FERIAS_AFASTAMENTOS_GROUP = "ferias-afastamentos";
+    public static final String HR_FERIAS_AFASTAMENTOS_TAG = "HR - Ferias Afastamentos";
+
     private ApiRouteDefinitions() {
         // Prevent instantiation
     }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/controller/EventoFolhaController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/controller/EventoFolhaController.java
@@ -1,0 +1,56 @@
+package com.example.praxis.humanresources.controller;
+
+import com.example.praxis.common.config.ApiRouteDefinitions;
+import com.example.praxis.humanresources.dto.EventoFolhaDTO;
+import com.example.praxis.humanresources.dto.EventoFolhaFilterDTO;
+import com.example.praxis.humanresources.entity.EventoFolha;
+import com.example.praxis.humanresources.mapper.EventoFolhaMapper;
+import com.example.praxis.humanresources.service.EventoFolhaService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.praxisplatform.uischema.controller.base.AbstractCrudController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(ApiRouteDefinitions.HR_EVENTOS_FOLHA_PATH)
+@Tag(name = ApiRouteDefinitions.HR_EVENTOS_FOLHA_TAG, description = "Operations related to HR Eventos de Folha")
+public class EventoFolhaController extends AbstractCrudController<EventoFolha, EventoFolhaDTO, EventoFolhaFilterDTO, Long> {
+
+    @Autowired
+    private EventoFolhaService eventoFolhaService;
+
+    @Autowired
+    private EventoFolhaMapper eventoFolhaMapper;
+
+    @Override
+    protected EventoFolhaService getService() {
+        return eventoFolhaService;
+    }
+
+    @Override
+    protected EventoFolhaDTO toDto(EventoFolha entity) {
+        return eventoFolhaMapper.toDto(entity);
+    }
+
+    @Override
+    protected EventoFolha toEntity(EventoFolhaDTO dto) {
+        return eventoFolhaMapper.toEntity(dto);
+    }
+
+    @Override
+    protected Long getEntityId(EventoFolha entity) {
+        return entity.getId();
+    }
+
+    @Override
+    protected Long getDtoId(EventoFolhaDTO dto) {
+        return dto.getId();
+    }
+
+    @Override
+    protected String getBasePath() {
+        return ApiRouteDefinitions.HR_EVENTOS_FOLHA_PATH;
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/controller/FeriasAfastamentoController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/controller/FeriasAfastamentoController.java
@@ -1,0 +1,56 @@
+package com.example.praxis.humanresources.controller;
+
+import com.example.praxis.common.config.ApiRouteDefinitions;
+import com.example.praxis.humanresources.dto.FeriasAfastamentoDTO;
+import com.example.praxis.humanresources.dto.FeriasAfastamentoFilterDTO;
+import com.example.praxis.humanresources.entity.FeriasAfastamento;
+import com.example.praxis.humanresources.mapper.FeriasAfastamentoMapper;
+import com.example.praxis.humanresources.service.FeriasAfastamentoService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.praxisplatform.uischema.controller.base.AbstractCrudController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(ApiRouteDefinitions.HR_FERIAS_AFASTAMENTOS_PATH)
+@Tag(name = ApiRouteDefinitions.HR_FERIAS_AFASTAMENTOS_TAG, description = "Operations related to HR Ferias/Afastamentos")
+public class FeriasAfastamentoController extends AbstractCrudController<FeriasAfastamento, FeriasAfastamentoDTO, FeriasAfastamentoFilterDTO, Long> {
+
+    @Autowired
+    private FeriasAfastamentoService feriasAfastamentoService;
+
+    @Autowired
+    private FeriasAfastamentoMapper feriasAfastamentoMapper;
+
+    @Override
+    protected FeriasAfastamentoService getService() {
+        return feriasAfastamentoService;
+    }
+
+    @Override
+    protected FeriasAfastamentoDTO toDto(FeriasAfastamento entity) {
+        return feriasAfastamentoMapper.toDto(entity);
+    }
+
+    @Override
+    protected FeriasAfastamento toEntity(FeriasAfastamentoDTO dto) {
+        return feriasAfastamentoMapper.toEntity(dto);
+    }
+
+    @Override
+    protected Long getEntityId(FeriasAfastamento entity) {
+        return entity.getId();
+    }
+
+    @Override
+    protected Long getDtoId(FeriasAfastamentoDTO dto) {
+        return dto.getId();
+    }
+
+    @Override
+    protected String getBasePath() {
+        return ApiRouteDefinitions.HR_FERIAS_AFASTAMENTOS_PATH;
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/controller/FolhaPagamentoController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/controller/FolhaPagamentoController.java
@@ -1,0 +1,56 @@
+package com.example.praxis.humanresources.controller;
+
+import com.example.praxis.common.config.ApiRouteDefinitions;
+import com.example.praxis.humanresources.dto.FolhaPagamentoDTO;
+import com.example.praxis.humanresources.dto.FolhaPagamentoFilterDTO;
+import com.example.praxis.humanresources.entity.FolhaPagamento;
+import com.example.praxis.humanresources.mapper.FolhaPagamentoMapper;
+import com.example.praxis.humanresources.service.FolhaPagamentoService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.praxisplatform.uischema.controller.base.AbstractCrudController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(ApiRouteDefinitions.HR_FOLHAS_PAGAMENTO_PATH)
+@Tag(name = ApiRouteDefinitions.HR_FOLHAS_PAGAMENTO_TAG, description = "Operations related to HR Folhas de Pagamento")
+public class FolhaPagamentoController extends AbstractCrudController<FolhaPagamento, FolhaPagamentoDTO, FolhaPagamentoFilterDTO, Long> {
+
+    @Autowired
+    private FolhaPagamentoService folhaPagamentoService;
+
+    @Autowired
+    private FolhaPagamentoMapper folhaPagamentoMapper;
+
+    @Override
+    protected FolhaPagamentoService getService() {
+        return folhaPagamentoService;
+    }
+
+    @Override
+    protected FolhaPagamentoDTO toDto(FolhaPagamento entity) {
+        return folhaPagamentoMapper.toDto(entity);
+    }
+
+    @Override
+    protected FolhaPagamento toEntity(FolhaPagamentoDTO dto) {
+        return folhaPagamentoMapper.toEntity(dto);
+    }
+
+    @Override
+    protected Long getEntityId(FolhaPagamento entity) {
+        return entity.getId();
+    }
+
+    @Override
+    protected Long getDtoId(FolhaPagamentoDTO dto) {
+        return dto.getId();
+    }
+
+    @Override
+    protected String getBasePath() {
+        return ApiRouteDefinitions.HR_FOLHAS_PAGAMENTO_PATH;
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/dto/EventoFolhaFilterDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/dto/EventoFolhaFilterDTO.java
@@ -1,0 +1,62 @@
+package com.example.praxis.humanresources.dto;
+
+import org.praxisplatform.uischema.extension.annotation.UISchema;
+import org.praxisplatform.uischema.filter.annotation.Filterable;
+import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
+
+import java.math.BigDecimal;
+
+/**
+ * DTO de filtro para pesquisar EventoFolha.
+ */
+public class EventoFolhaFilterDTO implements GenericFilterDTO {
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.EQUAL, relation = "folhaPagamento.id")
+    private Long folhaPagamentoId;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.LIKE)
+    private String descricao;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.LIKE)
+    private String tipo;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.BETWEEN)
+    private java.util.List<BigDecimal> valor;
+
+    public Long getFolhaPagamentoId() {
+        return folhaPagamentoId;
+    }
+
+    public void setFolhaPagamentoId(Long folhaPagamentoId) {
+        this.folhaPagamentoId = folhaPagamentoId;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public String getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
+
+    public java.util.List<BigDecimal> getValor() {
+        return valor;
+    }
+
+    public void setValor(java.util.List<BigDecimal> valor) {
+        this.valor = valor;
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/dto/FeriasAfastamentoFilterDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/dto/FeriasAfastamentoFilterDTO.java
@@ -1,0 +1,63 @@
+package com.example.praxis.humanresources.dto;
+
+import org.praxisplatform.uischema.extension.annotation.UISchema;
+import org.praxisplatform.uischema.filter.annotation.Filterable;
+import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * DTO de filtro para pesquisas de Ferias/Afastamentos.
+ */
+public class FeriasAfastamentoFilterDTO implements GenericFilterDTO {
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.EQUAL, relation = "funcionario.id")
+    private Long funcionarioId;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.LIKE)
+    private String tipo;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.BETWEEN)
+    private List<LocalDate> dataInicio;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.BETWEEN)
+    private List<LocalDate> dataFim;
+
+    public Long getFuncionarioId() {
+        return funcionarioId;
+    }
+
+    public void setFuncionarioId(Long funcionarioId) {
+        this.funcionarioId = funcionarioId;
+    }
+
+    public String getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
+
+    public List<LocalDate> getDataInicio() {
+        return dataInicio;
+    }
+
+    public void setDataInicio(List<LocalDate> dataInicio) {
+        this.dataInicio = dataInicio;
+    }
+
+    public List<LocalDate> getDataFim() {
+        return dataFim;
+    }
+
+    public void setDataFim(List<LocalDate> dataFim) {
+        this.dataFim = dataFim;
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/dto/FolhaPagamentoFilterDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/dto/FolhaPagamentoFilterDTO.java
@@ -1,0 +1,76 @@
+package com.example.praxis.humanresources.dto;
+
+import org.praxisplatform.uischema.extension.annotation.UISchema;
+import org.praxisplatform.uischema.filter.annotation.Filterable;
+import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * DTO de filtro para pesquisar FolhaPagamento.
+ */
+public class FolhaPagamentoFilterDTO implements GenericFilterDTO {
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.EQUAL, relation = "funcionario.id")
+    private Long funcionarioId;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.EQUAL)
+    private Integer ano;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.EQUAL)
+    private Integer mes;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.BETWEEN)
+    private List<BigDecimal> salarioBruto;
+
+    @UISchema
+    @Filterable(operation = Filterable.FilterOperation.BETWEEN)
+    private List<LocalDate> dataPagamento;
+
+    public Long getFuncionarioId() {
+        return funcionarioId;
+    }
+
+    public void setFuncionarioId(Long funcionarioId) {
+        this.funcionarioId = funcionarioId;
+    }
+
+    public Integer getAno() {
+        return ano;
+    }
+
+    public void setAno(Integer ano) {
+        this.ano = ano;
+    }
+
+    public Integer getMes() {
+        return mes;
+    }
+
+    public void setMes(Integer mes) {
+        this.mes = mes;
+    }
+
+    public List<BigDecimal> getSalarioBruto() {
+        return salarioBruto;
+    }
+
+    public void setSalarioBruto(List<BigDecimal> salarioBruto) {
+        this.salarioBruto = salarioBruto;
+    }
+
+    public List<LocalDate> getDataPagamento() {
+        return dataPagamento;
+    }
+
+    public void setDataPagamento(List<LocalDate> dataPagamento) {
+        this.dataPagamento = dataPagamento;
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/mapper/EventoFolhaMapper.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/mapper/EventoFolhaMapper.java
@@ -1,0 +1,60 @@
+package com.example.praxis.humanresources.mapper;
+
+import com.example.praxis.humanresources.dto.EventoFolhaDTO;
+import com.example.praxis.humanresources.entity.EventoFolha;
+import com.example.praxis.humanresources.entity.FolhaPagamento;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class EventoFolhaMapper {
+
+    public EventoFolha toEntity(EventoFolhaDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+        EventoFolha entity = new EventoFolha();
+        entity.setId(dto.getId());
+        if (dto.getFolhaPagamentoId() != null) {
+            FolhaPagamento fp = new FolhaPagamento();
+            fp.setId(dto.getFolhaPagamentoId());
+            entity.setFolhaPagamento(fp);
+        }
+        entity.setDescricao(dto.getDescricao());
+        entity.setTipo(dto.getTipo());
+        entity.setValor(dto.getValor());
+        return entity;
+    }
+
+    public EventoFolhaDTO toDto(EventoFolha entity) {
+        if (entity == null) {
+            return null;
+        }
+        EventoFolhaDTO dto = new EventoFolhaDTO();
+        dto.setId(entity.getId());
+        if (entity.getFolhaPagamento() != null) {
+            dto.setFolhaPagamentoId(entity.getFolhaPagamento().getId());
+        }
+        dto.setDescricao(entity.getDescricao());
+        dto.setTipo(entity.getTipo());
+        dto.setValor(entity.getValor());
+        return dto;
+    }
+
+    public List<EventoFolhaDTO> toDtoList(List<EventoFolha> entities) {
+        if (entities == null) {
+            return null;
+        }
+        return entities.stream().map(this::toDto).collect(Collectors.toList());
+    }
+
+    public List<EventoFolha> toEntityList(List<EventoFolhaDTO> dtos) {
+        if (dtos == null) {
+            return null;
+        }
+        return dtos.stream().map(this::toEntity).collect(Collectors.toList());
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/mapper/FeriasAfastamentoMapper.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/mapper/FeriasAfastamentoMapper.java
@@ -1,0 +1,62 @@
+package com.example.praxis.humanresources.mapper;
+
+import com.example.praxis.humanresources.dto.FeriasAfastamentoDTO;
+import com.example.praxis.humanresources.entity.FeriasAfastamento;
+import com.example.praxis.humanresources.entity.Funcionario;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class FeriasAfastamentoMapper {
+
+    public FeriasAfastamento toEntity(FeriasAfastamentoDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+        FeriasAfastamento entity = new FeriasAfastamento();
+        entity.setId(dto.getId());
+        if (dto.getFuncionarioId() != null) {
+            Funcionario f = new Funcionario();
+            f.setId(dto.getFuncionarioId());
+            entity.setFuncionario(f);
+        }
+        entity.setTipo(dto.getTipo());
+        entity.setDataInicio(dto.getDataInicio());
+        entity.setDataFim(dto.getDataFim());
+        entity.setObservacoes(dto.getObservacoes());
+        return entity;
+    }
+
+    public FeriasAfastamentoDTO toDto(FeriasAfastamento entity) {
+        if (entity == null) {
+            return null;
+        }
+        FeriasAfastamentoDTO dto = new FeriasAfastamentoDTO();
+        dto.setId(entity.getId());
+        if (entity.getFuncionario() != null) {
+            dto.setFuncionarioId(entity.getFuncionario().getId());
+        }
+        dto.setTipo(entity.getTipo());
+        dto.setDataInicio(entity.getDataInicio());
+        dto.setDataFim(entity.getDataFim());
+        dto.setObservacoes(entity.getObservacoes());
+        return dto;
+    }
+
+    public List<FeriasAfastamentoDTO> toDtoList(List<FeriasAfastamento> entities) {
+        if (entities == null) {
+            return null;
+        }
+        return entities.stream().map(this::toDto).collect(Collectors.toList());
+    }
+
+    public List<FeriasAfastamento> toEntityList(List<FeriasAfastamentoDTO> dtos) {
+        if (dtos == null) {
+            return null;
+        }
+        return dtos.stream().map(this::toEntity).collect(Collectors.toList());
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/mapper/FolhaPagamentoMapper.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/mapper/FolhaPagamentoMapper.java
@@ -1,0 +1,66 @@
+package com.example.praxis.humanresources.mapper;
+
+import com.example.praxis.humanresources.dto.FolhaPagamentoDTO;
+import com.example.praxis.humanresources.entity.FolhaPagamento;
+import com.example.praxis.humanresources.entity.Funcionario;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class FolhaPagamentoMapper {
+
+    public FolhaPagamento toEntity(FolhaPagamentoDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+        FolhaPagamento entity = new FolhaPagamento();
+        entity.setId(dto.getId());
+        if (dto.getFuncionarioId() != null) {
+            Funcionario f = new Funcionario();
+            f.setId(dto.getFuncionarioId());
+            entity.setFuncionario(f);
+        }
+        entity.setAno(dto.getAno());
+        entity.setMes(dto.getMes());
+        entity.setSalarioBruto(dto.getSalarioBruto());
+        entity.setTotalDescontos(dto.getTotalDescontos());
+        entity.setSalarioLiquido(dto.getSalarioLiquido());
+        entity.setDataPagamento(dto.getDataPagamento());
+        return entity;
+    }
+
+    public FolhaPagamentoDTO toDto(FolhaPagamento entity) {
+        if (entity == null) {
+            return null;
+        }
+        FolhaPagamentoDTO dto = new FolhaPagamentoDTO();
+        dto.setId(entity.getId());
+        if (entity.getFuncionario() != null) {
+            dto.setFuncionarioId(entity.getFuncionario().getId());
+        }
+        dto.setAno(entity.getAno());
+        dto.setMes(entity.getMes());
+        dto.setSalarioBruto(entity.getSalarioBruto());
+        dto.setTotalDescontos(entity.getTotalDescontos());
+        dto.setSalarioLiquido(entity.getSalarioLiquido());
+        dto.setDataPagamento(entity.getDataPagamento());
+        return dto;
+    }
+
+    public List<FolhaPagamentoDTO> toDtoList(List<FolhaPagamento> entities) {
+        if (entities == null) {
+            return null;
+        }
+        return entities.stream().map(this::toDto).collect(Collectors.toList());
+    }
+
+    public List<FolhaPagamento> toEntityList(List<FolhaPagamentoDTO> dtos) {
+        if (dtos == null) {
+            return null;
+        }
+        return dtos.stream().map(this::toEntity).collect(Collectors.toList());
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/repository/EventoFolhaRepository.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/repository/EventoFolhaRepository.java
@@ -1,9 +1,9 @@
 package com.example.praxis.humanresources.repository;
 
 import com.example.praxis.humanresources.entity.EventoFolha;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EventoFolhaRepository extends JpaRepository<EventoFolha, Long> {
+public interface EventoFolhaRepository extends BaseCrudRepository<EventoFolha, Long> {
 }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/repository/FeriasAfastamentoRepository.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/repository/FeriasAfastamentoRepository.java
@@ -1,9 +1,9 @@
 package com.example.praxis.humanresources.repository;
 
 import com.example.praxis.humanresources.entity.FeriasAfastamento;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FeriasAfastamentoRepository extends JpaRepository<FeriasAfastamento, Long> {
+public interface FeriasAfastamentoRepository extends BaseCrudRepository<FeriasAfastamento, Long> {
 }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/repository/FolhaPagamentoRepository.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/repository/FolhaPagamentoRepository.java
@@ -1,9 +1,9 @@
 package com.example.praxis.humanresources.repository;
 
 import com.example.praxis.humanresources.entity.FolhaPagamento;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FolhaPagamentoRepository extends JpaRepository<FolhaPagamento, Long> {
+public interface FolhaPagamentoRepository extends BaseCrudRepository<FolhaPagamento, Long> {
 }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/EventoFolhaService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/EventoFolhaService.java
@@ -1,0 +1,68 @@
+package com.example.praxis.humanresources.service;
+
+import com.example.praxis.humanresources.dto.EventoFolhaFilterDTO;
+import com.example.praxis.humanresources.entity.EventoFolha;
+import com.example.praxis.humanresources.entity.FolhaPagamento;
+import com.example.praxis.humanresources.repository.EventoFolhaRepository;
+import com.example.praxis.humanresources.repository.FolhaPagamentoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
+import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
+import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EventoFolhaService implements BaseCrudService<EventoFolha, Long, EventoFolhaFilterDTO> {
+
+    @Autowired
+    private EventoFolhaRepository eventoFolhaRepository;
+
+    @Autowired
+    private FolhaPagamentoRepository folhaPagamentoRepository;
+
+    @Override
+    public BaseCrudRepository<EventoFolha, Long> getRepository() {
+        return eventoFolhaRepository;
+    }
+
+    @Override
+    public GenericSpecificationsBuilder<EventoFolha> getSpecificationsBuilder() {
+        return new GenericSpecificationsBuilder<>();
+    }
+
+    @Override
+    public Class<EventoFolha> getEntityClass() {
+        return EventoFolha.class;
+    }
+
+    private void resolveRelations(EventoFolha evento) {
+        if (evento.getFolhaPagamento() != null && evento.getFolhaPagamento().getId() != null) {
+            FolhaPagamento folha = folhaPagamentoRepository.findById(evento.getFolhaPagamento().getId())
+                    .orElseThrow(() -> new EntityNotFoundException("FolhaPagamento nao encontrada com ID: " + evento.getFolhaPagamento().getId()));
+            evento.setFolhaPagamento(folha);
+        } else {
+            evento.setFolhaPagamento(null);
+        }
+    }
+
+    @Override
+    @Transactional
+    public EventoFolha save(EventoFolha evento) {
+        resolveRelations(evento);
+        return eventoFolhaRepository.save(evento);
+    }
+
+    @Override
+    @Transactional
+    public EventoFolha mergeUpdate(EventoFolha existing, EventoFolha payload) {
+        existing.setDescricao(payload.getDescricao());
+        existing.setTipo(payload.getTipo());
+        existing.setValor(payload.getValor());
+        existing.setFolhaPagamento(payload.getFolhaPagamento());
+        resolveRelations(existing);
+        return existing;
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FeriasAfastamentoService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FeriasAfastamentoService.java
@@ -1,0 +1,69 @@
+package com.example.praxis.humanresources.service;
+
+import com.example.praxis.humanresources.dto.FeriasAfastamentoFilterDTO;
+import com.example.praxis.humanresources.entity.FeriasAfastamento;
+import com.example.praxis.humanresources.entity.Funcionario;
+import com.example.praxis.humanresources.repository.FeriasAfastamentoRepository;
+import com.example.praxis.humanresources.repository.FuncionarioRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
+import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
+import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class FeriasAfastamentoService implements BaseCrudService<FeriasAfastamento, Long, FeriasAfastamentoFilterDTO> {
+
+    @Autowired
+    private FeriasAfastamentoRepository feriasAfastamentoRepository;
+
+    @Autowired
+    private FuncionarioRepository funcionarioRepository;
+
+    @Override
+    public BaseCrudRepository<FeriasAfastamento, Long> getRepository() {
+        return feriasAfastamentoRepository;
+    }
+
+    @Override
+    public GenericSpecificationsBuilder<FeriasAfastamento> getSpecificationsBuilder() {
+        return new GenericSpecificationsBuilder<>();
+    }
+
+    @Override
+    public Class<FeriasAfastamento> getEntityClass() {
+        return FeriasAfastamento.class;
+    }
+
+    private void resolveRelations(FeriasAfastamento registro) {
+        if (registro.getFuncionario() != null && registro.getFuncionario().getId() != null) {
+            Funcionario funcionario = funcionarioRepository.findById(registro.getFuncionario().getId())
+                    .orElseThrow(() -> new EntityNotFoundException("Funcionario nao encontrado com ID: " + registro.getFuncionario().getId()));
+            registro.setFuncionario(funcionario);
+        } else {
+            registro.setFuncionario(null);
+        }
+    }
+
+    @Override
+    @Transactional
+    public FeriasAfastamento save(FeriasAfastamento registro) {
+        resolveRelations(registro);
+        return feriasAfastamentoRepository.save(registro);
+    }
+
+    @Override
+    @Transactional
+    public FeriasAfastamento mergeUpdate(FeriasAfastamento existing, FeriasAfastamento payload) {
+        existing.setTipo(payload.getTipo());
+        existing.setDataInicio(payload.getDataInicio());
+        existing.setDataFim(payload.getDataFim());
+        existing.setObservacoes(payload.getObservacoes());
+        existing.setFuncionario(payload.getFuncionario());
+        resolveRelations(existing);
+        return existing;
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FolhaPagamentoService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FolhaPagamentoService.java
@@ -1,0 +1,71 @@
+package com.example.praxis.humanresources.service;
+
+import com.example.praxis.humanresources.dto.FolhaPagamentoFilterDTO;
+import com.example.praxis.humanresources.entity.FolhaPagamento;
+import com.example.praxis.humanresources.entity.Funcionario;
+import com.example.praxis.humanresources.repository.FolhaPagamentoRepository;
+import com.example.praxis.humanresources.repository.FuncionarioRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
+import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
+import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class FolhaPagamentoService implements BaseCrudService<FolhaPagamento, Long, FolhaPagamentoFilterDTO> {
+
+    @Autowired
+    private FolhaPagamentoRepository folhaPagamentoRepository;
+
+    @Autowired
+    private FuncionarioRepository funcionarioRepository;
+
+    @Override
+    public BaseCrudRepository<FolhaPagamento, Long> getRepository() {
+        return folhaPagamentoRepository;
+    }
+
+    @Override
+    public GenericSpecificationsBuilder<FolhaPagamento> getSpecificationsBuilder() {
+        return new GenericSpecificationsBuilder<>();
+    }
+
+    @Override
+    public Class<FolhaPagamento> getEntityClass() {
+        return FolhaPagamento.class;
+    }
+
+    private void resolveRelations(FolhaPagamento folha) {
+        if (folha.getFuncionario() != null && folha.getFuncionario().getId() != null) {
+            Funcionario funcionario = funcionarioRepository.findById(folha.getFuncionario().getId())
+                    .orElseThrow(() -> new EntityNotFoundException("Funcionario nao encontrado com ID: " + folha.getFuncionario().getId()));
+            folha.setFuncionario(funcionario);
+        } else {
+            folha.setFuncionario(null);
+        }
+    }
+
+    @Override
+    @Transactional
+    public FolhaPagamento save(FolhaPagamento folha) {
+        resolveRelations(folha);
+        return folhaPagamentoRepository.save(folha);
+    }
+
+    @Override
+    @Transactional
+    public FolhaPagamento mergeUpdate(FolhaPagamento existing, FolhaPagamento payload) {
+        existing.setAno(payload.getAno());
+        existing.setMes(payload.getMes());
+        existing.setSalarioBruto(payload.getSalarioBruto());
+        existing.setTotalDescontos(payload.getTotalDescontos());
+        existing.setSalarioLiquido(payload.getSalarioLiquido());
+        existing.setDataPagamento(payload.getDataPagamento());
+        existing.setFuncionario(payload.getFuncionario());
+        resolveRelations(existing);
+        return existing;
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/humanresources/HumanResourcesNewEndpointsTest.java
+++ b/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/humanresources/HumanResourcesNewEndpointsTest.java
@@ -1,0 +1,38 @@
+package com.example.praxis.humanresources;
+
+import com.example.praxis.common.config.ApiRouteDefinitions;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class HumanResourcesNewEndpointsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testFolhasPagamentoEndpoint() throws Exception {
+        mockMvc.perform(get(ApiRouteDefinitions.HR_FOLHAS_PAGAMENTO_PATH))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testEventosFolhaEndpoint() throws Exception {
+        mockMvc.perform(get(ApiRouteDefinitions.HR_EVENTOS_FOLHA_PATH))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testFeriasAfastamentosEndpoint() throws Exception {
+        mockMvc.perform(get(ApiRouteDefinitions.HR_FERIAS_AFASTAMENTOS_PATH))
+                .andExpect(status().isOk());
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/humanresources/dto/DtoAnnotationTest.java
+++ b/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/humanresources/dto/DtoAnnotationTest.java
@@ -76,6 +76,37 @@ public class DtoAnnotationTest {
         validateFilterDto(FuncionarioFilterDTO.class, expected);
     }
 
+    @Test
+    public void testFolhaPagamentoFilterDtoAnnotations() {
+        Map<String, Expectation> expected = new LinkedHashMap<>();
+        expected.put("funcionarioId", new Expectation(FilterOperation.EQUAL, "funcionario.id"));
+        expected.put("ano", new Expectation(FilterOperation.EQUAL, ""));
+        expected.put("mes", new Expectation(FilterOperation.EQUAL, ""));
+        expected.put("salarioBruto", new Expectation(FilterOperation.BETWEEN, ""));
+        expected.put("dataPagamento", new Expectation(FilterOperation.BETWEEN, ""));
+        validateFilterDto(FolhaPagamentoFilterDTO.class, expected);
+    }
+
+    @Test
+    public void testEventoFolhaFilterDtoAnnotations() {
+        Map<String, Expectation> expected = new LinkedHashMap<>();
+        expected.put("folhaPagamentoId", new Expectation(FilterOperation.EQUAL, "folhaPagamento.id"));
+        expected.put("descricao", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("tipo", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("valor", new Expectation(FilterOperation.BETWEEN, ""));
+        validateFilterDto(EventoFolhaFilterDTO.class, expected);
+    }
+
+    @Test
+    public void testFeriasAfastamentoFilterDtoAnnotations() {
+        Map<String, Expectation> expected = new LinkedHashMap<>();
+        expected.put("funcionarioId", new Expectation(FilterOperation.EQUAL, "funcionario.id"));
+        expected.put("tipo", new Expectation(FilterOperation.LIKE, ""));
+        expected.put("dataInicio", new Expectation(FilterOperation.BETWEEN, ""));
+        expected.put("dataFim", new Expectation(FilterOperation.BETWEEN, ""));
+        validateFilterDto(FeriasAfastamentoFilterDTO.class, expected);
+    }
+
     private void validateFilterDto(Class<?> clazz, Map<String, Expectation> expectations) {
         for (Field field : clazz.getDeclaredFields()) {
             assertTrue(clazz.getSimpleName() + "." + field.getName() + " should have @UISchema",


### PR DESCRIPTION
## Summary
- add path constants for payroll-related endpoints
- provide filter DTOs and mappers for FolhaPagamento, EventoFolha and FeriasAfastamento
- implement corresponding services and controllers
- expand DTO annotation tests and add endpoint smoke tests
- document new API paths

## Testing
- `./mvnw -q -pl examples/praxis-backend-libs-sample-app test` *(fails: Maven not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854a53c9bd88328870981d61c69ae42