### PR TITLE
Fix duplicate members in dynamic fields

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/base-dynamic-field.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/base-dynamic-field.component.ts
@@ -127,7 +127,6 @@ export abstract class BaseDynamicFieldComponent<
   protected readonly renderer = inject(Renderer2);
   private readonly destroyRef = inject(DestroyRef);
 
-
   /** Re-exposed signals and helpers from the base service */
   protected readonly metadata = this.base.metadataSignal();
   protected readonly componentId = this.base.componentIdSignal();
@@ -136,12 +135,6 @@ export abstract class BaseDynamicFieldComponent<
   readonly isDebugMode = () => this.base.getIsDebugMode();
   protected readonly log = (level: LogLevel, message: string, data?: any) =>
     this.base.logMessage(level, message, data);
-
-  /** Re-exposed signals from the base service */
-  protected readonly metadata = this.base.metadata;
-  protected readonly componentId = this.base.componentId;
-  protected readonly log = this.base.log.bind(this.base);
-
 
   /** Proxy to BaseDynamicComponent helper */
   protected takeUntilDestroyed() {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/dynamic-component.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/dynamic-component.service.ts
@@ -6,9 +6,6 @@ import {
   LogLevel,
 } from '../base/base-dynamic.component';
 
-import { BaseDynamicComponent } from '../base/base-dynamic.component';
-
-
 import { ComponentMetadata } from '@praxis/core';
 
 /**


### PR DESCRIPTION
## Summary
- remove duplicate property definitions in `BaseDynamicFieldComponent`
- tidy dynamic-component service imports

## Testing
- `npx ng build praxis-core` *(fails: Cannot destructure property 'pos')*
- `npx ng test praxis-dynamic-form --watch=false --browsers=ChromeHeadless` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_688c1e7bd8e483289094260fc3873d17