### PR TITLE
Add missing component exports and docs

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/README.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/README.md
@@ -8,6 +8,7 @@ Sistema simplificado de campos dinâmicos para aplicações corporativas Angular
 - **Lazy Loading**: Carregamento sob demanda com cache inteligente
 - **Material Design**: Componentes baseados no Angular Material
 - **Color Picker**: Novo componente de seleção de cores com suporte a paleta e canvas
+- **Novos Componentes**: Toggle, Slider, Time Picker e Rating
 - **TypeScript**: Totalmente tipado com integração do `@praxis/core`
 - **Corporativo**: Adequado para cenários empresariais
 
@@ -45,6 +46,11 @@ O sistema usa as constantes do `@praxis/core` para garantir consistência:
 - `FieldControlType.DATE_TIME_PICKER` - Data e hora
 - `FieldControlType.DATE_RANGE` - Intervalo de datas
 - `FieldControlType.FILE_UPLOAD` - Upload de arquivos
+- `FieldControlType.TOGGLE` - Interruptor Material Design
+- `FieldControlType.SLIDER` - Slider Material Design
+- `FieldControlType.TIME_PICKER` - Seletor de horário
+- `FieldControlType.RATING` - Classificação por estrelas
+- `FieldControlType.COLOR_PICKER` - Seletor de cores
 
 ## 📦 Instalação
 
@@ -82,6 +88,10 @@ export class DynamicFormComponent {
 
   async loadDatePicker() {
     await this.loadField(FieldControlType.DATE_PICKER);
+  }
+
+  async loadColorPicker() {
+    await this.loadField(FieldControlType.COLOR_PICKER);
   }
 }
 ```

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-rating/index.ts
@@ -1,0 +1,1 @@
+export * from './material-rating.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-slider/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-slider/index.ts
@@ -1,0 +1,1 @@
+export * from './material-slider.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-timepicker/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-timepicker/index.ts
@@ -1,0 +1,1 @@
+export * from './material-timepicker.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-toggle/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-toggle/index.ts
@@ -1,0 +1,1 @@
+export * from './material-toggle.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
@@ -51,6 +51,10 @@ export * from './lib/components/material-date-picker/material-date-picker.compon
 export * from './lib/components/material-date-range/material-date-range.component';
 export * from './lib/components/material-button/material-button.component';
 export * from './lib/components/material-colorpicker/material-colorpicker.component';
+export * from './lib/components/material-toggle/material-toggle.component';
+export * from './lib/components/material-slider/material-slider.component';
+export * from './lib/components/material-timepicker/material-timepicker.component';
+export * from './lib/components/material-rating/material-rating.component';
 
 // =============================================================================
 // DIRETIVAS


### PR DESCRIPTION
## Summary
- export Toggle, Slider, Time Picker and Rating in the dynamic fields library
- provide barrel files for new components
- document new components and example usage

## Testing
- `npx ng test praxis-dynamic-fields --browsers=ChromeHeadless --watch=false` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68894bc249348328afe5512537de48d2