### PR TITLE
Add dependentes OpenAPI group

### DIFF
--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/OpenApiGroupsConfig.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/OpenApiGroupsConfig.java
@@ -67,4 +67,12 @@ public class OpenApiGroupsConfig {
                 .pathsToMatch(ApiRouteDefinitions.HR_FERIAS_AFASTAMENTOS_PATH + "/**")
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi configureHrDependentesDocumentation() {
+        return GroupedOpenApi.builder()
+                .group(ApiRouteDefinitions.HR_DEPENDENTES_GROUP)
+                .pathsToMatch(ApiRouteDefinitions.HR_DEPENDENTES_PATH + "/**")
+                .build();
+    }
 }


### PR DESCRIPTION
## Summary
- configure documentation group for `/api/human-resources/dependentes`

## Testing
- `../../mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688accf587448328825e82d1e7dd27cd