### PR TITLE
Add docs directory for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <title>Documentação - Praxis</title>
+</head>
+<body>
+  <h1>Bem-vindo à documentação do Projeto Praxis</h1>
+  <ul>
+    <li><a href="./backend/index.html">Documentação da API Java (praxis-metadata-core)</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create new `docs/` folder with index.html

## Testing
- `./mvnw -q test -f backend-libs/praxis-metadata-core/pom.xml` *(fails: Maven is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68555897d26c8328a032be9d5e24d623