### PR TITLE
Add minimal text input component

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/text-input/text-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/text-input/text-input.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { TextInputComponent } from './text-input.component';
+
+describe('TextInputComponent', () => {
+  let component: TextInputComponent;
+  let fixture: ComponentFixture<TextInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TextInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TextInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({ label: 'Name', required: true });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input = fixture.nativeElement.querySelector('input');
+    input.value = 'test';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('test');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/text-input/text-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/text-input/text-input.component.ts
@@ -1,0 +1,57 @@
+import { Component, forwardRef, signal } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'pdx-text-input',
+  standalone: true,
+  template: `
+    <label>
+      {{ metadata()?.label || 'Text' }}
+      <input
+        type="text"
+        [value]="value"
+        [required]="metadata()?.required || false"
+        (input)="onInput($event)"
+      />
+    </label>
+  `,
+  imports: [CommonModule],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TextInputComponent),
+      multi: true,
+    },
+  ],
+})
+export class TextInputComponent implements ControlValueAccessor {
+  value = '';
+  metadata = signal<any>(null);
+
+  private onChange = (value: any) => {};
+  private onTouched = () => {};
+
+  onInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.value = target.value;
+    this.onChange(this.value);
+    this.onTouched();
+  }
+
+  writeValue(value: any): void {
+    this.value = value ?? '';
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    // no-op for now
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
@@ -30,6 +30,7 @@ export * from './lib/components/material-slider/material-slider.component';
 export * from './lib/components/material-textarea/material-textarea.component';
 export * from './lib/components/material-timepicker/material-timepicker.component';
 export * from './lib/components/material-toggle/material-toggle.component';
+export * from './lib/components/text-input/text-input.component';
 
 // Services
 export * from './lib/services/action-resolver.service';


### PR DESCRIPTION
## Summary
- add `TextInputComponent` with minimal functionality
- export new component via public API
- add unit tests for `TextInputComponent`

## Testing
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688ca3a439808328b38cbd012cb4f8d0