### PR TITLE
feat(core): add generic config storage service

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/config-storage.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/config-storage.service.spec.ts
@@ -1,0 +1,22 @@
+import { LocalStorageConfigService } from './config-storage.service';
+
+describe('LocalStorageConfigService', () => {
+  let service: LocalStorageConfigService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    service = new LocalStorageConfigService();
+  });
+
+  it('should save and load configuration', () => {
+    service.saveConfig('key', { test: true });
+    const loaded = service.loadConfig<{ test: boolean }>('key');
+    expect(loaded).toEqual({ test: true });
+  });
+
+  it('should clear configuration', () => {
+    localStorage.setItem('key', JSON.stringify({ test: true }));
+    service.clearConfig('key');
+    expect(localStorage.getItem('key')).toBeNull();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/config-storage.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/config-storage.service.ts
@@ -1,0 +1,43 @@
+import { inject, Injectable, InjectionToken } from '@angular/core';
+
+export interface ConfigStorage {
+  loadConfig<T>(key: string): T | null;
+  saveConfig<T>(key: string, config: T): void;
+  clearConfig(key: string): void;
+}
+
+@Injectable({ providedIn: 'root' })
+export class LocalStorageConfigService implements ConfigStorage {
+  loadConfig<T>(key: string): T | null {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw ? (JSON.parse(raw) as T) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  saveConfig<T>(key: string, config: T): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(config));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  clearConfig(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export const CONFIG_STORAGE = new InjectionToken<ConfigStorage>(
+  'CONFIG_STORAGE',
+  {
+    providedIn: 'root',
+    factory: () => inject(LocalStorageConfigService),
+  },
+);

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
@@ -8,6 +8,7 @@ export * from './lib/praxis-core';
 export * from './lib/services/generic-crud.service';
 export * from './lib/services/schema-normalizer.service';
 export * from './lib/services/table-config.service';
+export * from './lib/services/config-storage.service';
 
 // Tokens
 export * from './lib/tokens/api-url.token';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-layout.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-layout.service.spec.ts
@@ -1,12 +1,23 @@
-import { FormLayoutService, LOCAL_STORAGE_FORM_LAYOUT_PROVIDER } from './form-layout.service';
-import { FormLayout } from '@praxis/core';
+import { FormLayoutService } from './form-layout.service';
+import {
+  FormLayout,
+  LocalStorageConfigService,
+  CONFIG_STORAGE,
+} from '@praxis/core';
+import { TestBed } from '@angular/core/testing';
 
 describe('FormLayoutService', () => {
   let service: FormLayoutService;
 
   beforeEach(() => {
     localStorage.clear();
-    service = new FormLayoutService();
+    TestBed.configureTestingModule({
+      providers: [
+        FormLayoutService,
+        { provide: CONFIG_STORAGE, useClass: LocalStorageConfigService },
+      ],
+    });
+    service = TestBed.inject(FormLayoutService);
   });
 
   it('should save and load layout using localStorage', () => {
@@ -15,5 +26,11 @@ describe('FormLayoutService', () => {
 
     const loaded = service.loadLayout('test-form');
     expect(loaded).toEqual(layout);
+  });
+
+  it('should clear layout from storage', () => {
+    localStorage.setItem('praxis-layout-test', JSON.stringify({}));
+    service.clearLayout('test');
+    expect(localStorage.getItem('praxis-layout-test')).toBeNull();
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-layout.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/services/form-layout.service.ts
@@ -1,36 +1,23 @@
-import { Injectable, InjectionToken, Inject, Optional } from '@angular/core';
-import { FormLayout } from '@praxis/core';
-
-export interface FormLayoutStorage {
-  load(formId: string): FormLayout | null;
-  save(formId: string, layout: FormLayout): void;
-}
-
-export const LOCAL_STORAGE_FORM_LAYOUT_PROVIDER: FormLayoutStorage = {
-  load(formId: string): FormLayout | null {
-    const raw = localStorage.getItem(`praxis-layout-${formId}`);
-    return raw ? (JSON.parse(raw) as FormLayout) : null;
-  },
-  save(formId: string, layout: FormLayout): void {
-    localStorage.setItem(`praxis-layout-${formId}`, JSON.stringify(layout));
-  }
-};
-
-export const FORM_LAYOUT_STORAGE = new InjectionToken<FormLayoutStorage>('FORM_LAYOUT_STORAGE');
+import { Injectable, Inject, Optional } from '@angular/core';
+import { FormLayout, ConfigStorage, CONFIG_STORAGE } from '@praxis/core';
 
 @Injectable({ providedIn: 'root' })
 export class FormLayoutService {
-  private provider: FormLayoutStorage;
-
-  constructor(@Optional() @Inject(FORM_LAYOUT_STORAGE) provider?: FormLayoutStorage) {
-    this.provider = provider ?? LOCAL_STORAGE_FORM_LAYOUT_PROVIDER;
-  }
+  constructor(
+    @Optional() @Inject(CONFIG_STORAGE) private storage?: ConfigStorage,
+  ) {}
 
   loadLayout(formId: string): FormLayout | null {
-    return this.provider.load(formId);
+    return (
+      this.storage?.loadConfig<FormLayout>(`praxis-layout-${formId}`) ?? null
+    );
   }
 
   saveLayout(formId: string, layout: FormLayout): void {
-    this.provider.save(formId, layout);
+    this.storage?.saveConfig(`praxis-layout-${formId}`, layout);
+  }
+
+  clearLayout(formId: string): void {
+    this.storage?.clearConfig(`praxis-layout-${formId}`);
   }
 }


### PR DESCRIPTION
## Summary
- introduce `ConfigStorage` interface with a `LocalStorageConfigService`
- expose new service through praxis-core public API
- refactor `FormLayoutService` to use `CONFIG_STORAGE`
- update tests for new storage service

## Testing
- `npx ng test praxis-core --watch=false --browsers=ChromeHeadless` *(failed: could not determine executable)*
- `npx ng test praxis-dynamic-form --watch=false --browsers=ChromeHeadless` *(failed: build errors)*
- `npx ng build praxis-core` *(failed: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bfb4148c88328853c308f96e862d0