### PR TITLE
Add JSON utilities to FormConfigService

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-config.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-config.service.spec.ts
@@ -1,0 +1,36 @@
+import { FormConfigService } from './form-config.service';
+import { FormConfig } from '@praxis/core';
+
+describe('FormConfigService', () => {
+  let service: FormConfigService;
+
+  beforeEach(() => {
+    service = new FormConfigService();
+  });
+
+  it('should load config', () => {
+    const cfg: FormConfig = { sections: [{ id: 's1', rows: [] }] };
+    service.loadConfig(cfg);
+    expect(service.currentConfig).toEqual(cfg);
+  });
+
+  it('should update config', () => {
+    service.updateConfig({ sections: [{ id: 's2', rows: [] }] });
+    expect(service.currentConfig.sections[0].id).toBe('s2');
+  });
+
+  it('should export and import JSON', () => {
+    const cfg: FormConfig = { sections: [{ id: 's3', rows: [] }] };
+    service.loadConfig(cfg);
+    const json = service.exportToJson();
+    const other = new FormConfigService();
+    other.importFromJson(json);
+    expect(other.currentConfig).toEqual(cfg);
+  });
+
+  it('validateConfig should detect duplicates', () => {
+    const cfg: FormConfig = { sections: [{ id: 'dup', rows: [] }, { id: 'dup', rows: [] }] };
+    const errors = service.validateConfig(cfg);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-config.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-config.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import {
   FormConfig,
   FormConfigState,
@@ -15,6 +16,7 @@ export class FormConfigService {
   });
 
   readonly state$: Observable<FormConfigState> = this._state$.asObservable();
+  readonly config$: Observable<FormConfig> = this._state$.pipe(map(s => s.config));
 
   get currentConfig(): FormConfig {
     return this._state$.value.config;
@@ -37,5 +39,50 @@ export class FormConfigService {
 
   private updateState(state: Partial<FormConfigState>): void {
     this._state$.next({ ...this._state$.value, ...state });
+  }
+
+  /**
+   * Export the current configuration as a JSON string.
+   * @param pretty whether to pretty print the JSON
+   */
+  exportToJson(pretty = true): string {
+    return JSON.stringify(this.currentConfig, null, pretty ? 2 : undefined);
+  }
+
+  /**
+   * Load a configuration from a JSON string.
+   * Invalid JSON will emit an error on the service state.
+   */
+  importFromJson(json: string): void {
+    try {
+      const parsed = JSON.parse(json);
+      this.loadConfig(parsed);
+    } catch {
+      this.updateState({ error: 'Invalid JSON', isLoading: false });
+    }
+  }
+
+  /**
+   * Validate a configuration returning an array of error messages.
+   */
+  validateConfig(config: FormConfig): string[] {
+    const errors: string[] = [];
+    if (!isValidFormConfig(config)) {
+      errors.push('Invalid form configuration');
+      return errors;
+    }
+
+    const ids = new Set<string>();
+    for (const section of config.sections) {
+      if (!section.id) {
+        errors.push('Section id is required');
+      } else if (ids.has(section.id)) {
+        errors.push(`Duplicate section id: ${section.id}`);
+      } else {
+        ids.add(section.id);
+      }
+    }
+
+    return errors;
   }
 }


### PR DESCRIPTION
## Summary
- extend FormConfigService with config$ observable
- add JSON import/export helpers and validation
- add unit tests for FormConfigService

## Testing
- `npx ng test praxis-dynamic-form --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_688b4920efa483288dd053e3b779900d