### PR TITLE
Add initial config editor

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-config-editor.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-config-editor.ts
@@ -1,0 +1,59 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatDialogModule } from '@angular/material/dialog';
+import { TableConfig } from '@praxis/core';
+import { PraxisTableJsonConfig } from './praxis-table-json-config';
+import { PraxisTablePaginationConfig } from './praxis-table-pagination-config';
+
+@Component({
+  selector: 'praxis-table-config-editor',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTabsModule,
+    MatDialogModule,
+    PraxisTableJsonConfig,
+    PraxisTablePaginationConfig
+  ],
+  template: `
+    <h2>Editor de Configuração da Tabela</h2>
+    <mat-tab-group>
+      <mat-tab label="JSON" >
+        <praxis-table-json-config [config]="workingConfig" (configChange)="onJsonChange($event.config, $event.valid)"></praxis-table-json-config>
+      </mat-tab>
+      <mat-tab label="Paginação">
+        <praxis-table-pagination-config [config]="workingConfig" (configChange)="workingConfig = $event"></praxis-table-pagination-config>
+      </mat-tab>
+    </mat-tab-group>
+    <div style="margin-top:1rem;text-align:right;">
+      <span style="color:red;margin-right:auto;" *ngIf="!jsonValid">JSON inválido</span>
+      <button mat-button (click)="cancel.emit()">Cancelar</button>
+      <button mat-button color="primary" (click)="save.emit(workingConfig)" [disabled]="!jsonValid">Salvar</button>
+    </div>
+  `,
+  styles:[`:host{display:block;}`]
+})
+export class PraxisTableConfigEditor {
+  @Input() config: TableConfig = { columns: [], data: [] };
+  @Output() save = new EventEmitter<TableConfig>();
+  @Output() cancel = new EventEmitter<void>();
+
+  workingConfig: TableConfig = { columns: [], data: [] };
+  jsonValid = true;
+
+  ngOnInit() {
+    this.workingConfig = JSON.parse(JSON.stringify(this.config));
+  }
+
+  onJsonChange(cfg: TableConfig, valid: boolean) {
+    this.workingConfig = cfg;
+    this.jsonValid = valid;
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-json-config.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-json-config.ts
@@ -1,0 +1,59 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { TableConfig } from '@praxis/core';
+
+@Component({
+  selector: 'praxis-table-json-config',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatButtonModule, MatIconModule],
+  template: `
+    <textarea [(ngModel)]="jsonText" (ngModelChange)="onTextChange()" rows="10" style="width:100%"></textarea>
+    <div style="margin-top:0.5rem;">
+      <button mat-button (click)="formatJson()"><mat-icon>format_align_left</mat-icon>Formatar JSON</button>
+      <button mat-button (click)="copyJson()"><mat-icon>content_copy</mat-icon>Copiar</button>
+    </div>
+    <div style="color:red;" *ngIf="!valid">JSON inválido</div>
+  `,
+  styles:[`:host{display:block;}`]
+})
+export class PraxisTableJsonConfig {
+  @Input() config: TableConfig = { columns: [], data: [] };
+  @Output() configChange = new EventEmitter<{config: TableConfig; valid: boolean}>();
+
+  jsonText = '';
+  valid = true;
+
+  ngOnInit() {
+    this.jsonText = JSON.stringify(this.config, null, 2);
+  }
+
+  onTextChange() {
+    try {
+      const cfg = JSON.parse(this.jsonText);
+      this.valid = true;
+      this.configChange.emit({ config: cfg, valid: true });
+    } catch {
+      this.valid = false;
+      this.configChange.emit({ config: this.config, valid: false });
+    }
+  }
+
+  formatJson() {
+    try {
+      const obj = JSON.parse(this.jsonText);
+      this.jsonText = JSON.stringify(obj, null, 2);
+    } catch {}
+  }
+
+  copyJson() {
+    const textarea = document.createElement('textarea');
+    textarea.value = this.jsonText;
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-pagination-config.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-pagination-config.ts
@@ -1,0 +1,64 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { TableConfig } from '@praxis/core';
+
+@Component({
+  selector: 'praxis-table-pagination-config',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSlideToggleModule
+  ],
+  template: `
+    <mat-slide-toggle [(ngModel)]="enabled">Paginação</mat-slide-toggle>
+    <div *ngIf="enabled" style="margin-top:0.5rem;">
+      <mat-form-field appearance="fill">
+        <mat-label>Tamanho da página</mat-label>
+        <input matInput type="number" [(ngModel)]="pageSize" />
+      </mat-form-field>
+    </div>
+  `,
+  styles:[`:host{display:block;}`]
+})
+export class PraxisTablePaginationConfig {
+  @Input() config: TableConfig = { columns: [], data: [] };
+  @Output() configChange = new EventEmitter<TableConfig>();
+
+  enabled = false;
+  pageSize = 5;
+
+  ngOnInit() {
+    const pagination = this.config.gridOptions?.pagination;
+    if (pagination) {
+      this.enabled = true;
+      this.pageSize = pagination.pageSize;
+    }
+  }
+
+  ngOnChanges() {
+    this.emitChange();
+  }
+
+  emitChange() {
+    const cfg = JSON.parse(JSON.stringify(this.config));
+    if (!cfg.gridOptions) cfg.gridOptions = {};
+    if (this.enabled) {
+      cfg.gridOptions.pagination = { pageSize: this.pageSize };
+    } else {
+      cfg.gridOptions.pagination = undefined as any;
+    }
+    this.configChange.emit(cfg);
+  }
+
+  // watch for changes
+  ngDoCheck() {
+    this.emitChange();
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatDialogModule } from '@angular/material/dialog';
 import { PraxisTable } from './praxis-table';
 import { TableConfig, GenericCrudService, API_URL } from '@praxis/core';
 
@@ -9,7 +10,7 @@ describe('PraxisTable', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PraxisTable, HttpClientTestingModule],
+      imports: [PraxisTable, HttpClientTestingModule, MatDialogModule],
       providers: [GenericCrudService, { provide: API_URL, useValue: { default: {} } }]
     }).compileComponents();
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/public-api.ts
@@ -5,3 +5,6 @@
 export * from './lib/praxis-table';
 export * from './lib/praxis-table-toolbar';
 export * from './lib/praxis-table-event';
+export * from './lib/praxis-table-config-editor';
+export * from './lib/praxis-table-json-config';
+export * from './lib/praxis-table-pagination-config';


### PR DESCRIPTION
## Summary
- add edit mode button and dialog for PraxisTable
- implement PraxisTableConfigEditor modal with JSON and Pagination tabs
- add Json and Pagination subcomponents for config editing
- export new components and update table spec

## Testing
- `npm test` *(fails: ng not found)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ab608de883289a48a481fbab9297