### PR TITLE
Add AbstractBaseCrudService with transactional methods

### DIFF
--- a/backend-libs/praxis-metadata-core/README.md
+++ b/backend-libs/praxis-metadata-core/README.md
@@ -9,7 +9,7 @@ Praxis Metadata Core (`praxis-metadata-core`) is a foundational library providin
 The `praxis-metadata-core` library offers a comprehensive set of features to accelerate backend development and enable dynamic UI rendering:
 
 *   **Dynamic UI Schema Generation:** Define rich UI metadata directly in your Java DTOs or entities using the `@UISchema` annotation. This metadata, including details about labels, control types, layout, validation, and visibility, can be exposed via an API endpoint, allowing frontends to dynamically render interfaces.
-*   **Generic CRUD Infrastructure:** Provides abstract base classes (`AbstractCrudController`, `BaseCrudService`) to rapidly implement standardized CRUD (Create, Read, Update, Delete) operations, significantly reducing boilerplate code.
+*   **Generic CRUD Infrastructure:** Provides abstract base classes (`AbstractCrudController`, `AbstractBaseCrudService`, `BaseCrudService`) to rapidly implement standardized CRUD (Create, Read, Update, Delete) operations, significantly reducing boilerplate code.
 *   **Dynamic Query Filtering:** Annotate DTO fields with `@Filterable` to easily enable them as criteria for dynamic, type-safe JPA query generation, supporting various filter operations and entity relationships.
 *   **Automatic Validation Integration:** Standard Jakarta Bean Validation annotations are interpreted and exposed through the `x-ui` extension, allowing frontends to automatically enforce and display validation rules defined on the backend.
 *   **HATEOAS Support:** Automatically includes HATEOAS links in API responses, making your APIs more discoverable and self-descriptive.
@@ -22,7 +22,7 @@ The `praxis-metadata-core` library offers a comprehensive set of features to acc
 
 The main resources of this library are designed to work together and reduce boilerplate when creating data-driven applications:
 
-* **Generic CRUD** – Use `AbstractCrudController` and `BaseCrudService` as a starting point to implement standardized create, read, update and delete endpoints with minimal code.
+* **Generic CRUD** – Use `AbstractCrudController`, `AbstractBaseCrudService` and `BaseCrudService` as a starting point to implement standardized create, read, update and delete endpoints with minimal code.
 * **Filters** – Mark DTO fields with `@Filterable` and let the framework build type-safe JPA `Specification` queries behind the scenes, exposing a convenient `/filter` endpoint.
 * **Automatic Validation** – Bean Validation constraints (`@NotNull`, `@Size`, etc.) are merged with `@UISchema` attributes so that generated UI schemas contain the expected rules and error messages without extra configuration.
 
@@ -228,7 +228,12 @@ To simplify the creation of RESTful services with UI metadata capabilities, the 
     *   This generic class serves as a foundation for creating CRUD controllers. Concrete controllers extend it, specifying their Entity (`E`), DTO (`D`), Filter DTO (`FD`), and Identifier Type (`ID`).
     *   It automatically provides standard REST endpoints for create, read (all and by ID), update, delete, and a powerful `/filter` endpoint that works with `@Filterable` DTOs.
     *   Crucially, it integrates UI schema generation by providing a `/schemas` endpoint (and a `/schemas/filtered` variant) that exposes the metadata defined by `@UISchema` annotations for the controller's entity/DTO. This allows frontends to fetch UI configurations dynamically.
-    *   It also incorporates HATEOAS link generation and standardized API responses using `RestApiResponse`.
+*   It also incorporates HATEOAS link generation and standardized API responses using `RestApiResponse`.
+
+*   **`AbstractBaseCrudService<E, ID, FD>`**:
+    *   A convenient abstract class that already implements `BaseCrudService` and wires common dependencies like the repository and specification builder.
+    *   It annotates `save`, `update` and `deleteById` with `@Transactional` to ensure consistent transaction handling.
+    *   Concrete services typically extend this class and only provide custom business logic.
 
 *   **`BaseCrudService<E, ID, FD>`**:
     *   This generic interface (often implemented by an abstract class or a concrete service) defines the standard contract for service-layer CRUD operations.

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/AbstractBaseCrudService.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/AbstractBaseCrudService.java
@@ -1,0 +1,68 @@
+package org.praxisplatform.uischema.service.base;
+
+import org.praxisplatform.uischema.filter.dto.GenericFilterDTO;
+import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
+import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Convenience base class that wires required components for {@link BaseCrudService} implementations
+ * and applies transactional semantics to write operations.
+ *
+ * @param <E>  Entity type
+ * @param <ID> Identifier type
+ * @param <FD> Filter DTO type
+ */
+public abstract class AbstractBaseCrudService<E, ID, FD extends GenericFilterDTO>
+        implements BaseCrudService<E, ID, FD> {
+
+    private final BaseCrudRepository<E, ID> repository;
+    private final GenericSpecificationsBuilder<E> specificationsBuilder;
+    private final Class<E> entityClass;
+
+    protected AbstractBaseCrudService(BaseCrudRepository<E, ID> repository,
+                                      GenericSpecificationsBuilder<E> specificationsBuilder,
+                                      Class<E> entityClass) {
+        this.repository = repository;
+        this.specificationsBuilder = specificationsBuilder;
+        this.entityClass = entityClass;
+    }
+
+    protected AbstractBaseCrudService(BaseCrudRepository<E, ID> repository,
+                                      Class<E> entityClass) {
+        this(repository, new GenericSpecificationsBuilder<>(), entityClass);
+    }
+
+    @Override
+    public BaseCrudRepository<E, ID> getRepository() {
+        return repository;
+    }
+
+    @Override
+    public GenericSpecificationsBuilder<E> getSpecificationsBuilder() {
+        return specificationsBuilder;
+    }
+
+    @Override
+    public Class<E> getEntityClass() {
+        return entityClass;
+    }
+
+    @Override
+    @Transactional
+    public E save(E entity) {
+        return BaseCrudService.super.save(entity);
+    }
+
+    @Override
+    @Transactional
+    public E update(ID id, E entity) {
+        return BaseCrudService.super.update(id, entity);
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(ID id) {
+        BaseCrudService.super.deleteById(id);
+    }
+}

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/CargoService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/CargoService.java
@@ -3,32 +3,16 @@ package com.example.praxis.humanresources.service;
 import com.example.praxis.humanresources.dto.CargoFilterDTO;
 import com.example.praxis.humanresources.entity.Cargo;
 import com.example.praxis.humanresources.repository.CargoRepository;
-import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
-import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
-import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.praxisplatform.uischema.service.base.AbstractBaseCrudService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CargoService implements BaseCrudService<Cargo, Long, CargoFilterDTO> {
+public class CargoService extends AbstractBaseCrudService<Cargo, Long, CargoFilterDTO> {
 
     @Autowired
-    private CargoRepository cargoRepository;
-
-    @Override
-    public BaseCrudRepository<Cargo, Long> getRepository() {
-        return cargoRepository;
-    }
-
-    @Override
-    public GenericSpecificationsBuilder<Cargo> getSpecificationsBuilder() {
-        // Assuming default behavior is sufficient for now
-        return new GenericSpecificationsBuilder<>();
-    }
-
-    @Override
-    public Class<Cargo> getEntityClass() {
-        return Cargo.class;
+    public CargoService(CargoRepository cargoRepository) {
+        super(cargoRepository, Cargo.class);
     }
 
     @Override

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/DepartamentoService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/DepartamentoService.java
@@ -6,35 +6,23 @@ import com.example.praxis.humanresources.entity.Funcionario;
 import com.example.praxis.humanresources.repository.DepartamentoRepository;
 import com.example.praxis.humanresources.repository.FuncionarioRepository;
 import jakarta.persistence.EntityNotFoundException;
-import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
-import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
-import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.praxisplatform.uischema.service.base.AbstractBaseCrudService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class DepartamentoService implements BaseCrudService<Departamento, Long, DepartamentoFilterDTO> {
+public class DepartamentoService extends AbstractBaseCrudService<Departamento, Long, DepartamentoFilterDTO> {
+
+    private final DepartamentoRepository departamentoRepository;
+    private final FuncionarioRepository funcionarioRepository; // Needed to resolve responsavelId
 
     @Autowired
-    private DepartamentoRepository departamentoRepository;
-
-    @Autowired
-    private FuncionarioRepository funcionarioRepository; // Needed to resolve responsavelId
-
-    @Override
-    public BaseCrudRepository<Departamento, Long> getRepository() {
-        return departamentoRepository;
-    }
-
-    @Override
-    public GenericSpecificationsBuilder<Departamento> getSpecificationsBuilder() {
-        return new GenericSpecificationsBuilder<>();
-    }
-
-    @Override
-    public Class<Departamento> getEntityClass() {
-        return Departamento.class;
+    public DepartamentoService(DepartamentoRepository departamentoRepository,
+                               FuncionarioRepository funcionarioRepository) {
+        super(departamentoRepository, Departamento.class);
+        this.departamentoRepository = departamentoRepository;
+        this.funcionarioRepository = funcionarioRepository;
     }
 
     private void resolveRelations(Departamento departamento) {

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/EventoFolhaService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/EventoFolhaService.java
@@ -6,35 +6,23 @@ import com.example.praxis.humanresources.entity.FolhaPagamento;
 import com.example.praxis.humanresources.repository.EventoFolhaRepository;
 import com.example.praxis.humanresources.repository.FolhaPagamentoRepository;
 import jakarta.persistence.EntityNotFoundException;
-import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
-import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
-import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.praxisplatform.uischema.service.base.AbstractBaseCrudService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class EventoFolhaService implements BaseCrudService<EventoFolha, Long, EventoFolhaFilterDTO> {
+public class EventoFolhaService extends AbstractBaseCrudService<EventoFolha, Long, EventoFolhaFilterDTO> {
+
+    private final EventoFolhaRepository eventoFolhaRepository;
+    private final FolhaPagamentoRepository folhaPagamentoRepository;
 
     @Autowired
-    private EventoFolhaRepository eventoFolhaRepository;
-
-    @Autowired
-    private FolhaPagamentoRepository folhaPagamentoRepository;
-
-    @Override
-    public BaseCrudRepository<EventoFolha, Long> getRepository() {
-        return eventoFolhaRepository;
-    }
-
-    @Override
-    public GenericSpecificationsBuilder<EventoFolha> getSpecificationsBuilder() {
-        return new GenericSpecificationsBuilder<>();
-    }
-
-    @Override
-    public Class<EventoFolha> getEntityClass() {
-        return EventoFolha.class;
+    public EventoFolhaService(EventoFolhaRepository eventoFolhaRepository,
+                              FolhaPagamentoRepository folhaPagamentoRepository) {
+        super(eventoFolhaRepository, EventoFolha.class);
+        this.eventoFolhaRepository = eventoFolhaRepository;
+        this.folhaPagamentoRepository = folhaPagamentoRepository;
     }
 
     private void resolveRelations(EventoFolha evento) {

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FeriasAfastamentoService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FeriasAfastamentoService.java
@@ -6,35 +6,23 @@ import com.example.praxis.humanresources.entity.Funcionario;
 import com.example.praxis.humanresources.repository.FeriasAfastamentoRepository;
 import com.example.praxis.humanresources.repository.FuncionarioRepository;
 import jakarta.persistence.EntityNotFoundException;
-import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
-import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
-import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.praxisplatform.uischema.service.base.AbstractBaseCrudService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class FeriasAfastamentoService implements BaseCrudService<FeriasAfastamento, Long, FeriasAfastamentoFilterDTO> {
+public class FeriasAfastamentoService extends AbstractBaseCrudService<FeriasAfastamento, Long, FeriasAfastamentoFilterDTO> {
+
+    private final FeriasAfastamentoRepository feriasAfastamentoRepository;
+    private final FuncionarioRepository funcionarioRepository;
 
     @Autowired
-    private FeriasAfastamentoRepository feriasAfastamentoRepository;
-
-    @Autowired
-    private FuncionarioRepository funcionarioRepository;
-
-    @Override
-    public BaseCrudRepository<FeriasAfastamento, Long> getRepository() {
-        return feriasAfastamentoRepository;
-    }
-
-    @Override
-    public GenericSpecificationsBuilder<FeriasAfastamento> getSpecificationsBuilder() {
-        return new GenericSpecificationsBuilder<>();
-    }
-
-    @Override
-    public Class<FeriasAfastamento> getEntityClass() {
-        return FeriasAfastamento.class;
+    public FeriasAfastamentoService(FeriasAfastamentoRepository feriasAfastamentoRepository,
+                                    FuncionarioRepository funcionarioRepository) {
+        super(feriasAfastamentoRepository, FeriasAfastamento.class);
+        this.feriasAfastamentoRepository = feriasAfastamentoRepository;
+        this.funcionarioRepository = funcionarioRepository;
     }
 
     private void resolveRelations(FeriasAfastamento registro) {

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FolhaPagamentoService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FolhaPagamentoService.java
@@ -6,35 +6,23 @@ import com.example.praxis.humanresources.entity.Funcionario;
 import com.example.praxis.humanresources.repository.FolhaPagamentoRepository;
 import com.example.praxis.humanresources.repository.FuncionarioRepository;
 import jakarta.persistence.EntityNotFoundException;
-import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
-import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
-import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.praxisplatform.uischema.service.base.AbstractBaseCrudService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class FolhaPagamentoService implements BaseCrudService<FolhaPagamento, Long, FolhaPagamentoFilterDTO> {
+public class FolhaPagamentoService extends AbstractBaseCrudService<FolhaPagamento, Long, FolhaPagamentoFilterDTO> {
+
+    private final FolhaPagamentoRepository folhaPagamentoRepository;
+    private final FuncionarioRepository funcionarioRepository;
 
     @Autowired
-    private FolhaPagamentoRepository folhaPagamentoRepository;
-
-    @Autowired
-    private FuncionarioRepository funcionarioRepository;
-
-    @Override
-    public BaseCrudRepository<FolhaPagamento, Long> getRepository() {
-        return folhaPagamentoRepository;
-    }
-
-    @Override
-    public GenericSpecificationsBuilder<FolhaPagamento> getSpecificationsBuilder() {
-        return new GenericSpecificationsBuilder<>();
-    }
-
-    @Override
-    public Class<FolhaPagamento> getEntityClass() {
-        return FolhaPagamento.class;
+    public FolhaPagamentoService(FolhaPagamentoRepository folhaPagamentoRepository,
+                                 FuncionarioRepository funcionarioRepository) {
+        super(folhaPagamentoRepository, FolhaPagamento.class);
+        this.folhaPagamentoRepository = folhaPagamentoRepository;
+        this.funcionarioRepository = funcionarioRepository;
     }
 
     private void resolveRelations(FolhaPagamento folha) {

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FuncionarioService.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/humanresources/service/FuncionarioService.java
@@ -9,40 +9,25 @@ import com.example.praxis.humanresources.repository.CargoRepository;
 import com.example.praxis.humanresources.repository.DepartamentoRepository;
 import com.example.praxis.humanresources.repository.FuncionarioRepository;
 import jakarta.persistence.EntityNotFoundException;
-import org.praxisplatform.uischema.filter.specification.GenericSpecificationsBuilder;
-import org.praxisplatform.uischema.repository.base.BaseCrudRepository;
-import org.praxisplatform.uischema.service.base.BaseCrudService;
+import org.praxisplatform.uischema.service.base.AbstractBaseCrudService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class FuncionarioService implements BaseCrudService<Funcionario, Long, FuncionarioFilterDTO> {
+public class FuncionarioService extends AbstractBaseCrudService<Funcionario, Long, FuncionarioFilterDTO> {
+
+    private final FuncionarioRepository funcionarioRepository;
+    private final CargoRepository cargoRepository;
+    private final DepartamentoRepository departamentoRepository;
 
     @Autowired
-    private FuncionarioRepository funcionarioRepository;
-
-    @Autowired
-    private CargoRepository cargoRepository;
-
-    @Autowired
-    private DepartamentoRepository departamentoRepository;
-
-    @Override
-    public BaseCrudRepository<Funcionario, Long> getRepository() {
-        return funcionarioRepository;
-    }
-
-    @Override
-    public GenericSpecificationsBuilder<Funcionario> getSpecificationsBuilder() {
-        return new GenericSpecificationsBuilder<>();
-    }
-
-    /**
-     * @return
-     */
-    @Override
-    public Class<Funcionario> getEntityClass() {
-        return Funcionario.class; // Changed from null
+    public FuncionarioService(FuncionarioRepository funcionarioRepository,
+                              CargoRepository cargoRepository,
+                              DepartamentoRepository departamentoRepository) {
+        super(funcionarioRepository, Funcionario.class);
+        this.funcionarioRepository = funcionarioRepository;
+        this.cargoRepository = cargoRepository;
+        this.departamentoRepository = departamentoRepository;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add `AbstractBaseCrudService` as transactional base class
- update sample services to extend the new class
- document the new class in metadata-core README

## Testing
- `./mvnw -q -f backend-libs/praxis-metadata-core/pom.xml test` *(fails: Maven is not installed)*
- `./mvnw -q -f examples/praxis-backend-libs-sample-app/pom.xml test` *(fails: Maven is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854b20c35188328b0a21121d852a322