### PR TITLE
Add pagination/sort support to PraxisTable

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
@@ -3,6 +3,17 @@ export interface TableColumn {
   title: string;
 }
 
+export interface PaginationOptions {
+  pageSize: number;
+  pageSizeOptions?: number[];
+  showFirstLastButtons?: boolean;
+}
+
+export interface GridOptions {
+  pagination?: PaginationOptions;
+  sortable?: boolean;
+}
+
 export interface TableConfig {
   /**
    * Column definitions describing how data should be displayed
@@ -18,4 +29,9 @@ export interface TableConfig {
    * Whether an actions column should be added at the end
    */
   showActionsColumn?: boolean;
+
+  /**
+   * Grid behaviour configuration such as pagination and sorting
+   */
+  gridOptions?: GridOptions;
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.spec.ts
@@ -15,7 +15,11 @@ describe('PraxisTable', () => {
     component = fixture.componentInstance;
     const config: TableConfig = {
       columns: [{ field: 'id', title: 'ID' }],
-      data: []
+      data: [],
+      gridOptions: {
+        pagination: { pageSize: 5, pageSizeOptions: [5, 10] },
+        sortable: true
+      }
     };
     component.config = config;
     fixture.detectChanges();

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -1,17 +1,19 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, Input, OnChanges, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatButtonModule } from '@angular/material/button';
 import { TableConfig } from '@praxis/core';
 
 @Component({
   selector: 'praxis-table',
   standalone: true,
-  imports: [CommonModule, MatTableModule, MatButtonModule],
+  imports: [CommonModule, MatTableModule, MatButtonModule, MatPaginatorModule, MatSortModule],
   template: `
-    <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
       <ng-container *ngFor="let column of config.columns" [matColumnDef]="column.field">
-        <th mat-header-cell *matHeaderCellDef>{{ column.title }}</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ column.title }}</th>
         <td mat-cell *matCellDef="let element">{{ element[column.field] }}</td>
       </ng-container>
 
@@ -27,11 +29,19 @@ import { TableConfig } from '@praxis/core';
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
     </table>
+    <mat-paginator *ngIf="config.gridOptions?.pagination"
+                   [pageSize]="config.gridOptions.pagination.pageSize"
+                   [pageSizeOptions]="config.gridOptions.pagination.pageSizeOptions"
+                   [showFirstLastButtons]="config.gridOptions.pagination.showFirstLastButtons">
+    </mat-paginator>
   `,
   styles: [`table{width:100%;}`]
 })
 export class PraxisTable implements OnChanges {
   @Input() config: TableConfig = { columns: [], data: [] };
+
+  @ViewChild(MatPaginator) paginator?: MatPaginator;
+  @ViewChild(MatSort) sort?: MatSort;
 
   dataSource = new MatTableDataSource<any>();
   displayedColumns: string[] = [];
@@ -42,5 +52,11 @@ export class PraxisTable implements OnChanges {
       this.displayedColumns.push('actions');
     }
     this.dataSource.data = this.config.data;
+    if (this.paginator) {
+      this.dataSource.paginator = this.paginator;
+    }
+    if (this.sort) {
+      this.dataSource.sort = this.sort;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- expand `TableConfig` with new `GridOptions`
- implement paginator and sorting in `PraxisTable`
- update sample test to use pagination options

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a5856e94832890cf0c583ae0d3a6