### PR TITLE
Implement minimal dynamic MatTable

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
@@ -1,0 +1,21 @@
+export interface TableColumn {
+  field: string;
+  title: string;
+}
+
+export interface TableConfig {
+  /**
+   * Column definitions describing how data should be displayed
+   */
+  columns: TableColumn[];
+
+  /**
+   * Data to be rendered in the table
+   */
+  data: any[];
+
+  /**
+   * Whether an actions column should be added at the end
+   */
+  showActionsColumn?: boolean;
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
@@ -7,3 +7,5 @@ export * from './lib/praxis-core';
 export * from './lib/services/generic-crud.service';
 //ApiUrlConfig
 export * from './lib/tokens/api-url.token';
+// Table configuration models
+export * from './lib/models/table-config.model';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { PraxisTable } from './praxis-table';
+import { TableConfig } from '@praxis/core';
 
 describe('PraxisTable', () => {
   let component: PraxisTable;
@@ -9,11 +9,15 @@ describe('PraxisTable', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PraxisTable]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PraxisTable);
     component = fixture.componentInstance;
+    const config: TableConfig = {
+      columns: [{ field: 'id', title: 'ID' }],
+      data: []
+    };
+    component.config = config;
     fixture.detectChanges();
   });
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -1,37 +1,46 @@
-import { Component } from '@angular/core';
-import {GenericCrudService, PraxisCore} from '@praxis/core';
+import { Component, Input, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { TableConfig } from '@praxis/core';
 
 @Component({
   selector: 'praxis-table',
-  imports: [
-    PraxisCore
-  ],
+  standalone: true,
+  imports: [CommonModule, MatTableModule, MatButtonModule],
   template: `
-    <praxis-praxis-core></praxis-praxis-core>
+    <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+      <ng-container *ngFor="let column of config.columns" [matColumnDef]="column.field">
+        <th mat-header-cell *matHeaderCellDef>{{ column.title }}</th>
+        <td mat-cell *matCellDef="let element">{{ element[column.field] }}</td>
+      </ng-container>
+
+      <ng-container *ngIf="config.showActionsColumn" matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Ações</th>
+        <td mat-cell *matCellDef="let row">
+          <button mat-button color="primary">View</button>
+          <button mat-button color="accent">Edit</button>
+          <button mat-button color="warn">Delete</button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
   `,
-  styles: ``,
-  providers: [GenericCrudService],
+  styles: [`table{width:100%;}`]
 })
-export class PraxisTable {
+export class PraxisTable implements OnChanges {
+  @Input() config: TableConfig = { columns: [], data: [] };
 
-  funcionarios: any[] = [];
+  dataSource = new MatTableDataSource<any>();
+  displayedColumns: string[] = [];
 
-  constructor(service: GenericCrudService<any>) {
-    console.log('PraxisTable component initialized');
-    service.configure("funcionarios");
-    service.getAll().subscribe({
-      next: (response) => {
-        this.funcionarios = response || [];
-        console.log('Funcionários carregados:', this.funcionarios);
-      },
-      error: (erro) => {
-        console.error('Erro ao carregar funcionários:', erro);
-      },
-      complete: () => {
-        console.log('Consulta de funcionários finalizada');
-      }
-    });
+  ngOnChanges(): void {
+    this.displayedColumns = this.config.columns.map(c => c.field);
+    if (this.config.showActionsColumn) {
+      this.displayedColumns.push('actions');
+    }
+    this.dataSource.data = this.config.data;
   }
-
-
 }


### PR DESCRIPTION
## Summary
- add TableConfig models to `praxis-core`
- expose new models in public API
- refactor `PraxisTable` to a standalone Angular Material table driven by config
- update unit test to set a simple config

## Testing
- `npm test -- -c projects/praxis-table/karma.conf.js` *(fails: `ng: not found`)*
- `npx ng test projects/praxis-table` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6858a40528a08328bcd2d2dae645f09b