### PR TITLE
Fix docs workflow and README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,26 +23,10 @@ jobs:
           ../../mvnw --batch-mode javadoc:javadoc
           test -d target/site/apidocs
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-
-      - name: Install frontend dependencies
-        working-directory: frontend-libs/praxis-metadata-core
-        run: npm ci
-
-      - name: Generate frontend docs
-        working-directory: frontend-libs/praxis-metadata-core
-        run: |
-          npx compodoc -p tsconfig.json -d documentation
-          test -d documentation
-
       - name: Prepare docs folder
         run: |
-          mkdir -p docs/backend docs/frontend
+          mkdir -p docs/backend
           cp -r backend-libs/praxis-metadata-core/target/site/apidocs/. docs/backend/
-          cp -r frontend-libs/praxis-metadata-core/documentation/. docs/frontend/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The `praxis-metadata-core` library offers a comprehensive set of features to acc
 
 ## Documentation
 
-This repository contains backend and frontend libraries. Documentation can be generated locally or published automatically via GitHub Actions.
+This repository currently contains only the backend library. Documentation can be generated locally or published automatically via GitHub Actions.
 
 ### Generating backend docs
 
@@ -29,13 +29,3 @@ cd backend-libs/praxis-metadata-core
 ```
 
 The generated Javadoc will be placed in `target/site/apidocs`.
-
-### Generating frontend docs
-
-```bash
-cd frontend-libs/praxis-metadata-core
-npm ci
-npx compodoc -p tsconfig.json -d documentation
-```
-
-The generated site will be available in the `documentation` folder.


### PR DESCRIPTION
## Summary
- remove nonexistent frontend steps from docs workflow
- clarify README to only mention backend library

## Testing
- `../../mvnw test` *(fails: Maven is not installed and Maven Wrapper jar is missing)*

------
https://chatgpt.com/codex/tasks/task_e_685546f7eb9c8328a223875f3ff49afc