### PR TITLE
Fix build error in Angular table

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -80,7 +80,7 @@ import { BehaviorSubject, take } from 'rxjs';
     <mat-paginator *ngIf="config.gridOptions?.pagination"
                    [length]="config.gridOptions?.pagination?.length ?? config.data.length"
                    [pageSize]="config.gridOptions?.pagination?.pageSize"
-                   [pageSizeOptions]="config.gridOptions?.pagination?.pageSizeOptions"
+                  [pageSizeOptions]="config.gridOptions?.pagination?.pageSizeOptions ?? []"
                    [showFirstLastButtons]="config.gridOptions?.pagination?.showFirstLastButtons"
                    (page)="onPageChange($event)">
     </mat-paginator>


### PR DESCRIPTION
## Summary
- ensure `pageSizeOptions` always returns an array for `<mat-paginator>`

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module '@angular/common/http' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68598d5e0704832899e6b6d2af0222a2