### PR TITLE
Configure API URL with injection token

### DIFF
--- a/frontend-libs/praxis-ui-workspace/angular.json
+++ b/frontend-libs/praxis-ui-workspace/angular.json
@@ -32,6 +32,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/version.helper.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/version.helper.ts
@@ -1,0 +1,16 @@
+import { HttpHeaders } from '@angular/common/http';
+import { ApiUrlEntry } from '../tokens/api-url.token';
+import { buildHeaders } from '../tokens/api-url.token';
+
+/**
+ * Compose headers including optional API version information.
+ * If the entry already defines custom headers, they will be preserved.
+ * The version will be added using the provided header name when available.
+ */
+export function composeHeadersWithVersion(entry: ApiUrlEntry, headerName = 'Api-Version'): HttpHeaders | undefined {
+  let headers = buildHeaders(entry) ?? new HttpHeaders();
+  if (entry.version) {
+    headers = headers.set(headerName, entry.version);
+  }
+  return headers.keys().length ? headers : undefined;
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/generic-crud.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/generic-crud.service.ts
@@ -9,6 +9,7 @@ import { FieldDefinition } from '../models/field-definition.model';
 
 import {Inject, Injectable} from '@angular/core';
 import {API_URL, ApiUrlConfig, ApiUrlEntry, buildApiUrl, buildHeaders} from '../tokens/api-url.token';
+import { composeHeadersWithVersion } from '../helpers/version.helper';
 import {SchemaNormalizerService} from './schema-normalizer.service';
 
 /**
@@ -268,7 +269,7 @@ private getEndpointUrl(
     const url = this.getEndpointUrl('schema', undefined, options?.parentPath, options?.endpointKey);
     // Armazena a URL para referência posterior this._schemaUrl = url;
     this._schemaUrl = url;
-    return this.http.get<any>(url, { headers: buildHeaders(entry) }).pipe(
+    return this.http.get<any>(url, { headers: composeHeadersWithVersion(entry) }).pipe(
       map((response) => this.schemaNormalizer.normalizeSchema(response)),
       catchError(this.handleError)
     );
@@ -339,7 +340,7 @@ public schemaUrl(): string {
     const entry = this.resolveEndpointEntry();
     const baseUrl = buildApiUrl(entry);
     const url = `${baseUrl}/schemas/filtered`;
-    return this.http.get<any>(url, { params: httpParams, headers: buildHeaders(entry) }).pipe(
+    return this.http.get<any>(url, { params: httpParams, headers: composeHeadersWithVersion(entry) }).pipe(
       map((response) => this.schemaNormalizer.normalizeSchema(response)),
       catchError(this.handleError)
     );
@@ -371,7 +372,7 @@ public schemaUrl(): string {
     this.ensureConfigured();
     const entry = this.resolveEndpointEntry(options?.endpointKey);
     const url = this.getEndpointUrl('getAll', undefined, options?.parentPath, options?.endpointKey);
-    return this.http.get<RestApiResponse<T[]>>(url, { headers: buildHeaders(entry) }).pipe(catchError(this.handleError));
+    return this.http.get<RestApiResponse<T[]>>(url, { headers: composeHeadersWithVersion(entry) }).pipe(catchError(this.handleError));
   }
 
   /**
@@ -402,7 +403,7 @@ public schemaUrl(): string {
     this.ensureConfigured();
     const entry = this.resolveEndpointEntry(options?.endpointKey);
     const url = this.getEndpointUrl('getById', id, options?.parentPath, options?.endpointKey);
-    return this.http.get<RestApiResponse<T>>(url, { headers: buildHeaders(entry) }).pipe(catchError(this.handleError));
+    return this.http.get<RestApiResponse<T>>(url, { headers: composeHeadersWithVersion(entry) }).pipe(catchError(this.handleError));
   }
 
   /**
@@ -433,7 +434,7 @@ public schemaUrl(): string {
     this.ensureConfigured();
     const entry = this.resolveEndpointEntry(options?.endpointKey);
     const url = this.getEndpointUrl('create', undefined, options?.parentPath, options?.endpointKey);
-    return this.http.post<RestApiResponse<T>>(url, entity, { headers: buildHeaders(entry) }).pipe(catchError(this.handleError));
+    return this.http.post<RestApiResponse<T>>(url, entity, { headers: composeHeadersWithVersion(entry) }).pipe(catchError(this.handleError));
   }
 
   /**
@@ -466,7 +467,7 @@ public schemaUrl(): string {
     this.ensureConfigured();
     const entry = this.resolveEndpointEntry(options?.endpointKey);
     const url = this.getEndpointUrl('update', id, options?.parentPath, options?.endpointKey);
-    return this.http.put<RestApiResponse<T>>(url, entity, { headers: buildHeaders(entry) }).pipe(catchError(this.handleError));
+    return this.http.put<RestApiResponse<T>>(url, entity, { headers: composeHeadersWithVersion(entry) }).pipe(catchError(this.handleError));
   }
 
   /**
@@ -497,7 +498,7 @@ public schemaUrl(): string {
     this.ensureConfigured();
     const entry = this.resolveEndpointEntry(options?.endpointKey);
     const url = this.getEndpointUrl('delete', id, options?.parentPath, options?.endpointKey);
-    return this.http.delete<RestApiResponse<void>>(url, { headers: buildHeaders(entry) }).pipe(catchError(this.handleError));
+    return this.http.delete<RestApiResponse<void>>(url, { headers: composeHeadersWithVersion(entry) }).pipe(catchError(this.handleError));
   }
 
   /**
@@ -533,7 +534,7 @@ public schemaUrl(): string {
     this.ensureConfigured();
     const entry = this.resolveEndpointEntry(options?.endpointKey);
     const url = this.getEndpointUrl('filter', undefined, options?.parentPath, options?.endpointKey);
-    return this.http.post<RestApiResponse<Page<T>>>(url, filterCriteria, { params, headers: buildHeaders(entry) }).pipe(catchError(this.handleError));
+    return this.http.post<RestApiResponse<Page<T>>>(url, filterCriteria, { params, headers: composeHeadersWithVersion(entry) }).pipe(catchError(this.handleError));
   }
 
   /**

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
@@ -3,3 +3,5 @@
  */
 
 export * from './lib/tokens/api-url.token';
+export * from './lib/services/generic-crud.service';
+export * from './lib/helpers/version.helper';

--- a/frontend-libs/praxis-ui-workspace/src/app/app.config.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/app.config.ts
@@ -1,5 +1,7 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { API_URL } from '@praxis/core';
+import { environment } from '../environments/environment';
 
 import { routes } from './app.routes';
 
@@ -7,6 +9,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes)
+    provideRouter(routes),
+    { provide: API_URL, useValue: environment.apiUrl }
   ]
 };

--- a/frontend-libs/praxis-ui-workspace/src/environments/environment.prod.ts
+++ b/frontend-libs/praxis-ui-workspace/src/environments/environment.prod.ts
@@ -1,0 +1,8 @@
+import { ApiUrlConfig } from '@praxis/core';
+
+export const environment = {
+  production: true,
+  apiUrl: {
+    default: { baseUrl: '/api', version: 'v1' }
+  } as ApiUrlConfig
+};

--- a/frontend-libs/praxis-ui-workspace/src/environments/environment.ts
+++ b/frontend-libs/praxis-ui-workspace/src/environments/environment.ts
@@ -1,0 +1,8 @@
+import { ApiUrlConfig } from '@praxis/core';
+
+export const environment = {
+  production: false,
+  apiUrl: {
+    default: { baseUrl: 'http://localhost:3000/api', version: 'v1' }
+  } as ApiUrlConfig
+};


### PR DESCRIPTION
## Summary
- add environment files for local/prod config
- provide API_URL using environment
- create helper to compose versioned headers
- use the helper in GenericCrudService
- export GenericCrudService and helper
- enable Angular file replacements for environments

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685860b12c40832897114a6c038cd3b8