### PR TITLE
feat(table): extend config model with toolbar and pagination

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
@@ -1,24 +1,53 @@
-export interface TableColumn {
+export interface ColumnDefinition {
   field: string;
   title: string;
+  /** Enable sorting for this column */
+  sortable?: boolean;
+}
+
+export interface ToolbarAction {
+  label: string;
+  action: string;
+  icon?: string;
+}
+
+export interface ToolbarConfig {
+  /** Whether the toolbar should be shown */
+  visible?: boolean;
+  actions?: ToolbarAction[];
+}
+
+export interface ExportOptions {
+  excel?: boolean;
+  pdf?: boolean;
+}
+
+export interface GridMessageConfig {
+  empty?: string;
+  loading?: string;
+  error?: string;
 }
 
 export interface PaginationOptions {
   pageSize: number;
   pageSizeOptions?: number[];
   showFirstLastButtons?: boolean;
+  /** Total number of items for server side pagination */
+  length?: number;
 }
 
 export interface GridOptions {
   pagination?: PaginationOptions;
   sortable?: boolean;
+  filterable?: boolean;
+  groupable?: boolean;
 }
 
 export interface TableConfig {
   /**
    * Column definitions describing how data should be displayed
    */
-  columns: TableColumn[];
+  columns: ColumnDefinition[];
 
   /**
    * Data to be rendered in the table
@@ -34,4 +63,13 @@ export interface TableConfig {
    * Grid behaviour configuration such as pagination and sorting
    */
   gridOptions?: GridOptions;
+
+  /** Toolbar configuration */
+  toolbar?: ToolbarConfig;
+
+  /** Export options */
+  exportOptions?: ExportOptions;
+
+  /** Custom grid messages */
+  messages?: GridMessageConfig;
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -1,8 +1,8 @@
-import { Component, Input, OnChanges, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, ViewChild, AfterViewInit, EventEmitter, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
-import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
-import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
 import { MatButtonModule } from '@angular/material/button';
 import { TableConfig } from '@praxis/core';
 
@@ -11,9 +11,15 @@ import { TableConfig } from '@praxis/core';
   standalone: true,
   imports: [CommonModule, MatTableModule, MatButtonModule, MatPaginatorModule, MatSortModule],
   template: `
-    <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8">
+    <table mat-table [dataSource]="dataSource" matSort
+           (matSortChange)="onSortChange($event)"
+           [matSortDisabled]="!config.gridOptions?.sortable"
+           class="mat-elevation-z8">
       <ng-container *ngFor="let column of config.columns" [matColumnDef]="column.field">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ column.title }}</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header
+            [disabled]="!config.gridOptions?.sortable || column.sortable === false">
+          {{ column.title }}
+        </th>
         <td mat-cell *matCellDef="let element">{{ element[column.field] }}</td>
       </ng-container>
 
@@ -30,15 +36,20 @@ import { TableConfig } from '@praxis/core';
       <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
     </table>
     <mat-paginator *ngIf="config.gridOptions?.pagination"
+                   [length]="config.gridOptions.pagination.length ?? config.data.length"
                    [pageSize]="config.gridOptions.pagination.pageSize"
                    [pageSizeOptions]="config.gridOptions.pagination.pageSizeOptions"
-                   [showFirstLastButtons]="config.gridOptions.pagination.showFirstLastButtons">
+                   [showFirstLastButtons]="config.gridOptions.pagination.showFirstLastButtons"
+                   (page)="onPageChange($event)">
     </mat-paginator>
   `,
   styles: [`table{width:100%;}`]
 })
-export class PraxisTable implements OnChanges {
+export class PraxisTable implements OnChanges, AfterViewInit {
   @Input() config: TableConfig = { columns: [], data: [] };
+
+  @Output() pageChange = new EventEmitter<PageEvent>();
+  @Output() sortChange = new EventEmitter<Sort>();
 
   @ViewChild(MatPaginator) paginator?: MatPaginator;
   @ViewChild(MatSort) sort?: MatSort;
@@ -52,8 +63,29 @@ export class PraxisTable implements OnChanges {
       this.displayedColumns.push('actions');
     }
     this.dataSource.data = this.config.data;
+    this.applyDataSourceSettings();
+  }
+
+  ngAfterViewInit(): void {
+    this.applyDataSourceSettings();
+  }
+
+  onPageChange(event: PageEvent): void {
+    this.pageChange.emit(event);
+  }
+
+  onSortChange(event: Sort): void {
+    this.sortChange.emit(event);
+  }
+
+  private applyDataSourceSettings(): void {
     if (this.paginator) {
       this.dataSource.paginator = this.paginator;
+      if (this.config.gridOptions?.pagination?.length !== undefined) {
+        this.paginator.length = this.config.gridOptions.pagination.length;
+      } else {
+        this.paginator.length = this.config.data.length;
+      }
     }
     if (this.sort) {
       this.dataSource.sort = this.sort;


### PR DESCRIPTION
## Summary
- add advanced table configuration models
- support toolbar/export/messages options
- emit pagination and sorting events from the table component
- ensure MatPaginator shows total item count

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6858a728b6348328b386029a4cde30d8