### PR TITLE
Add dynamic form component

### DIFF
--- a/frontend-libs/praxis-ui-workspace/angular.json
+++ b/frontend-libs/praxis-ui-workspace/angular.json
@@ -226,6 +226,26 @@
           }
         }
       }
+    },
+    "praxis-dynamic-form": {
+      "projectType": "library",
+      "root": "projects/praxis-dynamic-form",
+      "sourceRoot": "projects/praxis-dynamic-form/src",
+      "prefix": "praxis",
+      "architect": {
+        "build": {
+          "builder": "@angular/build:ng-packagr",
+          "configurations": {
+            "production": { "tsConfig": "projects/praxis-dynamic-form/tsconfig.lib.prod.json" },
+            "development": { "tsConfig": "projects/praxis-dynamic-form/tsconfig.lib.json" }
+          },
+          "defaultConfiguration": "production"
+        },
+        "test": {
+          "builder": "@angular/build:karma",
+          "options": { "tsConfig": "projects/praxis-dynamic-form/tsconfig.spec.json" }
+        }
+      }
     }
   },
   "cli": {

--- a/frontend-libs/praxis-ui-workspace/package.json
+++ b/frontend-libs/praxis-ui-workspace/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve  --port 4003",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "watch-all": "concurrently -n core,table,spec,dynamic -c blue,green,yellow,red \"ng build praxis-core --watch --configuration development\" \"ng build praxis-table --watch --configuration development\" \"ng build praxis-specification --watch --configuration development\" \"ng build praxis-dynamic-fields --watch --configuration development\"",
+    "watch-all": "concurrently -n core,table,spec,dynamic,form -c blue,green,yellow,red,cyan \"ng build praxis-core --watch --configuration development\" \"ng build praxis-table --watch --configuration development\" \"ng build praxis-specification --watch --configuration development\" \"ng build praxis-dynamic-fields --watch --configuration development\" \"ng build praxis-dynamic-form --watch --configuration development\"",
     "dev": "concurrently -n libs,app -c cyan,magenta \"npm run watch-all\" \"ng serve --configuration development --port 4003\"",
     "test": "ng test"
   },

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
@@ -1,0 +1,61 @@
+import { mapFieldDefinitionToMetadata, mapFieldDefinitionsToMetadata } from './helpers/field-definition-mapper';
+import { FieldDefinition } from './models/field-definition.model';
+import { FieldMetadata } from './models/component-metadata.interface';
+
+describe('FieldDefinition to FieldMetadata mapper', () => {
+  it('should map basic properties', () => {
+    const def: FieldDefinition = {
+      name: 'firstName',
+      label: 'First Name',
+      type: 'string',
+      controlType: 'input',
+      required: true,
+      defaultValue: 'John',
+      hint: 'Your given name',
+      order: 2
+    };
+
+    const meta = mapFieldDefinitionToMetadata(def);
+
+    const expected: FieldMetadata = {
+      name: 'firstName',
+      label: 'First Name',
+      controlType: 'input',
+      dataType: 'string',
+      required: true,
+      defaultValue: 'John',
+      hint: 'Your given name',
+      order: 2
+    } as any;
+
+    expect(meta).toEqual(jasmine.objectContaining(expected));
+  });
+
+  it('should map validators and options', () => {
+    const def: FieldDefinition = {
+      name: 'age',
+      label: 'Age',
+      type: 'number',
+      controlType: 'input',
+      min: 18,
+      max: 60,
+      options: [{ key: '18', value: '18' }]
+    };
+
+    const meta = mapFieldDefinitionToMetadata(def);
+
+    expect(meta.validators).toEqual(jasmine.objectContaining({ min: 18, max: 60 }));
+    expect(meta.options?.length).toBe(1);
+  });
+
+  it('should map arrays', () => {
+    const defs: FieldDefinition[] = [
+      { name: 'a', controlType: 'input' },
+      { name: 'b', controlType: 'input' }
+    ];
+    const metas = mapFieldDefinitionsToMetadata(defs);
+    expect(metas.length).toBe(2);
+    expect(metas[0].name).toBe('a');
+    expect(metas[1].name).toBe('b');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
@@ -1,0 +1,86 @@
+import { FieldDefinition } from '../models/field-definition.model';
+import { FieldMetadata, ValidatorOptions } from '../models/component-metadata.interface';
+
+/**
+ * Convert a `FieldDefinition` coming from the backend schema into
+ * `FieldMetadata` used by the dynamic field loader.
+ */
+export function mapFieldDefinitionToMetadata(field: FieldDefinition): FieldMetadata {
+  const metadata: FieldMetadata = {
+    name: field.name,
+    label: field.label ?? field.name,
+    controlType: field.controlType as any,
+  } as FieldMetadata;
+
+  if (field.type) {
+    metadata.dataType = field.type as any;
+  }
+
+  const simpleProps: Array<keyof FieldDefinition & keyof FieldMetadata> = [
+    'order',
+    'group',
+    'description',
+    'placeholder',
+    'defaultValue',
+    'width',
+    'isFlex',
+    'disabled',
+    'readOnly',
+    'hidden',
+    'unique',
+    'mask',
+    'inlineEditing',
+    'endpoint',
+    'valueField',
+    'displayField',
+  ];
+
+  for (const prop of simpleProps) {
+    const value = field[prop];
+    if (value !== undefined) {
+      (metadata as any)[prop] = value;
+    }
+  }
+
+  if (field.required !== undefined) {
+    metadata.required = field.required;
+  }
+
+  if (field.hint || field.helpText) {
+    metadata.hint = field.hint ?? field.helpText;
+  }
+
+  if (field.options) {
+    metadata.options = field.options;
+  }
+
+  const validators: ValidatorOptions = {};
+  const validatorProps: Array<keyof FieldDefinition & keyof ValidatorOptions> = [
+    'required',
+    'minLength',
+    'maxLength',
+    'min',
+    'max',
+    'pattern',
+  ];
+
+  for (const prop of validatorProps) {
+    const value = field[prop];
+    if (value !== undefined) {
+      (validators as any)[prop] = value;
+    }
+  }
+
+  if (Object.keys(validators).length) {
+    metadata.validators = validators;
+  }
+
+  return metadata;
+}
+
+/**
+ * Convenience function to map an array of definitions.
+ */
+export function mapFieldDefinitionsToMetadata(fields: FieldDefinition[]): FieldMetadata[] {
+  return fields.map(mapFieldDefinitionToMetadata);
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
@@ -32,3 +32,4 @@ export * from './lib/services/table-config.service';
 // Resizable Window Component
 export * from './lib/components/resizable-window/praxis-resizable-window.component';
 export * from './lib/components/resizable-window/services/praxis-resizable-window.service';
+export * from './lib/helpers/field-definition-mapper';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/ng-package.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/praxis-dynamic-form",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/package.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@praxis/dynamic-form",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/common": "^20.0.0",
+    "@angular/core": "^20.0.0"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "sideEffects": false
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/models/form-config.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/models/form-config.model.ts
@@ -1,0 +1,32 @@
+export interface FormColumn {
+  fields: string[];
+}
+
+export interface FormRow {
+  columns: FormColumn[];
+}
+
+export interface FormSection {
+  id: string;
+  title?: string;
+  description?: string;
+  rows: FormRow[];
+}
+
+export interface FormConfig {
+  sections: FormSection[];
+}
+
+export interface FormConfigState {
+  config: FormConfig;
+  isLoading: boolean;
+  error?: string;
+}
+
+export function createDefaultFormConfig(): FormConfig {
+  return { sections: [] };
+}
+
+export function isValidFormConfig(config: any): config is FormConfig {
+  return config && typeof config === 'object' && Array.isArray(config.sections);
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
@@ -1,0 +1,42 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { PraxisDynamicForm, FormSubmitEvent } from './praxis-dynamic-form';
+import { GenericCrudService } from '@praxis/core';
+import { DynamicFieldLoaderDirective } from '@praxis/dynamic-fields';
+
+describe('PraxisDynamicForm', () => {
+  let fixture: ComponentFixture<PraxisDynamicForm>;
+  let component: PraxisDynamicForm;
+  let crudService: jasmine.SpyObj<GenericCrudService<any>>;
+
+  beforeEach(async () => {
+    crudService = jasmine.createSpyObj('GenericCrudService', ['configure', 'getSchema', 'get', 'create', 'update']);
+
+    await TestBed.configureTestingModule({
+      imports: [PraxisDynamicForm, DynamicFieldLoaderDirective],
+      providers: [{ provide: GenericCrudService, useValue: crudService }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PraxisDynamicForm);
+    component = fixture.componentInstance;
+  });
+
+  it('gera formulário a partir do resourcePath', async () => {
+    const schema = [{ name: 'nome', controlType: 'input' }];
+    crudService.getSchema.and.returnValue(of(schema as any));
+    component.resourcePath = 'usuarios';
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component['fieldMetadata'].length).toBe(1);
+  });
+
+  it('altera para modo edit ao receber resourceId', () => {
+    crudService.get.and.returnValue(of({ id: 1, nome: 'Teste' }));
+    component.mode = 'edit';
+    component.resourceId = 1;
+    component.resourcePath = 'usuarios';
+    crudService.getSchema.and.returnValue(of([]));
+    component.ngOnChanges({ resourcePath: { currentValue: 'usuarios', previousValue: undefined, firstChange: true, isFirstChange: () => true }, resourceId: { currentValue: 1, previousValue: undefined, firstChange: true, isFirstChange: () => true } });
+    expect(crudService.get).toHaveBeenCalled();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
@@ -1,0 +1,130 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+  ChangeDetectorRef
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { GenericCrudService, FieldMetadata, mapFieldDefinitionsToMetadata } from '@praxis/core';
+import { DynamicFieldLoaderDirective } from '@praxis/dynamic-fields';
+import { FormConfig } from './models/form-config.model';
+
+export interface FormSubmitEvent {
+  mode: 'create' | 'edit';
+  data: any;
+  formValue: any;
+}
+
+@Component({
+  selector: 'praxis-dynamic-form',
+  standalone: true,
+  providers: [GenericCrudService],
+  imports: [CommonModule, ReactiveFormsModule, DynamicFieldLoaderDirective],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()" class="praxis-dynamic-form">
+      <ng-container *ngFor="let section of config.sections">
+        <div class="form-section">
+          <h3 *ngIf="section.title">{{ section.title }}</h3>
+          <div *ngFor="let row of section.rows" class="form-row">
+            <div *ngFor="let column of row.columns" class="form-column">
+              <ng-container
+                dynamicFieldLoader
+                [fields]="getColumnFields(column)"
+                [formGroup]="form">
+              </ng-container>
+            </div>
+          </div>
+        </div>
+      </ng-container>
+      <div class="form-actions">
+        <button type="submit" mat-raised-button color="primary" [disabled]="form.invalid">
+          {{ mode === 'edit' ? 'Atualizar' : 'Criar' }}
+        </button>
+      </div>
+    </form>
+  `,
+  styles: [`:host{display:block;}`]
+})
+export class PraxisDynamicForm implements OnChanges, OnDestroy {
+  @Input() resourcePath?: string;
+  @Input() resourceId?: string | number;
+  @Input() mode: 'create' | 'edit' | 'view' = 'create';
+  @Input() config: FormConfig = { sections: [] };
+
+  @Output() formSubmit = new EventEmitter<FormSubmitEvent>();
+  @Output() formCancel = new EventEmitter<void>();
+  @Output() formReset = new EventEmitter<void>();
+  @Output() configChange = new EventEmitter<FormConfig>();
+
+  form: FormGroup = this.fb.group({});
+  private fieldMetadata: FieldMetadata[] = [];
+
+  constructor(
+    private crud: GenericCrudService<any>,
+    private fb: FormBuilder,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['resourcePath'] && this.resourcePath) {
+      this.crud.configure(this.resourcePath);
+      this.loadSchema();
+    }
+    if (changes['resourceId'] && this.resourceId != null) {
+      this.loadEntity();
+    }
+  }
+
+  private loadSchema(): void {
+    this.crud.getSchema().pipe(takeUntilDestroyed()).subscribe(defs => {
+      this.fieldMetadata = mapFieldDefinitionsToMetadata(defs);
+      this.buildForm();
+      this.cdr.detectChanges();
+    });
+  }
+
+  private loadEntity(): void {
+    if (!this.resourceId) { return; }
+    this.crud.get(this.resourceId).pipe(takeUntilDestroyed()).subscribe(data => {
+      this.form.patchValue(data);
+    });
+  }
+
+  private buildForm(): void {
+    const controls: any = {};
+    for (const field of this.fieldMetadata) {
+      const validators = [];
+      if (field.required) { validators.push(Validators.required); }
+      if (field.validators?.minLength) { validators.push(Validators.minLength(field.validators.minLength)); }
+      if (field.validators?.maxLength) { validators.push(Validators.maxLength(field.validators.maxLength)); }
+      if (field.validators?.pattern) { validators.push(Validators.pattern(field.validators.pattern)); }
+      controls[field.name] = [field.defaultValue ?? null, validators];
+    }
+    this.form = this.fb.group(controls);
+  }
+
+  getColumnFields(column: { fields: string[] }): FieldMetadata[] {
+    return this.fieldMetadata.filter(f => column.fields.includes(f.name));
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) { return; }
+    const value = this.form.value;
+    const req$ = this.mode === 'edit' && this.resourceId != null
+      ? this.crud.update(this.resourceId, value)
+      : this.crud.create(value);
+    req$.pipe(takeUntilDestroyed()).subscribe(data => {
+      this.formSubmit.emit({ mode: this.mode === 'edit' ? 'edit' : 'create', data, formValue: value });
+    });
+  }
+
+  ngOnDestroy(): void {
+    // cleanup via takeUntilDestroyed
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-config.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-config.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import {
+  FormConfig,
+  FormConfigState,
+  createDefaultFormConfig,
+  isValidFormConfig
+} from '../models/form-config.model';
+
+@Injectable({ providedIn: 'root' })
+export class FormConfigService {
+  private readonly _state$ = new BehaviorSubject<FormConfigState>({
+    config: createDefaultFormConfig(),
+    isLoading: false
+  });
+
+  readonly state$: Observable<FormConfigState> = this._state$.asObservable();
+
+  get currentConfig(): FormConfig {
+    return this._state$.value.config;
+  }
+
+  loadConfig(config: FormConfig): void {
+    if (!isValidFormConfig(config)) {
+      this.updateState({ error: 'Invalid form configuration', isLoading: false });
+      return;
+    }
+    this.updateState({ config: { ...config }, isLoading: false, error: undefined });
+  }
+
+  updateConfig(configUpdate: Partial<FormConfig>): void {
+    this.updateState({
+      config: { ...this.currentConfig, ...configUpdate },
+      error: undefined
+    });
+  }
+
+  private updateState(state: Partial<FormConfigState>): void {
+    this._state$.next({ ...this._state$.value, ...state });
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
@@ -1,0 +1,3 @@
+export * from './lib/models/form-config.model';
+export * from './lib/services/form-config.service';
+export * from './lib/praxis-dynamic-form';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/tsconfig.lib.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib",
+    "declaration": true,
+    "types": []
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts"
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/tsconfig.lib.prod.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/tsconfig.lib.prod.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false,
+    "sourceMap": false
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/tsconfig.spec.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": ["jasmine"]
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/tsconfig.json
+++ b/frontend-libs/praxis-ui-workspace/tsconfig.json
@@ -25,6 +25,9 @@
       ],
       "praxis-visual-builder": [
         "./dist/praxis-visual-builder"
+      ],
+      "praxis-dynamic-form": [
+        "./dist/praxis-dynamic-form"
       ]
     },
     "importHelpers": true,


### PR DESCRIPTION
## Summary
- introduce `praxis-dynamic-form` library
- implement `PraxisDynamicForm` component
- provide minimal `FormConfig` models and service
- wire library into Angular workspace configuration

## Testing
- `npx ng test praxis-dynamic-form --watch=false --browsers=ChromeHeadless` *(failed: could not determine executable to run)*
- `npx ng build praxis-core` *(failed: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_688961cee94083289cd35e677b279a39