### PR TITLE
Enable default row actions

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
@@ -197,12 +197,16 @@ export function createDefaultTableConfig(): TableConfig {
     },
     actions: {
       row: {
-        enabled: false,
+        enabled: true,
         position: 'end',
         width: '120px',
         display: 'icons',
         trigger: 'hover',
-        actions: []
+        actions: [
+          { id: 'view', label: 'Visualizar', icon: 'visibility', action: 'view' },
+          { id: 'edit', label: 'Editar', icon: 'edit', action: 'edit' },
+          { id: 'delete', label: 'Excluir', icon: 'delete', action: 'delete' }
+        ]
       },
       bulk: {
         enabled: false,

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -102,7 +102,7 @@ import {ColumnDataType} from './data-formatter/data-formatter-types';
   }`]
 })
 export class PraxisTable implements OnChanges, AfterViewInit, AfterContentInit, OnDestroy {
-  @Input() config: TableConfig = {columns: []};
+  @Input() config: TableConfig = createDefaultTableConfig();
   @Input() resourcePath?: string;
   @Input() filterCriteria: any = {};
   /** Controls toolbar visibility */


### PR DESCRIPTION
## Summary
- expose default row actions in the core default config
- use `createDefaultTableConfig()` as `PraxisTable`'s default config

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688abe856e0c8328b764ff4c505df8b9