### PR TITLE
Add Material ColorPicker component

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/README.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/README.md
@@ -7,6 +7,7 @@ Sistema simplificado de campos dinâmicos para aplicações corporativas Angular
 - **Registro Simplificado**: Sistema de registro de componentes focado no essencial
 - **Lazy Loading**: Carregamento sob demanda com cache inteligente
 - **Material Design**: Componentes baseados no Angular Material
+- **Color Picker**: Novo componente de seleção de cores com suporte a paleta e canvas
 - **TypeScript**: Totalmente tipado com integração do `@praxis/core`
 - **Corporativo**: Adequado para cenários empresariais
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/index.ts
@@ -1,0 +1,1 @@
+export * from './material-colorpicker.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.html
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.html
@@ -1,0 +1,65 @@
+<div class="pdx-colorpicker-container" [class]="cssClasses() + ' ' + fieldCssClasses()">
+  <mat-form-field [appearance]="materialAppearance()" [color]="materialColor()">
+    <mat-label>{{ metadata()?.label }}</mat-label>
+    <input matInput
+           [formControl]="formControl"
+           [placeholder]="getColorPlaceholder()"
+           [readonly]="metadata()?.readonly"
+           [disabled]="effectiveDisabled()"
+           (input)="onColorInput($event)"
+           (focus)="focus()"
+           (blur)="blur()">
+    <div matPrefix class="pdx-color-preview"
+         [style.background-color]="currentColor()"
+         (click)="openColorPicker()"></div>
+    <mat-icon matSuffix class="pdx-picker-icon"
+              (click)="openColorPicker()"
+              [class.disabled]="effectiveDisabled()">palette</mat-icon>
+    <mat-hint *ngIf="metadata()?.hint && !hasValidationError()">{{ metadata()?.hint }}</mat-hint>
+    <mat-error *ngIf="hasValidationError()">{{ primaryErrorMessage() }}</mat-error>
+  </mat-form-field>
+
+  <div *ngIf="isPickerOpen()" class="pdx-colorpicker-overlay" (click)="closeColorPicker()">
+    <div class="pdx-colorpicker-dialog" (click)="$event.stopPropagation()">
+      <div class="pdx-current-color">
+        <div class="pdx-color-display" [style.background-color]="currentColor()"></div>
+        <span class="pdx-color-value">{{ currentColor() }}</span>
+      </div>
+      <div *ngIf="hasPresetColors()" class="pdx-preset-colors">
+        <div class="pdx-color-grid">
+          <button *ngFor="let color of getPresetColors(); trackBy: trackByColor"
+                  type="button"
+                  class="pdx-preset-color"
+                  [style.background-color]="color"
+                  [class.selected]="isColorSelected(color)"
+                  (click)="selectPresetColor(color)"></button>
+        </div>
+      </div>
+      <div *ngIf="allowCustomColors()" class="pdx-custom-color-picker">
+        <canvas #colorCanvas class="pdx-color-canvas"
+                width="200" height="200"
+                (mousedown)="onCanvasMouseDown($event)"
+                (mousemove)="onCanvasMouseMove($event)"
+                (mouseup)="onCanvasMouseUp()"></canvas>
+        <div class="pdx-color-cursor" [style.transform]="getCursorTransform()"></div>
+        <div class="pdx-hue-slider">
+          <input type="range" min="0" max="360" [value]="0" (input)="onHueChange($event)">
+        </div>
+        <div *ngIf="showAlpha()" class="pdx-alpha-slider">
+          <input type="range" min="0" max="1" step="0.01" [value]="1" (input)="onAlphaChange($event)">
+        </div>
+      </div>
+      <div *ngIf="showInput()" class="pdx-color-inputs">
+        <mat-form-field>
+          <mat-label>Color</mat-label>
+          <input matInput [(ngModel)]="formControl.value">
+        </mat-form-field>
+      </div>
+      <div class="pdx-colorpicker-actions">
+        <button mat-button (click)="closeColorPicker()">Cancelar</button>
+        <button mat-button (click)="clearColor()">Limpar</button>
+        <button mat-button color="primary" (click)="confirmColor()">OK</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.scss
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.scss
@@ -1,0 +1,77 @@
+.pdx-colorpicker-container {
+  position: relative;
+}
+
+.pdx-color-preview {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid #ccc;
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.pdx-picker-icon.disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.pdx-colorpicker-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.pdx-colorpicker-dialog {
+  background: #fff;
+  padding: 16px;
+  border-radius: 4px;
+  min-width: 220px;
+  position: relative;
+}
+
+.pdx-color-canvas {
+  border: 1px solid #ccc;
+  cursor: crosshair;
+  display: block;
+}
+
+.pdx-color-cursor {
+  width: 10px;
+  height: 10px;
+  border: 1px solid #000;
+  border-radius: 50%;
+  pointer-events: none;
+  position: absolute;
+}
+
+.pdx-color-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.pdx-preset-color {
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 50%;
+}
+
+.pdx-preset-color.selected {
+  outline: 2px solid #000;
+}
+
+.pdx-colorpicker-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, FormControl, FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { MaterialColorPickerComponent } from './material-colorpicker.component';
+import { MaterialColorPickerMetadata } from '@praxis/core';
+
+describe('MaterialColorPickerComponent', () => {
+  let component: MaterialColorPickerComponent;
+  let fixture: ComponentFixture<MaterialColorPickerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        MaterialColorPickerComponent,
+        ReactiveFormsModule,
+        FormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatIconModule,
+        MatButtonModule,
+        NoopAnimationsModule
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialColorPickerComponent);
+    component = fixture.componentInstance;
+    const metadata: MaterialColorPickerMetadata = {
+      name: 'color',
+      label: 'Color',
+      controlType: 'colorPicker'
+    } as any;
+    component.setMetadata(metadata);
+    component.setFormControl(new FormControl('#000000'));
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should open and close the picker', () => {
+    component.openColorPicker();
+    expect(component.isPickerOpen()).toBeTrue();
+    component.closeColorPicker();
+    expect(component.isPickerOpen()).toBeFalse();
+  });
+
+  it('should update value when confirming color', () => {
+    component.openColorPicker();
+    component.selectPresetColor('#ff0000');
+    component.confirmColor();
+    expect(component.formControl.value).toBe('#ff0000');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.ts
@@ -1,0 +1,179 @@
+import { Component, ElementRef, ViewChild, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+
+import { BaseDynamicFieldComponent } from '../../base/base-dynamic-field.component';
+import { MaterialColorPickerMetadata } from '@praxis/core';
+
+interface ColorState {
+  isPickerOpen: boolean;
+  currentColor: string;
+  hue: number;
+  saturation: number;
+  lightness: number;
+  alpha: number;
+  isSelecting: boolean;
+  cursorX: number;
+  cursorY: number;
+}
+
+@Component({
+  selector: 'pdx-material-colorpicker',
+  standalone: true,
+  templateUrl: './material-colorpicker.component.html',
+  styleUrls: ['./material-colorpicker.component.scss'],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule
+  ],
+  host: {
+    '[class]': 'cssClasses() + " " + fieldCssClasses()',
+    '[attr.data-field-type]': '"colorpicker"',
+    '[attr.data-field-name]': 'metadata()?.name'
+  }
+})
+export class MaterialColorPickerComponent extends BaseDynamicFieldComponent<MaterialColorPickerMetadata> {
+  @ViewChild('colorCanvas', { static: false }) colorCanvas?: ElementRef<HTMLCanvasElement>;
+
+  private readonly colorState = signal<ColorState>({
+    isPickerOpen: false,
+    currentColor: '#000000',
+    hue: 0,
+    saturation: 100,
+    lightness: 50,
+    alpha: 1,
+    isSelecting: false,
+    cursorX: 0,
+    cursorY: 0
+  });
+
+  readonly currentColor = computed(() => this.colorState().currentColor);
+  readonly isPickerOpen = computed(() => this.colorState().isPickerOpen);
+  readonly showAlpha = computed(() => this.metadata()?.showAlpha === true);
+  readonly hasPresetColors = computed(() => Boolean(this.metadata()?.presetColors?.length));
+  readonly allowCustomColors = computed(() => this.metadata()?.allowCustomColors !== false);
+  readonly showInput = computed(() => this.metadata()?.showInput !== false);
+
+  openColorPicker(): void {
+    if (this.effectiveDisabled()) return;
+    this.colorState.update(s => ({ ...s, isPickerOpen: true }));
+    setTimeout(() => this.initializeColorCanvas());
+  }
+
+  closeColorPicker(): void {
+    this.colorState.update(s => ({ ...s, isPickerOpen: false, isSelecting: false }));
+  }
+
+  clearColor(): void {
+    this.setValue(null);
+    this.colorState.update(s => ({ ...s, currentColor: '#000000' }));
+  }
+
+  confirmColor(): void {
+    this.setValue(this.colorState().currentColor);
+    this.closeColorPicker();
+  }
+
+  selectPresetColor(color: string): void {
+    this.colorState.update(s => ({ ...s, currentColor: color }));
+  }
+
+  onColorInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.colorState.update(s => ({ ...s, currentColor: value }));
+  }
+
+  onCanvasMouseDown(event: MouseEvent): void {
+    this.colorState.update(s => ({ ...s, isSelecting: true }));
+    this.updateColorFromCanvas(event.offsetX, event.offsetY);
+  }
+
+  onCanvasMouseMove(event: MouseEvent): void {
+    if (!this.colorState().isSelecting) return;
+    this.updateColorFromCanvas(event.offsetX, event.offsetY);
+  }
+
+  onCanvasMouseUp(): void {
+    this.colorState.update(s => ({ ...s, isSelecting: false }));
+  }
+
+  onHueChange(event: Event): void {
+    const hue = parseInt((event.target as HTMLInputElement).value, 10);
+    this.colorState.update(s => ({ ...s, hue }));
+    this.drawColorCanvas();
+  }
+
+  onAlphaChange(event: Event): void {
+    const alpha = parseFloat((event.target as HTMLInputElement).value);
+    this.colorState.update(s => ({ ...s, alpha }));
+  }
+
+  isColorSelected(color: string): boolean {
+    return this.colorState().currentColor.toLowerCase() === color.toLowerCase();
+  }
+
+  trackByColor(_: number, color: string): string {
+    return color;
+  }
+
+  getPresetColors(): string[] {
+    return this.metadata()?.presetColors || [];
+  }
+
+  getColorPlaceholder(): string {
+    return this.metadata()?.format?.toUpperCase() || 'HEX';
+  }
+
+  getCursorTransform(): string {
+    const { cursorX, cursorY } = this.colorState();
+    return `translate(${cursorX - 5}px, ${cursorY - 5}px)`;
+  }
+
+  private initializeColorCanvas(): void {
+    this.drawColorCanvas();
+  }
+
+  private drawColorCanvas(): void {
+    if (!this.colorCanvas) return;
+    const canvas = this.colorCanvas.nativeElement;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const hue = this.colorState().hue;
+    const width = canvas.width;
+    const height = canvas.height;
+
+    const gradientSat = ctx.createLinearGradient(0, 0, width, 0);
+    gradientSat.addColorStop(0, 'white');
+    gradientSat.addColorStop(1, `hsl(${hue}, 100%, 50%)`);
+    ctx.fillStyle = gradientSat;
+    ctx.fillRect(0, 0, width, height);
+
+    const gradientVal = ctx.createLinearGradient(0, 0, 0, height);
+    gradientVal.addColorStop(0, 'rgba(0,0,0,0)');
+    gradientVal.addColorStop(1, 'black');
+    ctx.fillStyle = gradientVal;
+    ctx.fillRect(0, 0, width, height);
+  }
+
+  private updateColorFromCanvas(x: number, y: number): void {
+    if (!this.colorCanvas) return;
+    const canvas = this.colorCanvas.nativeElement;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const data = ctx.getImageData(x, y, 1, 1).data;
+    const [r, g, b] = data;
+    const color = `rgba(${r},${g},${b},${this.colorState().alpha})`;
+    this.colorState.update(s => ({ ...s, currentColor: color, cursorX: x, cursorY: y }));
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
@@ -304,6 +304,12 @@ export class ComponentRegistryService implements IComponentRegistry {
       () => import('../../components/material-rating/material-rating.component').then(m => m.MaterialRatingComponent)
     );
 
+    // Color Picker
+    this.register(
+      FieldControlTypeEnum.COLOR_PICKER,
+      () => import('../../components/material-colorpicker/material-colorpicker.component').then(m => m.MaterialColorPickerComponent)
+    );
+
     // COMPONENTES PLANEJADOS PARA IMPLEMENTAÇÃO FUTURA
 
     // Rating (futura implementação)

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
@@ -50,6 +50,7 @@ export * from './lib/components/material-radio/material-radio.component';
 export * from './lib/components/material-date-picker/material-date-picker.component';
 export * from './lib/components/material-date-range/material-date-range.component';
 export * from './lib/components/material-button/material-button.component';
+export * from './lib/components/material-colorpicker/material-colorpicker.component';
 
 // =============================================================================
 // DIRETIVAS


### PR DESCRIPTION
## Summary
- implement `MaterialColorPickerComponent` with palette and canvas
- register the new component in `ComponentRegistryService`
- export it from the library public API
- mention color picker in README

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889461f350883289b2c966947e47555