### PR TITLE
Add FormLayout service and storage interface

### DIFF
--- a/frontend-libs/praxis-ui-workspace/README.md
+++ b/frontend-libs/praxis-ui-workspace/README.md
@@ -279,6 +279,15 @@ praxis-ui-workspace/
 └── ARCHITECTURE-UNIFICATION.md # Detalhes da arquitetura
 ```
 
+### Persistência de Layout de Formulários
+
+O layout dos formulários dinâmicos é armazenado localmente utilizando o
+`localStorage`. Cada formulário é salvo com a chave
+`praxis-layout-<formId>`, permitindo que o usuário mantenha personalizações
+entre sessões. O serviço responsável por essa funcionalidade foi estruturado
+para que, futuramente, seja possível substituir o mecanismo de persistência por
+uma chamada REST sem alterar as chamadas no restante da aplicação.
+
 ## 📚 Documentação
 
 ### Guias Detalhados

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-layout.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-layout.service.spec.ts
@@ -1,0 +1,19 @@
+import { FormLayoutService, LOCAL_STORAGE_FORM_LAYOUT_PROVIDER } from './form-layout.service';
+import { FormLayout } from '../models/form-layout.model';
+
+describe('FormLayoutService', () => {
+  let service: FormLayoutService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    service = new FormLayoutService();
+  });
+
+  it('should save and load layout using localStorage', () => {
+    const layout: FormLayout = { fieldsets: [] };
+    service.saveLayout('test-form', layout);
+
+    const loaded = service.loadLayout('test-form');
+    expect(loaded).toEqual(layout);
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-layout.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-layout.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, InjectionToken, Inject, Optional } from '@angular/core';
+import { FormLayout } from '../models/form-layout.model';
+
+export interface FormLayoutStorage {
+  load(formId: string): FormLayout | null;
+  save(formId: string, layout: FormLayout): void;
+}
+
+export const LOCAL_STORAGE_FORM_LAYOUT_PROVIDER: FormLayoutStorage = {
+  load(formId: string): FormLayout | null {
+    const raw = localStorage.getItem(`praxis-layout-${formId}`);
+    return raw ? (JSON.parse(raw) as FormLayout) : null;
+  },
+  save(formId: string, layout: FormLayout): void {
+    localStorage.setItem(`praxis-layout-${formId}`, JSON.stringify(layout));
+  }
+};
+
+export const FORM_LAYOUT_STORAGE = new InjectionToken<FormLayoutStorage>('FORM_LAYOUT_STORAGE');
+
+@Injectable({ providedIn: 'root' })
+export class FormLayoutService {
+  private provider: FormLayoutStorage;
+
+  constructor(@Optional() @Inject(FORM_LAYOUT_STORAGE) provider?: FormLayoutStorage) {
+    this.provider = provider ?? LOCAL_STORAGE_FORM_LAYOUT_PROVIDER;
+  }
+
+  loadLayout(formId: string): FormLayout | null {
+    return this.provider.load(formId);
+  }
+
+  saveLayout(formId: string, layout: FormLayout): void {
+    this.provider.save(formId, layout);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
@@ -2,4 +2,6 @@ export * from './lib/models/form-config.model';
 export * from './lib/models/form-layout.model';
 export * from './lib/models/form-events.model';
 export * from './lib/services/form-config.service';
+export * from './lib/services/form-layout.service';
+export type { FormLayoutStorage } from './lib/services/form-layout.service';
 export * from './lib/praxis-dynamic-form';


### PR DESCRIPTION
## Summary
- implement `FormLayoutService` with optional storage provider
- export `FormLayoutService` and `FormLayoutStorage`
- document form layout persistence in README
- add unit test for `FormLayoutService`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a35a268448328bc9630ea91c895fa