### PR TITLE
Add hints for CRUD icon customization

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-config-editor.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-config-editor.ts
@@ -158,17 +158,19 @@ import { EducationalCardsService, TabCardKey } from './services/educational-card
                 tabKey="toolbar"
                 icon="handyman"
                 title="Ferramentas e Ações Personalizadas"
-                description="Adicione poder e praticidade à sua tabela com uma barra de ferramentas personalizada e ações específicas por linha."
+                description="Adicione poder e praticidade à sua tabela com uma barra de ferramentas personalizada e ações específicas por linha. Configure também os ícones das ações CRUD para maior clareza."
                 [benefits]="[
                   'Criar botões personalizados na barra superior',
                   'Configurar ações rápidas para cada linha (editar, excluir, etc.)',
+                  'Personalizar ícones das ações para fácil identificação',
                   'Ativar exportação para Excel e PDF',
                   'Adicionar botão Novo registro personalizado',
                   'Controlar visibilidade da barra de ferramentas'
                 ]"
                 [tips]="[
                   'Limite a 3-5 ações principais para evitar sobrecarga visual',
-                  'Use ícones intuitivos para ações comuns',
+                  'Use ícones intuitivos para ações comuns (ex: add, edit, delete)',
+                  'Consulte material.io/icons para os nomes corretos',
                   'Ações destrutivas (excluir) devem ter confirmação'
                 ]"
                 (cardHidden)="onCardHidden($event)">

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/toolbar-actions-editor/toolbar-actions-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/toolbar-actions-editor/toolbar-actions-editor.component.ts
@@ -366,10 +366,11 @@ export interface ToolbarActionsChange {
                         <input matInput [(ngModel)]="action.label" (ngModelChange)="updateRowActions()">
                       </mat-form-field>
                       
-                      <mat-form-field appearance="outline">
-                        <mat-label>Ícone</mat-label>
-                        <input matInput [(ngModel)]="action.icon" (ngModelChange)="updateRowActions()">
-                      </mat-form-field>
+                    <mat-form-field appearance="outline">
+                      <mat-label>Ícone</mat-label>
+                      <input matInput [(ngModel)]="action.icon" (ngModelChange)="updateRowActions()">
+                      <mat-hint>Nome do Material Icon (ex: add, edit, delete)</mat-hint>
+                    </mat-form-field>
                       
                       <mat-form-field appearance="outline">
                         <mat-label>Ação/Função</mat-label>
@@ -477,6 +478,7 @@ export interface ToolbarActionsChange {
                       <mat-form-field appearance="outline">
                         <mat-label>Ícone</mat-label>
                         <input matInput [(ngModel)]="action.icon" (ngModelChange)="updateBulkActions()">
+                        <mat-hint>Nome do Material Icon (ex: add, edit, delete)</mat-hint>
                       </mat-form-field>
                       
                       <mat-form-field appearance="outline">


### PR DESCRIPTION
## Summary
- highlight CRUD icon customization in toolbar tutorial card
- show Material Icon examples when editing row/bulk actions

## Testing
- `npm install --legacy-peer-deps` *(fails: unable to authenticate)*

------
https://chatgpt.com/codex/tasks/task_e_688abfc656608328bc68ce836f10041c