### PR TITLE
Add dynamic form models

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/models/form-events.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/models/form-events.model.ts
@@ -1,0 +1,58 @@
+import { FormGroup } from '@angular/forms';
+import { FieldMetadata } from '@praxis/core';
+import { FormLayout } from './form-layout.model';
+
+export interface FormValueChangeEvent {
+  formData: any;
+  changedField?: string;
+  previousValue?: any;
+  currentValue?: any;
+  changedFields: string[];
+  isValid: boolean;
+  entityId?: string | number;
+}
+
+export interface ValidationError {
+  field: string;
+  type: 'required' | 'pattern' | 'min' | 'max' | 'email' | 'custom';
+  message: string;
+  currentValue?: any;
+  expectedValue?: any;
+}
+
+export interface FormSubmitEvent {
+  stage: 'before' | 'after' | 'error';
+  formData: any;
+  isValid: boolean;
+  validationErrors?: ValidationError[];
+  entityId?: string | number;
+  operation: 'create' | 'update';
+  result?: any;
+  error?: any;
+}
+
+export interface FormValidationEvent {
+  isValid: boolean;
+  errors: { [fieldName: string]: ValidationError[] };
+  validatedFields: string[];
+  invalidFields: string[];
+  formStatus: 'VALID' | 'INVALID' | 'PENDING' | 'DISABLED';
+}
+
+export interface FormEntityEvent {
+  operation: 'load' | 'create' | 'update' | 'delete';
+  entityId?: string | number;
+  entityData?: any;
+  success: boolean;
+  result?: any;
+  error?: any;
+  timestamp: Date;
+}
+
+export interface FormReadyEvent {
+  formGroup: FormGroup;
+  fieldsMetadata: FieldMetadata[];
+  layout?: FormLayout;
+  hasEntity: boolean;
+  entityId?: string | number;
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/models/form-layout.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/models/form-layout.model.ts
@@ -1,0 +1,114 @@
+export interface FormActionsLayout {
+  showSaveButton?: boolean;
+  submitButtonLabel?: string;
+  showCancelButton?: boolean;
+  cancelButtonLabel?: string;
+  showResetButton?: boolean;
+  resetButtonLabel?: string;
+  position?: 'left' | 'center' | 'right' | 'justified';
+  containerClassName?: string;
+  containerStyles?: { [key: string]: any };
+}
+
+export interface FormApiLayout {
+  saveEndpoint?: string;
+  loadEndpoint?: string;
+  saveMethod?: 'POST' | 'PUT' | 'PATCH';
+  timeout?: number;
+  headers?: Record<string, string>;
+  idField?: string;
+  beforeSave?: string;
+  afterLoad?: string;
+}
+
+export interface FormBehaviorLayout {
+  confirmOnUnsavedChanges?: boolean;
+  trackHistory?: boolean;
+  focusFirstError?: boolean;
+  scrollToErrors?: boolean;
+  clearAfterSave?: boolean;
+  redirectAfterSave?: string;
+}
+
+export interface FormMetadataLayout {
+  formCode?: string;
+  version?: string;
+  [key: string]: any;
+}
+
+export interface FormMessagesLayout {
+  updateRegistrySuccess?: string;
+  createRegistrySuccess?: string;
+  updateRegistryError?: string;
+  createRegistryError?: string;
+  [key: string]: any;
+}
+
+import { FieldMetadata } from '@praxis/core';
+import { Specification } from '@praxis/specification';
+
+export interface FormRowLayout {
+  id: string;
+  name?: string;
+  label?: string;
+  orientation: 'horizontal' | 'vertical';
+  fields: FieldMetadata[];
+  styles?: { [key: string]: any };
+  hiddenCondition?: Specification<any>;
+  visibilityCondition?: Specification<any>;
+}
+
+export interface NestedFieldsetLayout extends FormRowLayout {
+  fieldsets?: FieldsetLayout[];
+}
+
+export interface FieldsetLayout {
+  id: string;
+  title: string;
+  titleNew?: string;
+  titleView?: string;
+  titleEdit?: string;
+  orientation: 'horizontal' | 'vertical';
+  rows: FormRowLayout[];
+  hiddenCondition?: Specification<any>;
+}
+
+export type FormRuleContext =
+  | 'visibility'
+  | 'readOnly'
+  | 'style'
+  | 'validation'
+  | 'notification';
+
+export interface FormLayoutRule {
+  id: string;
+  name: string;
+  context: FormRuleContext;
+  targetFields: string[];
+  description?: string;
+  effect: {
+    condition: Specification<any> | null;
+    styleClass?: string;
+    style?: { [key: string]: any };
+  };
+}
+
+export interface FormLayout {
+  formTitle?: string;
+  formDescription?: string;
+  formTitleCreate?: string;
+  formDescriptionCreate?: string;
+  formTitleView?: string;
+  formDescriptionView?: string;
+  formTitleEdit?: string;
+  formDescriptionEdit?: string;
+  className?: string;
+  styles?: { [key: string]: any };
+  actions?: FormActionsLayout;
+  api?: FormApiLayout;
+  behavior?: FormBehaviorLayout;
+  metadata?: FormMetadataLayout;
+  messages?: FormMessagesLayout;
+  fieldsets: FieldsetLayout[];
+  formRules?: FormLayoutRule[];
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { PraxisDynamicForm, FormSubmitEvent } from './praxis-dynamic-form';
+import { PraxisDynamicForm } from './praxis-dynamic-form';
 import { GenericCrudService } from '@praxis/core';
 import { DynamicFieldLoaderDirective } from '@praxis/dynamic-fields';
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
@@ -18,12 +18,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GenericCrudService, FieldMetadata, mapFieldDefinitionsToMetadata } from '@praxis/core';
 import { DynamicFieldLoaderDirective } from '@praxis/dynamic-fields';
 import { FormConfig } from './models/form-config.model';
-
-export interface FormSubmitEvent {
-  mode: 'create' | 'edit';
-  data: any;
-  formValue: any;
-}
+import { FormSubmitEvent } from './models/form-events.model';
 
 @Component({
   selector: 'praxis-dynamic-form',

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
@@ -1,3 +1,5 @@
 export * from './lib/models/form-config.model';
+export * from './lib/models/form-layout.model';
+export * from './lib/models/form-events.model';
 export * from './lib/services/form-config.service';
 export * from './lib/praxis-dynamic-form';


### PR DESCRIPTION
## Summary
- add models for form layout and events
- export models from library public API
- update dynamic form component and tests to use new event model
- refactor: use Specification for layout conditions

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_688a1fe464f483288da2b57a3db50cb0