### PR TITLE
Publish sample app Javadoc in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,18 @@ jobs:
           ../../mvnw --batch-mode javadoc:javadoc
           test -d target/site/apidocs
 
+      - name: Generate sample app docs
+        working-directory: examples/praxis-backend-libs-sample-app
+        run: |
+          ../../mvnw --batch-mode javadoc:javadoc
+          test -d target/site/apidocs
+
       - name: Prepare docs folder
         run: |
           mkdir -p docs/backend
           cp -r backend-libs/praxis-metadata-core/target/site/apidocs/. docs/backend/
+          mkdir -p docs/sample-backend
+          cp -r examples/praxis-backend-libs-sample-app/target/site/apidocs/. docs/sample-backend/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,7 @@
   <h1>Bem-vindo à documentação do Projeto Praxis</h1>
   <ul>
     <li><a href="./backend/index.html">Documentação da API Java (praxis-metadata-core)</a></li>
+    <li><a href="./sample-backend/index.html">Documentação de exemplo (praxis-backend-libs-sample-app)</a></li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- generate Javadoc for the sample application
- copy generated docs to `docs/sample-backend`
- link sample docs on the main docs index

## Testing
- `./mvnw -q -f backend-libs/praxis-metadata-core/pom.xml -DskipTests package` *(failed: Maven is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855dcd8920c8328b95fd1335109b974