### PR TITLE
Add full table config editor

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-config-editor.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-config-editor.ts
@@ -8,6 +8,11 @@ import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/materia
 import { TableConfig } from '@praxis/core';
 import { PraxisTableJsonConfig } from './praxis-table-json-config';
 import { PraxisTablePaginationConfig } from './praxis-table-pagination-config';
+import { PraxisTableGridOptionsConfig } from './praxis-table-grid-options-config';
+import { PraxisTableToolbarConfig } from './praxis-table-toolbar-config';
+import { PraxisTableExportConfig } from './praxis-table-export-config';
+import { PraxisTableMessagesConfig } from './praxis-table-messages-config';
+import { PraxisTableRowActionsConfig } from './praxis-table-row-actions-config';
 import { mergeWithDefaults } from './table-config-defaults';
 
 @Component({
@@ -21,7 +26,12 @@ import { mergeWithDefaults } from './table-config-defaults';
     MatTabsModule,
     MatDialogModule,
     PraxisTableJsonConfig,
-    PraxisTablePaginationConfig
+    PraxisTablePaginationConfig,
+    PraxisTableGridOptionsConfig,
+    PraxisTableToolbarConfig,
+    PraxisTableExportConfig,
+    PraxisTableMessagesConfig,
+    PraxisTableRowActionsConfig
   ],
   template: `
     <h2>Editor de Configuração da Tabela</h2>
@@ -39,6 +49,41 @@ import { mergeWithDefaults } from './table-config-defaults';
           <span>Paginação</span>
         </ng-template>
         <praxis-table-pagination-config [config]="workingConfig" (configChange)="workingConfig = $event"></praxis-table-pagination-config>
+      </mat-tab>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>tune</mat-icon>
+          <span>Grid</span>
+        </ng-template>
+        <praxis-table-grid-options-config [config]="workingConfig" (configChange)="workingConfig = $event"></praxis-table-grid-options-config>
+      </mat-tab>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>dashboard</mat-icon>
+          <span>Toolbar</span>
+        </ng-template>
+        <praxis-table-toolbar-config [config]="workingConfig" (configChange)="workingConfig = $event"></praxis-table-toolbar-config>
+      </mat-tab>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>file_download</mat-icon>
+          <span>Exportar</span>
+        </ng-template>
+        <praxis-table-export-config [config]="workingConfig" (configChange)="workingConfig = $event"></praxis-table-export-config>
+      </mat-tab>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>message</mat-icon>
+          <span>Mensagens</span>
+        </ng-template>
+        <praxis-table-messages-config [config]="workingConfig" (configChange)="workingConfig = $event"></praxis-table-messages-config>
+      </mat-tab>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>list</mat-icon>
+          <span>Ações da linha</span>
+        </ng-template>
+        <praxis-table-row-actions-config [config]="workingConfig" (configChange)="workingConfig = $event"></praxis-table-row-actions-config>
       </mat-tab>
     </mat-tab-group>
     <div style="margin-top:1rem;text-align:right;">

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-export-config.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-export-config.ts
@@ -1,0 +1,39 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { TableConfig } from '@praxis/core';
+
+@Component({
+  selector: 'praxis-table-export-config',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatSlideToggleModule],
+  template: `
+    <mat-slide-toggle [(ngModel)]="excel">Excel</mat-slide-toggle>
+    <mat-slide-toggle [(ngModel)]="pdf">PDF</mat-slide-toggle>
+  `,
+  styles: [`:host{display:block;}`]
+})
+export class PraxisTableExportConfig {
+  @Input() config: TableConfig = { columns: [], data: [] };
+  @Output() configChange = new EventEmitter<TableConfig>();
+
+  excel = false;
+  pdf = false;
+
+  ngOnInit() {
+    const exp = this.config.exportOptions || {};
+    this.excel = exp.excel ?? false;
+    this.pdf = exp.pdf ?? false;
+  }
+
+  ngDoCheck() {
+    this.emitChange();
+  }
+
+  emitChange() {
+    const cfg = JSON.parse(JSON.stringify(this.config));
+    cfg.exportOptions = { excel: this.excel, pdf: this.pdf };
+    this.configChange.emit(cfg);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-grid-options-config.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-grid-options-config.ts
@@ -1,0 +1,45 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { TableConfig } from '@praxis/core';
+
+@Component({
+  selector: 'praxis-table-grid-options-config',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatSlideToggleModule],
+  template: `
+    <mat-slide-toggle [(ngModel)]="sortable">Ordenação</mat-slide-toggle>
+    <mat-slide-toggle [(ngModel)]="filterable">Filtro</mat-slide-toggle>
+    <mat-slide-toggle [(ngModel)]="groupable">Agrupamento</mat-slide-toggle>
+  `,
+  styles: [`:host{display:block;}`]
+})
+export class PraxisTableGridOptionsConfig {
+  @Input() config: TableConfig = { columns: [], data: [] };
+  @Output() configChange = new EventEmitter<TableConfig>();
+
+  sortable = true;
+  filterable = false;
+  groupable = false;
+
+  ngOnInit() {
+    const opts = this.config.gridOptions || {};
+    this.sortable = opts.sortable ?? true;
+    this.filterable = opts.filterable ?? false;
+    this.groupable = opts.groupable ?? false;
+  }
+
+  ngDoCheck() {
+    this.emitChange();
+  }
+
+  emitChange() {
+    const cfg = JSON.parse(JSON.stringify(this.config));
+    if (!cfg.gridOptions) cfg.gridOptions = {} as any;
+    cfg.gridOptions.sortable = this.sortable;
+    cfg.gridOptions.filterable = this.filterable;
+    cfg.gridOptions.groupable = this.groupable;
+    this.configChange.emit(cfg);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-messages-config.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-messages-config.ts
@@ -1,0 +1,50 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { TableConfig } from '@praxis/core';
+
+@Component({
+  selector: 'praxis-table-messages-config',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatFormFieldModule, MatInputModule],
+  template: `
+    <mat-form-field appearance="fill">
+      <mat-label>Mensagem de vazio</mat-label>
+      <input matInput [(ngModel)]="empty" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Mensagem de carregamento</mat-label>
+      <input matInput [(ngModel)]="loading" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Mensagem de erro</mat-label>
+      <input matInput [(ngModel)]="error" />
+    </mat-form-field>
+  `,
+  styles:[`:host{display:block;}`]
+})
+export class PraxisTableMessagesConfig {
+  @Input() config: TableConfig = { columns: [], data: [] };
+  @Output() configChange = new EventEmitter<TableConfig>();
+
+  empty = '';
+  loading = '';
+  error = '';
+
+  ngOnInit() {
+    const msg = this.config.messages || {};
+    this.empty = msg.empty || '';
+    this.loading = msg.loading || '';
+    this.error = msg.error || '';
+  }
+
+  ngDoCheck() { this.emitChange(); }
+
+  emitChange() {
+    const cfg = JSON.parse(JSON.stringify(this.config));
+    cfg.messages = { empty: this.empty, loading: this.loading, error: this.error };
+    this.configChange.emit(cfg);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-row-actions-config.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-row-actions-config.ts
@@ -1,0 +1,73 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { TableConfig, RowAction } from '@praxis/core';
+
+@Component({
+  selector: 'praxis-table-row-actions-config',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatButtonModule, MatIconModule],
+  template: `
+    <label>Ações de linha (JSON)</label>
+    <textarea [(ngModel)]="actionsJson" rows="5" style="width:100%" (ngModelChange)="onChange()"></textarea>
+    <div style="margin-top:0.5rem;">
+      <button mat-button (click)="formatJson()"><mat-icon>format_align_left</mat-icon>Formatar</button>
+      <button mat-button (click)="copyJson()"><mat-icon>content_copy</mat-icon>Copiar</button>
+    </div>
+    <div style="color:red" *ngIf="!valid">JSON inválido</div>
+  `,
+  styles:[`:host{display:block;}`]
+})
+export class PraxisTableRowActionsConfig {
+  @Input() config: TableConfig = { columns: [], data: [] };
+  @Output() configChange = new EventEmitter<TableConfig>();
+
+  actions: RowAction[] = [];
+  actionsJson = '[]';
+  valid = true;
+
+  ngOnInit() {
+    if (this.config.rowActions) {
+      this.actions = this.config.rowActions;
+    }
+    this.actionsJson = JSON.stringify(this.actions, null, 2);
+  }
+
+  onChange() {
+    try {
+      this.actions = JSON.parse(this.actionsJson);
+      this.valid = true;
+    } catch {
+      this.valid = false;
+    }
+  }
+
+  formatJson() {
+    try {
+      const obj = JSON.parse(this.actionsJson);
+      this.actionsJson = JSON.stringify(obj, null, 2);
+    } catch {}
+  }
+
+  copyJson() {
+    const textarea = document.createElement('textarea');
+    textarea.value = this.actionsJson;
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+  }
+
+  ngDoCheck() {
+    this.emitChange();
+  }
+
+  emitChange() {
+    if (!this.valid) return;
+    const cfg = JSON.parse(JSON.stringify(this.config));
+    cfg.rowActions = this.actions;
+    this.configChange.emit(cfg);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-toolbar-config.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-toolbar-config.ts
@@ -1,0 +1,103 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { TableConfig, ToolbarAction } from '@praxis/core';
+
+@Component({
+  selector: 'praxis-table-toolbar-config',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatSlideToggleModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule
+  ],
+  template: `
+    <mat-slide-toggle [(ngModel)]="visible">Toolbar visível</mat-slide-toggle>
+    <div style="margin-top:0.5rem;">
+      <mat-slide-toggle [(ngModel)]="showNewButton">Botão Novo</mat-slide-toggle>
+    </div>
+    <div *ngIf="showNewButton" style="margin-top:0.5rem;">
+      <mat-form-field appearance="fill">
+        <mat-label>Texto do botão</mat-label>
+        <input matInput [(ngModel)]="newButtonText" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Ícone</mat-label>
+        <input matInput [(ngModel)]="newButtonIcon" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Cor</mat-label>
+        <input matInput [(ngModel)]="newButtonColor" />
+      </mat-form-field>
+    </div>
+    <div style="margin-top:0.5rem;">
+      <label>Ações (JSON)</label>
+      <textarea [(ngModel)]="actionsJson" rows="5" style="width:100%" (ngModelChange)="onActionsChange()"></textarea>
+      <div style="color:red" *ngIf="!actionsValid">JSON inválido</div>
+    </div>
+  `,
+  styles: [`:host{display:block;}`]
+})
+export class PraxisTableToolbarConfig {
+  @Input() config: TableConfig = { columns: [], data: [] };
+  @Output() configChange = new EventEmitter<TableConfig>();
+
+  visible = false;
+  showNewButton = true;
+  newButtonText = 'Novo';
+  newButtonIcon = '';
+  newButtonColor = 'primary';
+
+  actions: ToolbarAction[] = [];
+  actionsJson = '[]';
+  actionsValid = true;
+
+  ngOnInit() {
+    const tb = this.config.toolbar || {};
+    this.visible = tb.visible ?? false;
+    this.showNewButton = tb.showNewButton ?? true;
+    this.newButtonText = tb.newButtonText || 'Novo';
+    this.newButtonIcon = tb.newButtonIcon || '';
+    this.newButtonColor = tb.newButtonColor || 'primary';
+    if (tb.actions) {
+      this.actions = tb.actions;
+      this.actionsJson = JSON.stringify(tb.actions, null, 2);
+    }
+  }
+
+  onActionsChange() {
+    try {
+      this.actions = JSON.parse(this.actionsJson);
+      this.actionsValid = true;
+    } catch {
+      this.actionsValid = false;
+    }
+  }
+
+  ngDoCheck() {
+    this.emitChange();
+  }
+
+  emitChange() {
+    if (!this.actionsValid) return;
+    const cfg = JSON.parse(JSON.stringify(this.config));
+    cfg.toolbar = {
+      visible: this.visible,
+      actions: this.actions,
+      showNewButton: this.showNewButton,
+      newButtonText: this.newButtonText,
+      newButtonIcon: this.newButtonIcon,
+      newButtonColor: this.newButtonColor
+    };
+    this.configChange.emit(cfg);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/public-api.ts
@@ -8,3 +8,8 @@ export * from './lib/praxis-table-event';
 export * from './lib/praxis-table-config-editor';
 export * from './lib/praxis-table-json-config';
 export * from './lib/praxis-table-pagination-config';
+export * from './lib/praxis-table-grid-options-config';
+export * from './lib/praxis-table-toolbar-config';
+export * from './lib/praxis-table-export-config';
+export * from './lib/praxis-table-messages-config';
+export * from './lib/praxis-table-row-actions-config';


### PR DESCRIPTION
## Summary
- add components to configure grid, toolbar, export, messages and actions
- expose new components from the table package
- extend `PraxisTableConfigEditor` to include tabs for all config options

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b910d0bc8328a09700b2d3eb5766