### PR TITLE
Fix Angular scss compilation errors

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.scss
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.scss
@@ -1,0 +1,19 @@
+// =============================================================================
+// MATERIAL CURRENCY COMPONENT STYLES
+// =============================================================================
+
+.pdx-currency-input {
+  text-align: right;
+}
+
+.pdx-error-message {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  .pdx-error-icon {
+    width: 16px;
+    height: 16px;
+    font-size: 16px;
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-date-picker/material-date-picker.component.scss
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-date-picker/material-date-picker.component.scss
@@ -78,3 +78,7 @@
       
       mat-option {
         display: flex;
+      }
+    }
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-date-range/material-date-range.component.scss
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-date-range/material-date-range.component.scss
@@ -152,9 +152,12 @@
       display: flex;
       align-items: center;
       gap: 6px;
-      
+
       .pdx-error-icon {
         width: 16px;
         height: 16px;
         font-size: 16px;
       }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add missing styles for the currency component
- close unbalanced blocks in date range and date picker SCSS files

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688949a5274083288799313353433c4f