### PR TITLE
Implement profile-based CORS support

### DIFF
--- a/examples/praxis-backend-libs-sample-app/README.md
+++ b/examples/praxis-backend-libs-sample-app/README.md
@@ -42,12 +42,29 @@ Após construir o projeto, você pode executá-lo de duas maneiras:
     ./mvnw spring-boot:run
     ```
 
+
 2.  **Executando o JAR diretamente:**
 
     ```bash
     java -jar target/praxis-sample-app-1.0.0-SNAPSHOT.jar
     ```
     (O nome do artefato JAR pode variar dependendo da versão definida no `pom.xml`).
+
+### Ativando perfis Spring
+
+O comportamento de CORS varia de acordo com o perfil ativo. Utilize o parâmetro
+`--spring.profiles.active` para escolher entre `dev` ou `prod` no momento da
+execução. Exemplo para usar o perfil de desenvolvimento:
+
+```bash
+./mvnw spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=dev"
+```
+
+Ou, ao executar o JAR:
+
+```bash
+java -jar target/praxis-sample-app-1.0.0-SNAPSHOT.jar --spring.profiles.active=dev
+```
 
 A aplicação será iniciada e estará acessível em `http://localhost:8086`.
 

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/config/WebConfig.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.example.praxis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${app.cors.allowed-origins}")
+    private String[] allowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(allowedOrigins)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/examples/praxis-backend-libs-sample-app/src/main/resources/application-dev.properties
+++ b/examples/praxis-backend-libs-sample-app/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+app.cors.allowed-origins=http://localhost:4200

--- a/examples/praxis-backend-libs-sample-app/src/main/resources/application-prod.properties
+++ b/examples/praxis-backend-libs-sample-app/src/main/resources/application-prod.properties
@@ -1,0 +1,2 @@
+# Substitua pelo(s) domínio(s) real(is) de produção
+app.cors.allowed-origins=https://seusite.com.br


### PR DESCRIPTION
## Summary
- add `WebConfig` to configure CORS dynamically
- create `application-dev.properties` and `application-prod.properties`
- document how to run the sample app with Spring profiles

## Testing
- `./mvnw -f examples/praxis-backend-libs-sample-app/pom.xml -q test` *(fails: Maven not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68589fb85e8c8328940d9f6808a66b12