### PR TITLE
Fix docs workflow to publish HTML pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,14 @@ jobs:
           mkdir -p docs/backend
           cp -r backend-libs/praxis-metadata-core/target/site/apidocs/. docs/backend/
 
+      - name: Convert Markdown to HTML
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+          for md in $(find docs -name '*.md'); do
+            pandoc "$md" -o "${md%.md}.html" --standalone
+          done
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
- convert docs markdown files to HTML during build

## Testing
- `./mvnw -q -f backend-libs/praxis-metadata-core/pom.xml test` *(fails: Maven not installed)*
- `sudo apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856b40248888328bc6fc62df0f002f3