### PR TITLE
Fix ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -8,7 +8,8 @@ import {
   Output,
   SimpleChanges,
   AfterContentInit,
-  ContentChild
+  ContentChild,
+  ChangeDetectorRef
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
@@ -121,7 +122,10 @@ export class PraxisTable implements OnChanges, AfterViewInit, AfterContentInit {
 
   filterValue = '';
 
-  constructor(private crudService: GenericCrudService<any>) {
+  constructor(
+    private crudService: GenericCrudService<any>,
+    private cdr: ChangeDetectorRef
+  ) {
     this.dataSubject.subscribe(data => (this.dataSource.data = data));
   }
 
@@ -220,6 +224,7 @@ export class PraxisTable implements OnChanges, AfterViewInit, AfterContentInit {
           .map(f => this.convertFieldToColumn(f));
       }
       this.setupColumns();
+      this.cdr.detectChanges();
     });
   }
 


### PR DESCRIPTION
## Summary
- inject ChangeDetectorRef into PraxisTable
- trigger change detection after async schema load to avoid ExpressionChangedAfterItHasBeenCheckedError

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a0fb81dc8328a6b2005ced6e7492