### PR TITLE
Add mapper for FieldDefinition to FieldMetadata

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
@@ -1,0 +1,61 @@
+import { mapFieldDefinitionToMetadata, mapFieldDefinitionsToMetadata } from './helpers/field-definition-mapper';
+import { FieldDefinition } from './models/field-definition.model';
+import { FieldMetadata } from './models/component-metadata.interface';
+
+describe('FieldDefinition to FieldMetadata mapper', () => {
+  it('should map basic properties', () => {
+    const def: FieldDefinition = {
+      name: 'firstName',
+      label: 'First Name',
+      type: 'string',
+      controlType: 'input',
+      required: true,
+      defaultValue: 'John',
+      hint: 'Your given name',
+      order: 2
+    };
+
+    const meta = mapFieldDefinitionToMetadata(def);
+
+    const expected: FieldMetadata = {
+      name: 'firstName',
+      label: 'First Name',
+      controlType: 'input',
+      dataType: 'string',
+      required: true,
+      defaultValue: 'John',
+      hint: 'Your given name',
+      order: 2
+    } as any;
+
+    expect(meta).toEqual(jasmine.objectContaining(expected));
+  });
+
+  it('should map validators and options', () => {
+    const def: FieldDefinition = {
+      name: 'age',
+      label: 'Age',
+      type: 'number',
+      controlType: 'input',
+      min: 18,
+      max: 60,
+      options: [{ key: '18', value: '18' }]
+    };
+
+    const meta = mapFieldDefinitionToMetadata(def);
+
+    expect(meta.validators).toEqual(jasmine.objectContaining({ min: 18, max: 60 }));
+    expect(meta.options?.length).toBe(1);
+  });
+
+  it('should map arrays', () => {
+    const defs: FieldDefinition[] = [
+      { name: 'a', controlType: 'input' },
+      { name: 'b', controlType: 'input' }
+    ];
+    const metas = mapFieldDefinitionsToMetadata(defs);
+    expect(metas.length).toBe(2);
+    expect(metas[0].name).toBe('a');
+    expect(metas[1].name).toBe('b');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
@@ -1,0 +1,86 @@
+import { FieldDefinition } from '../models/field-definition.model';
+import { FieldMetadata, ValidatorOptions } from '../models/component-metadata.interface';
+
+/**
+ * Convert a `FieldDefinition` coming from the backend schema into
+ * `FieldMetadata` used by the dynamic field loader.
+ */
+export function mapFieldDefinitionToMetadata(field: FieldDefinition): FieldMetadata {
+  const metadata: FieldMetadata = {
+    name: field.name,
+    label: field.label ?? field.name,
+    controlType: field.controlType as any,
+  } as FieldMetadata;
+
+  if (field.type) {
+    metadata.dataType = field.type as any;
+  }
+
+  const simpleProps: Array<keyof FieldDefinition & keyof FieldMetadata> = [
+    'order',
+    'group',
+    'description',
+    'placeholder',
+    'defaultValue',
+    'width',
+    'isFlex',
+    'disabled',
+    'readOnly',
+    'hidden',
+    'unique',
+    'mask',
+    'inlineEditing',
+    'endpoint',
+    'valueField',
+    'displayField',
+  ];
+
+  for (const prop of simpleProps) {
+    const value = field[prop];
+    if (value !== undefined) {
+      (metadata as any)[prop] = value;
+    }
+  }
+
+  if (field.required !== undefined) {
+    metadata.required = field.required;
+  }
+
+  if (field.hint || field.helpText) {
+    metadata.hint = field.hint ?? field.helpText;
+  }
+
+  if (field.options) {
+    metadata.options = field.options;
+  }
+
+  const validators: ValidatorOptions = {};
+  const validatorProps: Array<keyof FieldDefinition & keyof ValidatorOptions> = [
+    'required',
+    'minLength',
+    'maxLength',
+    'min',
+    'max',
+    'pattern',
+  ];
+
+  for (const prop of validatorProps) {
+    const value = field[prop];
+    if (value !== undefined) {
+      (validators as any)[prop] = value;
+    }
+  }
+
+  if (Object.keys(validators).length) {
+    metadata.validators = validators;
+  }
+
+  return metadata;
+}
+
+/**
+ * Convenience function to map an array of definitions.
+ */
+export function mapFieldDefinitionsToMetadata(fields: FieldDefinition[]): FieldMetadata[] {
+  return fields.map(mapFieldDefinitionToMetadata);
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
@@ -32,3 +32,4 @@ export * from './lib/services/table-config.service';
 // Resizable Window Component
 export * from './lib/components/resizable-window/praxis-resizable-window.component';
 export * from './lib/components/resizable-window/services/praxis-resizable-window.service';
+export * from './lib/helpers/field-definition-mapper';


### PR DESCRIPTION
## Summary
- add `mapFieldDefinitionToMetadata` helper
- export helper in public API
- add tests for the new mapping utility

## Testing
- `npx ng test praxis-core --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_688961cee94083289cd35e677b279a39