### PR TITLE
Integrate PraxisTable with GenericCrudService

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { PraxisTable } from './praxis-table';
-import { TableConfig } from '@praxis/core';
+import { TableConfig, GenericCrudService, API_URL } from '@praxis/core';
 
 describe('PraxisTable', () => {
   let component: PraxisTable;
@@ -8,7 +9,8 @@ describe('PraxisTable', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PraxisTable]
+      imports: [PraxisTable, HttpClientTestingModule],
+      providers: [GenericCrudService, { provide: API_URL, useValue: { default: {} } }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(PraxisTable);

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -1,10 +1,11 @@
-import { Component, Input, OnChanges, ViewChild, AfterViewInit, EventEmitter, Output } from '@angular/core';
+import { Component, Input, OnChanges, ViewChild, AfterViewInit, EventEmitter, Output, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
 import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
 import { MatButtonModule } from '@angular/material/button';
-import { TableConfig } from '@praxis/core';
+import { TableConfig, GenericCrudService, Page, Pageable, FieldDefinition, ColumnDefinition } from '@praxis/core';
+import { BehaviorSubject, take } from 'rxjs';
 
 @Component({
   selector: 'praxis-table',
@@ -47,6 +48,8 @@ import { TableConfig } from '@praxis/core';
 })
 export class PraxisTable implements OnChanges, AfterViewInit {
   @Input() config: TableConfig = { columns: [], data: [] };
+  @Input() resourcePath?: string;
+  @Input() filterCriteria: any = {};
 
   @Output() pageChange = new EventEmitter<PageEvent>();
   @Output() sortChange = new EventEmitter<Sort>();
@@ -57,12 +60,33 @@ export class PraxisTable implements OnChanges, AfterViewInit {
   dataSource = new MatTableDataSource<any>();
   displayedColumns: string[] = [];
 
-  ngOnChanges(): void {
-    this.displayedColumns = this.config.columns.map(c => c.field);
-    if (this.config.showActionsColumn) {
-      this.displayedColumns.push('actions');
+  private dataSubject = new BehaviorSubject<any[]>([]);
+  private pageIndex = 0;
+  private pageSize = 5;
+  private sortState: Sort = { active: '', direction: '' };
+
+  constructor(private crudService: GenericCrudService<any>) {
+    this.dataSubject.subscribe(data => (this.dataSource.data = data));
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.config.gridOptions?.pagination?.pageSize) {
+      this.pageSize = this.config.gridOptions.pagination.pageSize;
     }
-    this.dataSource.data = this.config.data;
+
+    if (changes['resourcePath'] && this.resourcePath) {
+      this.crudService.configure(this.resourcePath);
+      this.loadSchema();
+      this.fetchData();
+    } else {
+      this.setupColumns();
+      this.dataSubject.next(this.config.data);
+    }
+
+    if (changes['filterCriteria'] && this.resourcePath) {
+      this.fetchData();
+    }
+
     this.applyDataSourceSettings();
   }
 
@@ -71,11 +95,16 @@ export class PraxisTable implements OnChanges, AfterViewInit {
   }
 
   onPageChange(event: PageEvent): void {
+    this.pageIndex = event.pageIndex;
+    this.pageSize = event.pageSize;
     this.pageChange.emit(event);
+    this.fetchData();
   }
 
   onSortChange(event: Sort): void {
+    this.sortState = event;
     this.sortChange.emit(event);
+    this.fetchData();
   }
 
   private applyDataSourceSettings(): void {
@@ -90,5 +119,56 @@ export class PraxisTable implements OnChanges, AfterViewInit {
     if (this.sort) {
       this.dataSource.sort = this.sort;
     }
+  }
+
+  private setupColumns(): void {
+    this.displayedColumns = this.config.columns.map(c => c.field);
+    if (this.config.showActionsColumn) {
+      this.displayedColumns.push('actions');
+    }
+  }
+
+  private loadSchema(): void {
+    this.crudService.getSchema().pipe(take(1)).subscribe((fields: FieldDefinition[]) => {
+      if (this.config.columns.length === 0) {
+        this.config.columns = fields
+          .filter(f => !f.tableHidden)
+          .map(f => this.convertFieldToColumn(f));
+      }
+      this.setupColumns();
+    });
+  }
+
+  private convertFieldToColumn(field: FieldDefinition): ColumnDefinition {
+    return {
+      field: field.name,
+      title: field.label ?? field.name,
+      sortable: field.sortable
+    } as ColumnDefinition;
+  }
+
+  private fetchData(): void {
+    if (!this.resourcePath) {
+      return;
+    }
+    const pageable: Pageable = {
+      pageNumber: this.pageIndex,
+      pageSize: this.pageSize
+    };
+    if (this.sortState.active && this.sortState.direction) {
+      pageable.sort = `${this.sortState.active},${this.sortState.direction}`;
+    }
+    this.crudService
+      .filter(this.filterCriteria || {}, pageable)
+      .pipe(take(1))
+      .subscribe((page: Page<any>) => {
+        this.dataSubject.next(page.content);
+        if (this.config.gridOptions?.pagination) {
+          this.config.gridOptions.pagination.length = page.totalElements;
+        }
+        if (this.paginator) {
+          this.paginator.length = page.totalElements;
+        }
+      });
   }
 }


### PR DESCRIPTION
## Summary
- enhance `PraxisTable` to fetch schema and data using `GenericCrudService`
- update table behaviour to trigger server calls on page/sort/filter changes
- adjust unit tests to provide service dependencies

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a839ca5c83289080ba4863da9deb