### PR TITLE
Fix option mapping in field definition mapper

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
@@ -51,7 +51,10 @@ export function mapFieldDefinitionToMetadata(field: FieldDefinition): FieldMetad
   }
 
   if (field.options) {
-    metadata.options = field.options;
+    metadata.options = field.options.map(opt => ({
+      value: opt.key,
+      text: opt.value,
+    }));
   }
 
   const validators: ValidatorOptions = {};


### PR DESCRIPTION
## Summary
- properly map backend field options to `FieldOption`

## Testing
- `npx ng test praxis-dynamic-form --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable to run)*
- `npx ng build praxis-core` *(not run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a636192b48328b237df119c831f55