### PR TITLE
Add icons and defaults to table config editor

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-config-editor.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-config-editor.ts
@@ -8,6 +8,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { TableConfig } from '@praxis/core';
 import { PraxisTableJsonConfig } from './praxis-table-json-config';
 import { PraxisTablePaginationConfig } from './praxis-table-pagination-config';
+import { mergeWithDefaults } from './table-config-defaults';
 
 @Component({
   selector: 'praxis-table-config-editor',
@@ -25,10 +26,18 @@ import { PraxisTablePaginationConfig } from './praxis-table-pagination-config';
   template: `
     <h2>Editor de Configuração da Tabela</h2>
     <mat-tab-group>
-      <mat-tab label="JSON" >
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>code</mat-icon>
+          <span>JSON</span>
+        </ng-template>
         <praxis-table-json-config [config]="workingConfig" (configChange)="onJsonChange($event.config, $event.valid)"></praxis-table-json-config>
       </mat-tab>
-      <mat-tab label="Paginação">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>format_list_numbered</mat-icon>
+          <span>Paginação</span>
+        </ng-template>
         <praxis-table-pagination-config [config]="workingConfig" (configChange)="workingConfig = $event"></praxis-table-pagination-config>
       </mat-tab>
     </mat-tab-group>
@@ -49,7 +58,7 @@ export class PraxisTableConfigEditor {
   jsonValid = true;
 
   ngOnInit() {
-    this.workingConfig = JSON.parse(JSON.stringify(this.config));
+    this.workingConfig = mergeWithDefaults(this.config);
   }
 
   onJsonChange(cfg: TableConfig, valid: boolean) {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-json-config.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-json-config.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { TableConfig } from '@praxis/core';
+import { mergeWithDefaults } from './table-config-defaults';
 
 @Component({
   selector: 'praxis-table-json-config',
@@ -27,7 +28,8 @@ export class PraxisTableJsonConfig {
   valid = true;
 
   ngOnInit() {
-    this.jsonText = JSON.stringify(this.config, null, 2);
+    const cfg = mergeWithDefaults(this.config);
+    this.jsonText = JSON.stringify(cfg, null, 2);
   }
 
   onTextChange() {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/table-config-defaults.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/table-config-defaults.ts
@@ -1,0 +1,56 @@
+import { TableConfig } from '@praxis/core';
+
+export const DEFAULT_TABLE_CONFIG: TableConfig = {
+  columns: [],
+  data: [],
+  showActionsColumn: false,
+  gridOptions: {
+    pagination: { pageSize: 5 },
+    sortable: false,
+    filterable: false,
+    groupable: false
+  },
+  toolbar: {
+    visible: false,
+    actions: [],
+    showNewButton: true,
+    newButtonText: 'Novo'
+  },
+  exportOptions: {
+    excel: false,
+    pdf: false
+  },
+  messages: {
+    empty: '',
+    loading: '',
+    error: ''
+  },
+  rowActions: []
+};
+
+export function mergeWithDefaults(config: TableConfig): TableConfig {
+  const merged: TableConfig = JSON.parse(JSON.stringify(DEFAULT_TABLE_CONFIG));
+  Object.assign(merged, config);
+  if (config.gridOptions) {
+    merged.gridOptions = { ...DEFAULT_TABLE_CONFIG.gridOptions, ...config.gridOptions };
+    if (config.gridOptions.pagination) {
+      merged.gridOptions.pagination = {
+        ...DEFAULT_TABLE_CONFIG.gridOptions.pagination,
+        ...config.gridOptions.pagination
+      };
+    }
+  }
+  if (config.toolbar) {
+    merged.toolbar = { ...DEFAULT_TABLE_CONFIG.toolbar, ...config.toolbar };
+  }
+  if (config.exportOptions) {
+    merged.exportOptions = { ...DEFAULT_TABLE_CONFIG.exportOptions, ...config.exportOptions };
+  }
+  if (config.messages) {
+    merged.messages = { ...DEFAULT_TABLE_CONFIG.messages, ...config.messages };
+  }
+  if (config.rowActions) {
+    merged.rowActions = [...config.rowActions];
+  }
+  return merged;
+}


### PR DESCRIPTION
## Summary
- show JSON with default config values in editor
- add Material icons to config editor tabs
- create default table config helper

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b197ad3c8328a596b4b507e6e4bc