### PR TITLE
Improve generic crud service with links support

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/models/rest-api-response.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-ui-core/src/lib/models/rest-api-response.model.ts
@@ -1,8 +1,24 @@
+export interface HateoasLink {
+  href: string;
+  templated?: boolean;
+  type?: string;
+  deprecation?: string;
+  profile?: string;
+  name?: string;
+  title?: string;
+  hreflang?: string;
+  [prop: string]: any;
+}
+
+export interface RestApiLinks {
+  [rel: string]: HateoasLink | HateoasLink[];
+}
+
 export interface RestApiResponse<T> {
   status?: string;
   message?: string;
   data: T;
-  links?: any;
+  _links?: RestApiLinks;
   errors?: any;
   timestamp?: string;
 }


### PR DESCRIPTION
## Summary
- add typed HATEOAS links to `RestApiResponse`
- add validation for unconfigured service
- expose API methods that return `RestApiResponse` preserving HATEOAS links
- implement utility to call `/schemas/filtered`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f43d1f5c832882b27fb48fce3f44