### PR TITLE
Fix docs build by installing libs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: Install library modules
+        run: |
+          ./mvnw --batch-mode -f backend-libs/praxis-metadata-core/pom.xml install -DskipTests
+
       - name: Generate backend docs
         working-directory: backend-libs/praxis-metadata-core
         run: |


### PR DESCRIPTION
## Summary
- ensure `docs` workflow installs lib modules before building sample app docs

## Testing
- `./mvnw --version` *(fails: Maven is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855e3a6b99c8328af892ec1e5fae16c