### PR TITLE
Fix docs workflow to use Maven

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Generate backend docs
         working-directory: backend-libs/praxis-metadata-core
         run: |
-          ./gradlew asciidoctor
-          test -d build/docs/asciidoc
+          ../../mvnw --batch-mode javadoc:javadoc
+          test -d target/site/apidocs
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -41,7 +41,7 @@ jobs:
       - name: Prepare docs folder
         run: |
           mkdir -p docs/backend docs/frontend
-          cp -r backend-libs/praxis-metadata-core/build/docs/asciidoc/. docs/backend/
+          cp -r backend-libs/praxis-metadata-core/target/site/apidocs/. docs/backend/
           cp -r frontend-libs/praxis-metadata-core/documentation/. docs/frontend/
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- fix the docs workflow to call Maven in the backend step
- copy generated Javadoc to docs folder

## Testing
- `pre-commit` *(fails: no pre-commit config)*

------
https://chatgpt.com/codex/tasks/task_e_68553f00fa2c83288b4edf5e2a28d27f