### PR TITLE
Implement layout context features

### DIFF
--- a/frontend-libs/praxis-ui-workspace/README.md
+++ b/frontend-libs/praxis-ui-workspace/README.md
@@ -288,6 +288,13 @@ entre sessões. O serviço responsável por essa funcionalidade foi estruturado
 para que, futuramente, seja possível substituir o mecanismo de persistência por
 uma chamada REST sem alterar as chamadas no restante da aplicação.
 
+### Contexto e Regras de Formulário
+
+O `FormContextService` gerencia a lista de campos disponíveis, referências de componentes e
+as regras de layout de cada formulário. Ele suporta múltiplos contextos, permitindo
+compartilhar regras entre formulários sem conflitos. Para verificar condições de
+visibilidade ou estilo, utilize as funções utilitárias em `form-rule.utils`.
+
 ## 📚 Documentação
 
 ### Guias Detalhados

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
@@ -51,4 +51,15 @@ describe('PraxisDynamicForm', () => {
     expect(button).toBeTruthy();
   });
 
+  it('emite formReady após construir o formulário', async () => {
+    const schema = [{ name: 'nome', controlType: 'input' }];
+    crudService.getSchema.and.returnValue(of(schema as any));
+    const readySpy = jasmine.createSpy('formReady');
+    component.formReady.subscribe(readySpy);
+    component.resourcePath = 'usuarios';
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(readySpy).toHaveBeenCalled();
+  });
+
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
@@ -5,6 +5,7 @@ import {
   EventEmitter,
   OnChanges,
   OnDestroy,
+  OnInit,
   SimpleChanges,
   ChangeDetectorRef
 } from '@angular/core';
@@ -18,7 +19,10 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GenericCrudService, FieldMetadata, mapFieldDefinitionsToMetadata } from '@praxis/core';
 import { DynamicFieldLoaderDirective } from '@praxis/dynamic-fields';
 import { FormConfig } from './models/form-config.model';
-import { FormSubmitEvent } from './models/form-events.model';
+import { FormLayout } from './models/form-layout.model';
+import { FormSubmitEvent, FormReadyEvent, FormValueChangeEvent } from './models/form-events.model';
+import { FormLayoutService } from './services/form-layout.service';
+import { FormContextService } from './services/form-context.service';
 
 @Component({
   selector: 'praxis-dynamic-form',
@@ -54,19 +58,25 @@ import { FormSubmitEvent } from './models/form-events.model';
   `,
   styles: [`:host{display:block;}`]
 })
-export class PraxisDynamicForm implements OnChanges, OnDestroy {
+export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
   @Input() resourcePath?: string;
   @Input() resourceId?: string | number;
   @Input() mode: 'create' | 'edit' | 'view' = 'create';
   @Input() config: FormConfig = { sections: [] };
   /** Shows the configuration editor button */
   @Input() editModeEnabled = false;
+  /** Identifier for persisting layouts */
+  @Input() formId?: string;
+  /** Optional layout to use instead of generated one */
+  @Input() layout?: FormLayout;
 
 
   @Output() formSubmit = new EventEmitter<FormSubmitEvent>();
   @Output() formCancel = new EventEmitter<void>();
   @Output() formReset = new EventEmitter<void>();
   @Output() configChange = new EventEmitter<FormConfig>();
+  @Output() formReady = new EventEmitter<FormReadyEvent>();
+  @Output() valueChange = new EventEmitter<FormValueChangeEvent>();
 
   form: FormGroup = this.fb.group({});
   private fieldMetadata: FieldMetadata[] = [];
@@ -74,8 +84,16 @@ export class PraxisDynamicForm implements OnChanges, OnDestroy {
   constructor(
     private crud: GenericCrudService<any>,
     private fb: FormBuilder,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private layoutService: FormLayoutService,
+    private contextService: FormContextService
   ) {}
+
+  ngOnInit(): void {
+    if (!this.layout && this.formId) {
+      this.layout = this.layoutService.loadLayout(this.formId) || undefined;
+    }
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['resourcePath'] && this.resourcePath) {
@@ -113,6 +131,30 @@ export class PraxisDynamicForm implements OnChanges, OnDestroy {
       controls[field.name] = [field.defaultValue ?? null, validators];
     }
     this.form = this.fb.group(controls);
+
+    this.contextService.setAvailableFields(this.fieldMetadata);
+    if (this.layout?.formRules) {
+      this.contextService.setFormRules(this.layout.formRules);
+    }
+
+    this.form.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe(values => {
+        this.valueChange.emit({
+          formData: values,
+          changedFields: Object.keys(values),
+          isValid: this.form.valid,
+          entityId: this.resourceId ?? undefined
+        });
+      });
+
+    this.formReady.emit({
+      formGroup: this.form,
+      fieldsMetadata: this.fieldMetadata,
+      layout: this.layout,
+      hasEntity: this.resourceId != null,
+      entityId: this.resourceId ?? undefined
+    });
   }
 
   getColumnFields(column: { fields: string[] }): FieldMetadata[] {
@@ -132,6 +174,9 @@ export class PraxisDynamicForm implements OnChanges, OnDestroy {
 
   openConfigEditor(): void {
     this.configChange.emit(this.config);
+    if (this.formId && this.layout) {
+      this.layoutService.saveLayout(this.formId, this.layout);
+    }
   }
 
   ngOnDestroy(): void {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-context.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-context.service.spec.ts
@@ -1,0 +1,31 @@
+import { FormContextService } from './form-context.service';
+import { FormLayoutRule } from '../models/form-layout.model';
+
+describe('FormContextService', () => {
+  let service: FormContextService;
+
+  beforeEach(() => {
+    service = new FormContextService();
+  });
+
+  it('should register and retrieve field components', () => {
+    const componentRef = { id: 1 } as any;
+    service.registerFieldComponent('name', componentRef);
+    expect(service.getFieldComponent('name')).toBe(componentRef);
+    service.unregisterFieldComponent('name');
+    expect(service.getFieldComponent('name')).toBeNull();
+  });
+
+  it('should store and retrieve form rules', () => {
+    const rule: FormLayoutRule = {
+      id: '1',
+      name: 'r',
+      context: 'visibility',
+      targetFields: ['name'],
+      effect: { condition: null }
+    };
+    service.setFormRules([rule]);
+    expect(service.getFormRuleById('1')).toEqual(rule);
+    expect(service.getFormRulesByContext('visibility')).toEqual([rule]);
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-context.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-context.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { FieldMetadata } from '@praxis/core';
+import { FormLayoutRule, FormRuleContext } from '../models/form-layout.model';
+
+@Injectable({ providedIn: 'root' })
+export class FormContextService {
+  private fieldsByContext = new Map<string, BehaviorSubject<FieldMetadata[]>>();
+  private componentsByContext = new Map<string, Map<string, any>>();
+  private formRulesByContext = new Map<string, FormLayoutRule[]>();
+  private currentContext = new BehaviorSubject<string>('default');
+
+  getCurrentContext(): string {
+    return this.currentContext.value;
+  }
+
+  setContext(context: string): void {
+    this.currentContext.next(context);
+    if (!this.fieldsByContext.has(context)) {
+      this.fieldsByContext.set(context, new BehaviorSubject<FieldMetadata[]>([]));
+    }
+    if (!this.componentsByContext.has(context)) {
+      this.componentsByContext.set(context, new Map<string, any>());
+    }
+    if (!this.formRulesByContext.has(context)) {
+      this.formRulesByContext.set(context, []);
+    }
+  }
+
+  getAvailableFields$(): Observable<FieldMetadata[]> {
+    const ctx = this.currentContext.value;
+    if (!this.fieldsByContext.has(ctx)) {
+      this.fieldsByContext.set(ctx, new BehaviorSubject<FieldMetadata[]>([]));
+    }
+    return this.fieldsByContext.get(ctx)!.asObservable();
+  }
+
+  setAvailableFields(fields: FieldMetadata[]): void {
+    const ctx = this.currentContext.value;
+    if (!this.fieldsByContext.has(ctx)) {
+      this.fieldsByContext.set(ctx, new BehaviorSubject<FieldMetadata[]>([]));
+    }
+    this.fieldsByContext.get(ctx)!.next(fields);
+  }
+
+  registerFieldComponent(fieldName: string, component: any): void {
+    const ctx = this.currentContext.value;
+    if (!this.componentsByContext.has(ctx)) {
+      this.componentsByContext.set(ctx, new Map<string, any>());
+    }
+    this.componentsByContext.get(ctx)!.set(fieldName, component);
+  }
+
+  getFieldComponent(fieldName: string): any | null {
+    const ctx = this.currentContext.value;
+    return this.componentsByContext.get(ctx)?.get(fieldName) ?? null;
+  }
+
+  unregisterFieldComponent(fieldName: string): void {
+    const ctx = this.currentContext.value;
+    this.componentsByContext.get(ctx)?.delete(fieldName);
+  }
+
+  setFormRules(rules: FormLayoutRule[]): void {
+    this.formRulesByContext.set(this.currentContext.value, rules);
+  }
+
+  getFormRuleById(ruleId: string): FormLayoutRule | undefined {
+    const rules = this.formRulesByContext.get(this.currentContext.value) || [];
+    return rules.find(r => r.id === ruleId);
+  }
+
+  getFormRulesByContext(ruleContext: FormRuleContext): FormLayoutRule[] {
+    const rules = this.formRulesByContext.get(this.currentContext.value) || [];
+    return rules.filter(r => r.context === ruleContext);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/utils/form-rule.utils.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/utils/form-rule.utils.spec.ts
@@ -1,0 +1,19 @@
+import { SpecificationFactory } from '@praxis/specification';
+import { FormLayoutRule } from '../models/form-layout.model';
+import { isRuleSatisfied } from './form-rule.utils';
+
+describe('form rule utilities', () => {
+  it('evaluates rule conditions', () => {
+    const condition = SpecificationFactory.equals('status', 'active');
+    const rule: FormLayoutRule = {
+      id: '1',
+      name: 'activeVisibility',
+      context: 'visibility',
+      targetFields: ['status'],
+      effect: { condition }
+    };
+
+    expect(isRuleSatisfied(rule, { status: 'active' })).toBeTrue();
+    expect(isRuleSatisfied(rule, { status: 'inactive' })).toBeFalse();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/utils/form-rule.utils.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/utils/form-rule.utils.ts
@@ -1,0 +1,34 @@
+import { FormLayoutRule } from '../models/form-layout.model';
+
+/**
+ * Evaluates whether a rule's condition is satisfied for the given data.
+ * If no condition is defined, defaults to true.
+ */
+export function isRuleSatisfied(rule: FormLayoutRule, data: any): boolean {
+  if (!rule.effect.condition) {
+    return true;
+  }
+  try {
+    return rule.effect.condition.isSatisfiedBy(data);
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Applies all visibility rules to the provided data and
+ * returns a map of field name to visibility state.
+ */
+export function applyVisibilityRules(rules: FormLayoutRule[], data: any): Record<string, boolean> {
+  const result: Record<string, boolean> = {};
+  for (const rule of rules) {
+    if (rule.context !== 'visibility') {
+      continue;
+    }
+    const visible = isRuleSatisfied(rule, data);
+    for (const field of rule.targetFields) {
+      result[field] = visible;
+    }
+  }
+  return result;
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
@@ -5,3 +5,5 @@ export * from './lib/services/form-config.service';
 export * from './lib/services/form-layout.service';
 export type { FormLayoutStorage } from './lib/services/form-layout.service';
 export * from './lib/praxis-dynamic-form';
+export * from './lib/services/form-context.service';
+export * from './lib/utils/form-rule.utils';


### PR DESCRIPTION
## Summary
- extend `PraxisDynamicForm` with new inputs and events
- emit `formReady` and `valueChange`
- load and store layouts via `FormLayoutService`
- document context service usage
- cover new event emission in unit tests

## Testing
- `npx ng test praxis-dynamic-form --watch=false --browsers=ChromeHeadless` *(fails: Could not find the '@angular/build:karma' builder)*
- `npx ng build praxis-core` *(fails: Could not find the '@angular/build:ng-packagr' builder)*

------
https://chatgpt.com/codex/tasks/task_e_688a13fdda448328a642ed7c583c12c2