### PR TITLE
Add initial Angular workspace with library and sample app

### DIFF
--- a/frontend-libs/praxis-ui-workspace/.eslintrc.json
+++ b/frontend-libs/praxis-ui-workspace/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "root": true,
+  "ignorePatterns": ["projects/**/*"],
+  "overrides": []
+}

--- a/frontend-libs/praxis-ui-workspace/README.md
+++ b/frontend-libs/praxis-ui-workspace/README.md
@@ -1,0 +1,5 @@
+# Praxis UI Workspace
+
+Este monorepo contém a biblioteca `praxis-ui-core` e o aplicativo de exemplo `praxis-ui-sample-app`.
+
+Execute `npm install` na raiz e use os scripts disponíveis em `package.json` para compilar ou servir o projeto.

--- a/frontend-libs/praxis-ui-workspace/angular.json
+++ b/frontend-libs/praxis-ui-workspace/angular.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "praxis-ui-core": {
+      "projectType": "library",
+      "root": "projects/praxis-ui-core",
+      "sourceRoot": "projects/praxis-ui-core/src",
+      "prefix": "puc",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:ng-packagr",
+          "options": {
+            "project": "projects/praxis-ui-core/ng-package.json",
+            "tsConfig": "projects/praxis-ui-core/tsconfig.lib.json"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "tsConfig": "projects/praxis-ui-core/tsconfig.spec.json",
+            "karmaConfig": "projects/praxis-ui-core/karma.conf.js"
+          }
+        }
+      }
+    },
+    "praxis-ui-sample-app": {
+      "projectType": "application",
+      "root": "apps/praxis-ui-sample-app",
+      "sourceRoot": "apps/praxis-ui-sample-app/src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/praxis-ui-sample-app",
+            "index": "apps/praxis-ui-sample-app/src/index.html",
+            "main": "apps/praxis-ui-sample-app/src/main.ts",
+            "polyfills": "apps/praxis-ui-sample-app/src/polyfills.ts",
+            "tsConfig": "apps/praxis-ui-sample-app/tsconfig.app.json",
+            "assets": [
+              "apps/praxis-ui-sample-app/src/favicon.ico",
+              "apps/praxis-ui-sample-app/src/assets"
+            ],
+            "styles": [
+              "apps/praxis-ui-sample-app/src/styles.css"
+            ],
+            "scripts": []
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "praxis-ui-sample-app:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "apps/praxis-ui-sample-app/src/test.ts",
+            "polyfills": "apps/praxis-ui-sample-app/src/polyfills.ts",
+            "tsConfig": "apps/praxis-ui-sample-app/tsconfig.spec.json",
+            "karmaConfig": "apps/praxis-ui-sample-app/karma.conf.js",
+            "assets": [
+              "apps/praxis-ui-sample-app/src/favicon.ico",
+              "apps/praxis-ui-sample-app/src/assets"
+            ],
+            "styles": [
+              "apps/praxis-ui-sample-app/src/styles.css"
+            ],
+            "scripts": []
+          }
+        }
+      }
+    }
+  },
+  "cli": {
+    "analytics": false
+  },
+  "defaultProject": "praxis-ui-sample-app"
+}

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/README.md
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/README.md
@@ -1,0 +1,22 @@
+# Praxis UI Sample App
+
+Aplicativo Angular de demonstração que utiliza a biblioteca `praxis-ui-core`.
+
+Estrutura:
+```
+frontend-libs/
+└── praxis-ui-workspace/
+    └── apps/
+        └── praxis-ui-sample-app/
+```
+
+## Executando
+
+1. Instale as dependências na raiz do workspace:
+   ```bash
+   npm install
+   ```
+2. Inicie o servidor de desenvolvimento:
+   ```bash
+   npm start
+   ```

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/karma.conf.js
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/karma.conf.js
@@ -1,0 +1,24 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../../coverage/praxis-ui-sample-app'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['ChromeHeadless'],
+    restartOnFileChange: true
+  });
+};

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/app/app.component.html
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/app/app.component.html
@@ -1,0 +1,3 @@
+<p>Sample app works!</p>
+<puc-dynamic-form></puc-dynamic-form>
+<puc-dynamic-grid></puc-dynamic-grid>

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/app/app.component.ts
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/app/app.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html'
+})
+export class AppComponent {}

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/app/app.module.ts
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/app/app.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { PraxisUiCoreModule } from '../../../projects/praxis-ui-core/src/public-api';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, PraxisUiCoreModule],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/index.html
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Praxis UI Sample App</title>
+  <base href="/" />
+</head>
+<body>
+  <app-root>Loading...</app-root>
+</body>
+</html>

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/main.ts
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/main.ts
@@ -1,0 +1,6 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/polyfills.ts
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js';

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/styles.css
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/styles.css
@@ -1,0 +1,1 @@
+/* Global styles placeholder */

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/test.ts
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/src/test.ts
@@ -1,0 +1,8 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/tsconfig.app.json
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/tsconfig.json
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/tsconfig.spec.json
+++ b/frontend-libs/praxis-ui-workspace/apps/praxis-ui-sample-app/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": ["jasmine", "node"]
+  },
+  "files": [
+    "src/test.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/package.json
+++ b/frontend-libs/praxis-ui-workspace/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "praxis-ui-workspace",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve praxis-ui-sample-app",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^20.0.0",
+    "@angular/cli": "^20.0.0",
+    "@angular/compiler-cli": "^20.0.0",
+    "typescript": "~5.4.0",
+    "karma": "^6.4.0",
+    "jasmine-core": "~5.1.0",
+    "karma-chrome-launcher": "~3.1.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0"
+  },
+  "dependencies": {
+    "@angular/animations": "^20.0.0",
+    "@angular/common": "^20.0.0",
+    "@angular/compiler": "^20.0.0",
+    "@angular/core": "^20.0.0",
+    "@angular/forms": "^20.0.0",
+    "@angular/platform-browser": "^20.0.0",
+    "@angular/platform-browser-dynamic": "^20.0.0",
+    "@angular/router": "^20.0.0",
+    "rxjs": "~7.8.0",
+    "tslib": "^2.6.0",
+    "zone.js": "~0.14.0"
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/README.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/README.md
@@ -1,0 +1,21 @@
+# Praxis UI Core
+
+Biblioteca Angular que interpreta metadados provenientes do backend e gera telas dinamicamente.
+
+```
+frontend-libs/
+└── praxis-ui-workspace/
+    └── projects/
+        └── praxis-ui-core/
+```
+
+## Desenvolvimento
+
+1. Instale as dependências na raiz do workspace:
+   ```bash
+   npm install
+   ```
+2. Gere a biblioteca:
+   ```bash
+   npm run build praxis-ui-core
+   ```

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/karma.conf.js
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/karma.conf.js
@@ -1,0 +1,24 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../../coverage/praxis-ui-core'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['ChromeHeadless'],
+    restartOnFileChange: true
+  });
+};

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/ng-package.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/praxis-ui-core",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/dynamic-form/dynamic-form.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/dynamic-form/dynamic-form.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * Simple dynamic form component placeholder.
+ */
+@Component({
+  selector: 'puc-dynamic-form',
+  template: `<p>dynamic form works!</p>`
+})
+export class DynamicFormComponent {
+  @Input() metadata: any;
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/dynamic-form/dynamic-form.module.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/dynamic-form/dynamic-form.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DynamicFormComponent } from './dynamic-form.component';
+
+@NgModule({
+  declarations: [DynamicFormComponent],
+  imports: [CommonModule],
+  exports: [DynamicFormComponent]
+})
+export class DynamicFormModule {}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/dynamic-grid/dynamic-grid.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/dynamic-grid/dynamic-grid.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * Simple dynamic grid component placeholder.
+ */
+@Component({
+  selector: 'puc-dynamic-grid',
+  template: `<p>dynamic grid works!</p>`
+})
+export class DynamicGridComponent {
+  @Input() metadata: any;
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/dynamic-grid/dynamic-grid.module.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/dynamic-grid/dynamic-grid.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DynamicGridComponent } from './dynamic-grid.component';
+
+@NgModule({
+  declarations: [DynamicGridComponent],
+  imports: [CommonModule],
+  exports: [DynamicGridComponent]
+})
+export class DynamicGridModule {}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/metadata/ui-metadata.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/metadata/ui-metadata.ts
@@ -1,0 +1,13 @@
+export interface UiFieldMetadata {
+  name: string;
+  label: string;
+  type: string;
+}
+
+export interface UiFormMetadata {
+  fields: UiFieldMetadata[];
+}
+
+export interface UiGridMetadata {
+  columns: UiFieldMetadata[];
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/praxis-ui-core.module.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/praxis-ui-core.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { DynamicFormModule } from './dynamic-form/dynamic-form.module';
+import { DynamicGridModule } from './dynamic-grid/dynamic-grid.module';
+
+@NgModule({
+  exports: [DynamicFormModule, DynamicGridModule]
+})
+export class PraxisUiCoreModule {}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/services/ui-metadata.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/services/ui-metadata.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class UiMetadataService {
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Fetch metadata from backend.
+   */
+  getMetadata(endpoint: string): Observable<any> {
+    return this.http.get(endpoint);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/public-api.ts
@@ -1,0 +1,7 @@
+export * from './lib/praxis-ui-core.module';
+export * from './lib/dynamic-form/dynamic-form.module';
+export * from './lib/dynamic-form/dynamic-form.component';
+export * from './lib/dynamic-grid/dynamic-grid.module';
+export * from './lib/dynamic-grid/dynamic-grid.component';
+export * from './lib/services/ui-metadata.service';
+export * from './lib/metadata/ui-metadata';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/test.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/test.ts
@@ -1,0 +1,8 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/tsconfig.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/tsconfig.lib.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib",
+    "declaration": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "files": [
+    "src/public-api.ts"
+  ],
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/tsconfig.spec.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": ["jasmine", "node"]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/tsconfig.base.json
+++ b/frontend-libs/praxis-ui-workspace/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2022", "dom"]
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/tsconfig.json
+++ b/frontend-libs/praxis-ui-workspace/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "projects/praxis-ui-core" },
+    { "path": "apps/praxis-ui-sample-app" }
+  ]
+}


### PR DESCRIPTION
## Summary
- create `praxis-ui-workspace` monorepo under `frontend-libs`
- add reusable Angular library `praxis-ui-core`
- add sample application `praxis-ui-sample-app`
- provide minimal README files and config

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*
- `../../mvnw -q test` *(fails: Maven not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856b3c6b3508328958e5f7c8ad59f69