### PR TITLE
Add MaterialSlider template and styles

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-slider/material-slider.component.html
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-slider/material-slider.component.html
@@ -1,0 +1,90 @@
+<!-- Container principal do slider -->
+<div class="pdx-slider-container" [class]="sliderSpecificClasses()">
+
+  <!-- Rótulo do campo -->
+  @if (metadata()?.label) {
+    <label class="pdx-slider-label" [for]="componentId() + '-slider'">
+      {{ metadata()?.label }}
+      @if (metadata()?.required) {
+        <span class="pdx-required-marker" aria-label="required"> *</span>
+      }
+    </label>
+  }
+
+  <!-- Controle do slider -->
+  <div class="pdx-slider-wrapper">
+    @if (showCurrentValue()) {
+      <div class="pdx-slider-value">{{ formattedValue() }}</div>
+    }
+
+    <mat-slider
+      class="pdx-slider-control"
+      [id]="componentId() + '-slider'"
+      [min]="minValue()"
+      [max]="maxValue()"
+      [step]="stepValue()"
+      [value]="sliderState().value"
+      [disabled]="componentState().disabled"
+      [color]="materialColor()"
+      [vertical]="isVertical()"
+      [thumbLabel]="shouldShowThumbLabel()"
+      [displayWith]="thumbLabelFormatter"
+      [tickInterval]="shouldShowTickMarks() ? stepValue() : 0"
+      (input)="onSliderInput($event)"
+      (change)="onSliderChange($event)"
+      (slideStart)="onSliderStart()"
+      (slideEnd)="onSliderEnd()"
+      (focus)="onSliderFocus()"
+      (blur)="onSliderBlur()">
+    </mat-slider>
+
+    @if (showMinMaxLabels()) {
+      <div class="pdx-slider-labels">
+        <span class="pdx-slider-min">{{ minValue() }}</span>
+        <span class="pdx-slider-max">{{ maxValue() }}</span>
+      </div>
+    }
+  </div>
+
+  <!-- Texto de ajuda -->
+  @if (metadata()?.hint) {
+    <div class="pdx-slider-hint" [id]="componentId() + '-hint'">{{ metadata()?.hint }}</div>
+  }
+
+  <!-- Mensagens de erro -->
+  @if (hasValidationError()) {
+    <div class="pdx-slider-errors">
+      <div class="pdx-error-message">
+        <mat-icon class="pdx-error-icon">error_outline</mat-icon>
+        {{ primaryErrorMessage() }}
+      </div>
+
+      @if (allErrorMessages().length > 1) {
+        <div class="pdx-additional-errors">
+          @for (error of allErrorMessages().slice(1); track error) {
+            <div class="pdx-error-message pdx-additional-error">{{ error }}</div>
+          }
+        </div>
+      }
+    </div>
+  }
+</div>
+
+<!-- Indicador de validação assíncrona -->
+@if (validationState().isValidating) {
+  <div class="pdx-validation-loading" [attr.aria-label]="'Validating ' + metadata()?.label">
+    <mat-icon class="pdx-loading-spinner">hourglass_empty</mat-icon>
+    <span class="pdx-sr-only">Validating...</span>
+  </div>
+}
+
+<!-- Informações de debug -->
+@if (isDebugMode() && metadata()?.security) {
+  <div class="pdx-debug-info">
+    <small class="pdx-debug-security">
+      Security Level: {{ metadata()?.security?.securityLevel }}
+      @if (metadata()?.security?.audit?.enabled) { | Audit: ON }
+      | Value: {{ formattedValue() }}
+    </small>
+  </div>
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-slider/material-slider.component.scss
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-slider/material-slider.component.scss
@@ -1,0 +1,69 @@
+/**
+ * Estilos para o componente Material Slider dinâmico
+ */
+
+.pdx-slider-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.pdx-slider-wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.pdx-slider-control {
+  width: 100%;
+}
+
+.pdx-slider-value {
+  font-size: 14px;
+  text-align: center;
+  margin-bottom: 4px;
+  color: var(--mdc-theme-on-surface, rgba(0, 0, 0, 0.87));
+}
+
+.pdx-slider-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  margin-top: 4px;
+  color: var(--mdc-theme-on-surface-variant, rgba(0, 0, 0, 0.6));
+}
+
+.pdx-validation-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--mdc-theme-on-surface-variant, rgba(0, 0, 0, 0.6));
+}
+
+.pdx-loading-spinner {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.pdx-debug-info {
+  margin-top: 8px;
+  padding: 4px 8px;
+  background: var(--mdc-theme-surface-variant, #f5f5f5);
+  border-radius: 4px;
+}
+
+.pdx-debug-security {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 10px;
+  color: var(--mdc-theme-on-surface-variant, rgba(0, 0, 0, 0.6));
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-slider/material-slider.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-slider/material-slider.component.ts
@@ -41,6 +41,8 @@ interface ExtendedSliderMetadata extends ComponentMetadata {
   range?: boolean;
   color?: 'primary' | 'accent' | 'warn';
   displayWith?: (value: number) => string;
+  showCurrentValue?: boolean;
+  showMinMaxLabels?: boolean;
 }
 
 function safeSliderMetadata(metadata: ComponentMetadata | null | undefined): ExtendedSliderMetadata {
@@ -158,6 +160,24 @@ export class MaterialSliderComponent
     const metadata = safeSliderMetadata(this.metadata());
     return metadata.range ?? false;
   });
+
+  /** Deve exibir o valor atual */
+  readonly showCurrentValue = computed(() => {
+    const metadata = safeSliderMetadata(this.metadata());
+    return metadata.showCurrentValue !== false;
+  });
+
+  /** Deve exibir os valores mínimo e máximo */
+  readonly showMinMaxLabels = computed(() => {
+    const metadata = safeSliderMetadata(this.metadata());
+    return metadata.showMinMaxLabels !== false;
+  });
+
+  /** Função para formatar o valor do thumb */
+  readonly thumbLabelFormatter = (value: number): string => {
+    const metadata = safeSliderMetadata(this.metadata());
+    return metadata.displayWith ? metadata.displayWith(value) : value.toString();
+  };
 
   /** Valor atual formatado */
   readonly formattedValue = computed(() => {
@@ -301,6 +321,14 @@ export class MaterialSliderComponent
   onSliderEnd(): void {
     this.updateSliderState({ isDragging: false });
     this.log('debug', 'Slider drag ended');
+  }
+
+  onSliderFocus(): void {
+    this.focus();
+  }
+
+  onSliderBlur(): void {
+    this.blur();
   }
 
   // =============================================================================


### PR DESCRIPTION
## Summary
- create HTML and SCSS files for `MaterialSliderComponent`
- extend component logic with display helpers and focus handlers
- update TypeScript to support new template

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893c81ea908328a49995a87788f17f