### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,18 +27,10 @@ jobs:
           ../../mvnw --batch-mode javadoc:javadoc
           test -d target/site/apidocs
 
-      - name: Generate sample app docs
-        working-directory: examples/praxis-backend-libs-sample-app
-        run: |
-          ../../mvnw --batch-mode javadoc:javadoc
-          test -d target/site/apidocs
-
       - name: Prepare docs folder
         run: |
           mkdir -p docs/backend
           cp -r backend-libs/praxis-metadata-core/target/site/apidocs/. docs/backend/
-          mkdir -p docs/sample-backend
-          cp -r examples/praxis-backend-libs-sample-app/target/site/apidocs/. docs/sample-backend/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Summary
- fix docs workflow to drop building sample app docs

## Testing
- `./mvnw -q -N validate` *(fails: Maven is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855e503d2a48328b4ad626e4e1c2fe8