### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish Angular Libraries
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend-libs/praxis-ui-workspace
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build libraries
+        run: |
+          npx ng build praxis-core
+          npx ng build praxis-table
+
+      - name: Verify build directories
+        run: |
+          test -d dist/praxis-core
+          test -d dist/praxis-table
+
+      - name: Publish @praxis/core
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./dist/praxis-core/package.json').version")
+          if npm view @praxis/core@$VERSION > /dev/null 2>&1; then
+            echo "@praxis/core@$VERSION already exists, skipping publish"
+          else
+            npm publish ./dist/praxis-core --access public
+          fi
+
+      - name: Publish @praxis/table
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./dist/praxis-table/package.json').version")
+          if npm view @praxis/table@$VERSION > /dev/null 2>&1; then
+            echo "@praxis/table@$VERSION already exists, skipping publish"
+          else
+            npm publish ./dist/praxis-table --access public
+          fi
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish Angular libraries when a tag is pushed

## Testing
- `./mvnw --batch-mode -f backend-libs/praxis-metadata-core/pom.xml test` *(fails: Maven wrapper jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_685722f529c48328bc0f621b9a2d67e4