### PR TITLE
Add dynamic form editor unit tests

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/json-config-editor/json-config-editor.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/json-config-editor/json-config-editor.component.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { JsonConfigEditorComponent } from './json-config-editor.component';
+import { FormConfig } from '@praxis/core';
+import { FormConfigService } from '../services/form-config.service';
+
+describe('JsonConfigEditorComponent', () => {
+  let component: JsonConfigEditorComponent;
+  let fixture: ComponentFixture<JsonConfigEditorComponent>;
+  let service: jasmine.SpyObj<FormConfigService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('FormConfigService', ['loadConfig', 'validateConfig'], { currentConfig: { sections: [] } });
+    service.validateConfig.and.returnValue([]);
+
+    await TestBed.configureTestingModule({
+      imports: [JsonConfigEditorComponent],
+      providers: [{ provide: FormConfigService, useValue: service }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(JsonConfigEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('initializes with config from service when none provided', () => {
+    expect(component.jsonText).toContain('sections');
+    expect(component.isValidJson).toBeTrue();
+  });
+
+  it('applyJsonChanges emits parsed config and calls service', () => {
+    const cfg: FormConfig = { sections: [{ id: 's1', rows: [] }] } as any;
+    component.jsonText = JSON.stringify(cfg);
+    const changeSpy = jasmine.createSpy('change');
+    const eventSpy = jasmine.createSpy('event');
+    component.configChange.subscribe(changeSpy);
+    component.editorEvent.subscribe(eventSpy);
+
+    component.applyJsonChanges();
+
+    expect(service.loadConfig).toHaveBeenCalledWith(cfg);
+    expect(changeSpy).toHaveBeenCalledWith(cfg);
+    expect(eventSpy).toHaveBeenCalled();
+  });
+
+  it('applyJsonChanges handles invalid JSON gracefully', () => {
+    const eventSpy = jasmine.createSpy('event');
+    component.editorEvent.subscribe(eventSpy);
+    component.jsonText = '{ invalid';
+
+    component.applyJsonChanges();
+
+    expect(service.loadConfig).not.toHaveBeenCalled();
+    expect(eventSpy).toHaveBeenCalled();
+    expect(component.isValidJson).toBeFalse();
+  });
+
+  it('formatJson prettifies JSON and emits event', () => {
+    const cfg = { sections: [] };
+    component.jsonText = JSON.stringify(cfg);
+    const eventSpy = jasmine.createSpy('event');
+    component.editorEvent.subscribe(eventSpy);
+
+    component.formatJson();
+
+    expect(component.jsonText).toContain('\n');
+    expect(eventSpy).toHaveBeenCalled();
+  });
+
+  it('updateJsonFromConfig updates text and validation state', () => {
+    const cfg: FormConfig = { sections: [{ id: 'n', rows: [] }] } as any;
+    component.updateJsonFromConfig(cfg);
+
+    expect(component.jsonText).toContain('"n"');
+    expect(component.isValidJson).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form-config-editor.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form-config-editor.spec.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PraxisDynamicFormConfigEditor } from './praxis-dynamic-form-config-editor';
+import { FormConfig, createDefaultFormConfig } from '@praxis/core';
+import { FormConfigService } from './services/form-config.service';
+import { JsonConfigEditorComponent } from './json-config-editor/json-config-editor.component';
+
+describe('PraxisDynamicFormConfigEditor', () => {
+  let component: PraxisDynamicFormConfigEditor;
+  let fixture: ComponentFixture<PraxisDynamicFormConfigEditor>;
+  let service: jasmine.SpyObj<FormConfigService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('FormConfigService', ['loadConfig'], { currentConfig: { sections: [] } });
+
+    await TestBed.configureTestingModule({
+      imports: [PraxisDynamicFormConfigEditor],
+      providers: [{ provide: FormConfigService, useValue: service }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PraxisDynamicFormConfigEditor);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('initializes editedConfig from service', () => {
+    expect(component.editedConfig).toEqual(service.currentConfig);
+  });
+
+  it('onReset sets default config and syncs editor', () => {
+    const editorSpy = jasmine.createSpyObj<JsonConfigEditorComponent>('JsonConfigEditorComponent', ['updateJsonFromConfig']);
+    component.jsonEditor = editorSpy;
+    component.editedConfig = { sections: [{ id: 'x', rows: [] }] } as any;
+
+    component.onReset();
+
+    expect(component.editedConfig).toEqual(createDefaultFormConfig());
+    expect(editorSpy.updateJsonFromConfig).toHaveBeenCalledWith(component.editedConfig);
+  });
+
+  it('onSave persists config via service and emits', () => {
+    const cfg: FormConfig = { sections: [{ id: 's1', rows: [] }] } as any;
+    component.editedConfig = cfg;
+    const saveSpy = jasmine.createSpy('saved');
+    component.configSaved.subscribe(saveSpy);
+
+    component.onSave();
+
+    expect(service.loadConfig).toHaveBeenCalledWith(cfg);
+    expect(saveSpy).toHaveBeenCalledWith(cfg);
+  });
+
+  it('onCancel emits cancelled', () => {
+    const cancelSpy = jasmine.createSpy('cancelled');
+    component.cancelled.subscribe(cancelSpy);
+    component.onCancel();
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+
+  it('onJsonConfigChange updates editedConfig', () => {
+    const newCfg: FormConfig = { sections: [{ id: 'new', rows: [] }] } as any;
+    component.onJsonConfigChange(newCfg);
+    expect(component.editedConfig).toEqual(newCfg);
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.config-editor.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.config-editor.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PraxisDynamicForm } from './praxis-dynamic-form';
+import { GenericCrudService, FormConfig } from '@praxis/core';
+import { DynamicFieldLoaderDirective } from '@praxis/dynamic-fields';
+import { FormLayoutService } from './services/form-layout.service';
+import { FormContextService } from './services/form-context.service';
+import { PraxisResizableWindowService } from '@praxis/core';
+import { of } from 'rxjs';
+
+describe('PraxisDynamicForm openConfigEditor', () => {
+  let component: PraxisDynamicForm;
+  let fixture: ComponentFixture<PraxisDynamicForm>;
+  let windowService: jasmine.SpyObj<PraxisResizableWindowService>;
+  let layoutService: jasmine.SpyObj<FormLayoutService>;
+
+  beforeEach(async () => {
+    const crud = jasmine.createSpyObj('GenericCrudService', ['configure', 'configureEndpoints', 'getSchema', 'get', 'create', 'update']);
+    layoutService = jasmine.createSpyObj('FormLayoutService', ['saveLayout', 'loadLayout']);
+    const contextService = jasmine.createSpyObj('FormContextService', ['setAvailableFields', 'setFormRules']);
+    windowService = jasmine.createSpyObj('PraxisResizableWindowService', ['open']);
+
+    await TestBed.configureTestingModule({
+      imports: [PraxisDynamicForm, DynamicFieldLoaderDirective],
+      providers: [
+        { provide: GenericCrudService, useValue: crud },
+        { provide: FormLayoutService, useValue: layoutService },
+        { provide: FormContextService, useValue: contextService },
+        { provide: PraxisResizableWindowService, useValue: windowService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PraxisDynamicForm);
+    component = fixture.componentInstance;
+    component.editModeEnabled = true;
+    component.formId = 'f1';
+    component.layout = { fieldsets: [] } as any;
+    component.config = { sections: [] };
+    fixture.detectChanges();
+  });
+
+  it('applies result when window closes with config', () => {
+    const returned: FormConfig = { sections: [{ id: 'n', rows: [] }] } as any;
+    windowService.open.and.returnValue({ closed: of(returned) } as any);
+
+    component.openConfigEditor();
+
+    expect(windowService.open).toHaveBeenCalled();
+    expect(component.config).toEqual(returned);
+    expect(layoutService.saveLayout).toHaveBeenCalledWith('f1', component.layout as any);
+  });
+
+  it('ignores close event without result', () => {
+    windowService.open.and.returnValue({ closed: of(null) } as any);
+    component.openConfigEditor();
+    expect(component.config.sections.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add JsonConfigEditorComponent tests
- add PraxisDynamicFormConfigEditor tests
- test openConfigEditor logic in PraxisDynamicForm

## Testing
- `npx ng test praxis-dynamic-form --watch=false` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_688b4d03b9c88328b9a4a6d619cf8b7c