### PR TITLE
Fix javadoc warnings in Filterable annotation

### DIFF
--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/filter/annotation/Filterable.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/filter/annotation/Filterable.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * especificações genéricas para consultas. Permite configurar a operação de filtro e especificar relacionamentos
  * complexos, quando necessário.</p>
  *
- * <h3>Configuração</h3>
+ * <h2>Configuração</h2>
  * <ul>
  *     <li><b>operation</b>: Especifica o tipo de operação de filtro a ser aplicado no campo, como
  *         igualdade, maior que, menor que, entre outros. Consulte {@link FilterOperation} para as opções disponíveis.</li>
@@ -20,35 +20,36 @@ import java.lang.annotation.Target;
  *         à entidade raiz. Use o formato "relacao1.relacao2.campo" para navegar por relacionamentos aninhados.</li>
  * </ul>
  *
- * <h3>Exemplo de Uso</h3>
+ * <h2>Exemplo de Uso</h2>
  * <p>Considere um DTO que representa os filtros aplicáveis a uma consulta de pessoa física:</p>
  *
- * <pre>
+ * <pre>{@code
  * public class PessoaFisicaFilterDTO {
  *
  *     // Filtro de igualdade em um campo direto da entidade
- *     {@code @Filterable(operation = FilterOperation.EQUAL)}
+ *     @Filterable(operation = FilterOperation.EQUAL)
  *     private UUID tipoSexoUuid;
  *
  *     // Filtro de LIKE em um campo relacionado (e.g., "tipoSexo.nome")
- *     {@code @Filterable(operation = FilterOperation.LIKE, relation = "tipoSexo.nome")}
+ *     @Filterable(operation = FilterOperation.LIKE, relation = "tipoSexo.nome")
  *     private String tipoSexoDescricao;
  *
  *     // Filtro de maior que em um campo de data
- *     {@code @Filterable(operation = FilterOperation.GREATER_THAN)}
+ *     @Filterable(operation = FilterOperation.GREATER_THAN)
  *     private LocalDate dataNascimento;
  *
- *      @Schema(description = "Filtro por intervalo de datas de verificação", example = "[\"2019-01-01\", \"2022-12-31\"]")
- *      @Filterable(operation = Filterable.FilterOperation.BETWEEN,relation = "dataVerificacao")
- *      List<LocalDate> dataVerificacaoFiltro,
+ *     @Schema(description = "Filtro por intervalo de datas de verificação",
+ *             example = "[\"2019-01-01\", \"2022-12-31\"]")
+ *     @Filterable(operation = Filterable.FilterOperation.BETWEEN, relation = "dataVerificacao")
+ *     private List<LocalDate> dataVerificacaoFiltro;
  * }
  * </pre>
  * <p>
- *  * <h3>Validação de Campos de Filtro</h3>
+ *  * <h2>Validação de Campos de Filtro</h2>
  *  * <p>Certifique-se de que os campos de filtro, como {@code dataVerificacao}, sejam usados apenas para consultas e, se necessário,
  *  * configurados para serem ignorados nos mapeamentos com a entidade principal.</p>
  *
- * <h3>Notas para Relacionamentos</h3>
+ * <h2>Notas para Relacionamentos</h2>
  * <p>Quando o filtro envolve campos relacionados:</p>
  * <ul>
  *     <li>Use o atributo <b>relation</b> para especificar o caminho até o campo da entidade relacionada.</li>


### PR DESCRIPTION
## Summary
- adjust heading levels in `Filterable` javadoc
- wrap example code block with `<pre>{@code ... }</pre>`

## Testing
- `./mvnw -q -pl backend-libs/praxis-metadata-core -am javadoc:javadoc` *(fails: Maven is not installed and Maven Wrapper jar is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855488378ec8328b6b21535a7e8b57a