### PR TITLE
Add MaterialRatingComponent

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/material-rating.component.html
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/material-rating.component.html
@@ -1,0 +1,61 @@
+<div class="pdx-field-container pdx-rating-container" [class]="cssClasses() + ' ' + fieldCssClasses()">
+
+  <label class="pdx-field-label" [class.required]="metadata()?.required" [for]="componentId() + '-rating'">
+    {{ metadata()?.label }}
+    <span *ngIf="metadata()?.required" class="pdx-required-marker" aria-hidden="true">*</span>
+  </label>
+
+  <div class="pdx-field-control">
+    <div class="pdx-rating-stars"
+         [id]="componentId() + '-rating'"
+         [class.readonly]="isReadonly()"
+         [class.disabled]="effectiveDisabled()"
+         role="radiogroup"
+         [attr.aria-label]="'Rating from 0 to ' + (metadata()?.max || 5)"
+         [attr.aria-describedby]="getAriaDescribedBy()">
+
+      <button *ngFor="let star of getStars(); trackBy: trackByIndex"
+              type="button"
+              class="pdx-rating-star"
+              [class.filled]="star.filled"
+              [class.half]="star.half"
+              [class.empty]="star.empty"
+              [class.hover]="star.hover"
+              [disabled]="effectiveDisabled() || isReadonly()"
+              [attr.aria-label]="getStarAriaLabel(star.index)"
+              [attr.aria-checked]="star.filled"
+              role="radio"
+              (click)="selectRating(star.value)"
+              (mouseenter)="onStarHover(star.index)"
+              (mouseleave)="onStarLeave()"
+              (keydown)="onStarKeyDown($event, star.index)">
+
+        <mat-icon *ngIf="star.filled" [color]="materialColor()">
+          {{ metadata()?.icon || 'star' }}
+        </mat-icon>
+
+        <mat-icon *ngIf="star.half" [color]="materialColor()" class="pdx-half-star">
+          {{ metadata()?.icon || 'star' }}
+        </mat-icon>
+
+        <mat-icon *ngIf="star.empty" class="pdx-empty-star">
+          {{ metadata()?.emptyIcon || 'star_border' }}
+        </mat-icon>
+      </button>
+    </div>
+
+    <div *ngIf="showValueDisplay()" class="pdx-rating-value">
+      {{ formatRatingValue(fieldValue()) }} / {{ metadata()?.max || 5 }}
+    </div>
+  </div>
+
+  <div class="pdx-field-hints">
+    <div *ngIf="metadata()?.hint && !hasValidationError()" class="pdx-field-hint" [id]="componentId() + '-hint'">
+      {{ metadata()?.hint }}
+    </div>
+
+    <div *ngIf="hasValidationError()" class="pdx-field-error" [id]="componentId() + '-error'" role="alert">
+      {{ primaryErrorMessage() }}
+    </div>
+  </div>
+</div>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/material-rating.component.scss
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/material-rating.component.scss
@@ -1,0 +1,45 @@
+/**
+ * Estilos para MaterialRatingComponent
+ */
+
+.pdx-rating-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.pdx-rating-stars {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pdx-rating-star {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+}
+
+.pdx-rating-star.filled mat-icon,
+.pdx-rating-star.half mat-icon {
+  color: inherit;
+}
+
+.pdx-rating-star.empty mat-icon {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.pdx-rating-stars.readonly .pdx-rating-star,
+.pdx-rating-stars.disabled .pdx-rating-star {
+  cursor: default;
+  pointer-events: none;
+}
+
+.pdx-rating-value {
+  margin-left: 8px;
+  font-size: 14px;
+  color: var(--mdc-theme-on-surface, rgba(0,0,0,.87));
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/material-rating.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/material-rating.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { MaterialRatingComponent } from './material-rating.component';
+import { MaterialRatingMetadata } from '@praxis/core';
+
+describe('MaterialRatingComponent', () => {
+  let component: MaterialRatingComponent;
+  let fixture: ComponentFixture<MaterialRatingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        MaterialRatingComponent,
+        ReactiveFormsModule,
+        MatIconModule,
+        MatFormFieldModule,
+        NoopAnimationsModule
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialRatingComponent);
+    component = fixture.componentInstance;
+    const metadata: MaterialRatingMetadata = {
+      name: 'rating',
+      label: 'Rating',
+      controlType: 'rating'
+    } as any;
+    component.setMetadata(metadata);
+    component.setFormControl(new FormControl(0));
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should update value when selecting rating', () => {
+    component.selectRating(3);
+    expect(component.formControl.value).toBe(3);
+  });
+
+  it('should handle half-star selection', () => {
+    component.setMetadata({ ...(component.metadata() as any), allowHalf: true } as any);
+    component.selectRating(2);
+    component.selectRating(2);
+    expect(component.formControl.value).toBe(1.5);
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/material-rating.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/material-rating.component.ts
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview Componente Material Rating din\u00e2mico
+ *
+ * Implementa um sistema de avalia\u00e7\u00e3o com estrelas ou \u00edcones customizados.
+ */
+
+import { Component, computed, signal } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+
+import { BaseDynamicFieldComponent } from '../../base/base-dynamic-field.component';
+import { MaterialRatingMetadata } from '@praxis/core';
+
+interface HoverState {
+  hoveredIndex: number;
+  isHovering: boolean;
+}
+
+interface StarConfig {
+  index: number;
+  value: number;
+  filled: boolean;
+  half: boolean;
+  empty: boolean;
+  hover: boolean;
+}
+
+@Component({
+  selector: 'pdx-material-rating',
+  standalone: true,
+  templateUrl: './material-rating.component.html',
+  styleUrls: ['./material-rating.component.scss'],
+  imports: [CommonModule, ReactiveFormsModule, MatIconModule, MatFormFieldModule]
+})
+export class MaterialRatingComponent extends BaseDynamicFieldComponent<MaterialRatingMetadata> {
+  private readonly hoverState = signal<HoverState>({ hoveredIndex: -1, isHovering: false });
+
+  readonly materialColor = computed(() => this.metadata()?.color || 'primary');
+  readonly isReadonly = computed(() => this.metadata()?.readonly === true);
+  readonly maxRating = computed(() => this.metadata()?.max || 5);
+  readonly precision = computed(() => this.metadata()?.precision || 1);
+  readonly allowHalf = computed(() => this.metadata()?.allowHalf === true);
+  readonly showValueDisplay = computed(() => this.metadata()?.showValue !== false);
+
+  readonly getStars = computed(() => {
+    const stars: StarConfig[] = [];
+    const currentValue = this.fieldValue() || 0;
+    const { hoveredIndex, isHovering } = this.hoverState();
+    const max = this.maxRating();
+
+    for (let i = 0; i < max; i++) {
+      const starValue = i + 1;
+      const displayValue = isHovering ? hoveredIndex + 1 : currentValue;
+
+      stars.push({
+        index: i,
+        value: starValue,
+        filled: displayValue >= starValue,
+        half: this.allowHalf() && displayValue >= starValue - 0.5 && displayValue < starValue,
+        empty: displayValue < starValue - (this.allowHalf() ? 0.5 : 0),
+        hover: isHovering && i <= hoveredIndex
+      });
+    }
+
+    return stars;
+  });
+
+  selectRating(value: number): void {
+    if (this.effectiveDisabled() || this.isReadonly()) return;
+
+    let newValue = value;
+    if (this.allowHalf() && this.fieldValue() === value) {
+      newValue = value - 0.5;
+    }
+
+    const precision = this.precision();
+    newValue = Math.round(newValue / precision) * precision;
+    this.setValue(newValue);
+  }
+
+  onStarHover(index: number): void {
+    if (this.effectiveDisabled() || this.isReadonly()) return;
+    this.hoverState.set({ hoveredIndex: index, isHovering: true });
+  }
+
+  onStarLeave(): void {
+    this.hoverState.set({ hoveredIndex: -1, isHovering: false });
+  }
+
+  onStarKeyDown(event: KeyboardEvent, index: number): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.selectRating(index + 1);
+    }
+  }
+
+  getStarAriaLabel(index: number): string {
+    return `Rate ${index + 1} out of ${this.maxRating()}`;
+  }
+
+  formatRatingValue(value: number): string {
+    return value?.toFixed(this.precision() < 1 ? 1 : 0) || '0';
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
@@ -298,6 +298,12 @@ export class ComponentRegistryService implements IComponentRegistry {
       () => import('../../components/material-timepicker/material-timepicker.component').then(m => m.MaterialTimepickerComponent)
     );
 
+    // Rating
+    this.register(
+      FieldControlTypeEnum.RATING,
+      () => import('../../components/material-rating/material-rating.component').then(m => m.MaterialRatingComponent)
+    );
+
     // COMPONENTES PLANEJADOS PARA IMPLEMENTAÇÃO FUTURA
 
     // Rating (futura implementação)


### PR DESCRIPTION
## Summary
- create MaterialRatingComponent with fractional star rating
- register `FieldControlType.RATING` in `ComponentRegistryService`
- add specs for the new component

## Testing
- `npx ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6889438952388328909e92d0d47823b8