### PR TITLE
Fix config editor window for dynamic form

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/layout-editor/form-layout-editor.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/layout-editor/form-layout-editor.component.spec.ts
@@ -9,7 +9,7 @@ describe('FormLayoutEditorComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FormLayoutEditorComponent, DragDropModule]
+      imports: [FormLayoutEditorComponent, DragDropModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(FormLayoutEditorComponent);
@@ -20,8 +20,8 @@ describe('FormLayoutEditorComponent', () => {
     const layout: FormLayout = {
       fieldsets: [
         { id: 'fs1', title: 'FS1', orientation: 'vertical', rows: [] },
-        { id: 'fs2', title: 'FS2', orientation: 'vertical', rows: [] }
-      ]
+        { id: 'fs2', title: 'FS2', orientation: 'vertical', rows: [] },
+      ],
     } as any;
     component.layout = layout;
     fixture.detectChanges();
@@ -33,8 +33,8 @@ describe('FormLayoutEditorComponent', () => {
       previousContainer: { data: layout.fieldsets } as any,
       item: {} as any,
       isPointerOverContainer: true,
-      distance: { x: 0, y: 0 }
-    });
+      distance: { x: 0, y: 0 },
+    } as any);
 
     expect(component.layout.fieldsets[0].id).toBe('fs2');
   });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form-config-editor.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form-config-editor.spec.ts
@@ -10,11 +10,13 @@ describe('PraxisDynamicFormConfigEditor', () => {
   let service: jasmine.SpyObj<FormConfigService>;
 
   beforeEach(async () => {
-    service = jasmine.createSpyObj('FormConfigService', ['loadConfig'], { currentConfig: { sections: [] } });
+    service = jasmine.createSpyObj('FormConfigService', ['loadConfig'], {
+      currentConfig: { sections: [] },
+    });
 
     await TestBed.configureTestingModule({
       imports: [PraxisDynamicFormConfigEditor],
-      providers: [{ provide: FormConfigService, useValue: service }]
+      providers: [{ provide: FormConfigService, useValue: service }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PraxisDynamicFormConfigEditor);
@@ -27,14 +29,19 @@ describe('PraxisDynamicFormConfigEditor', () => {
   });
 
   it('onReset sets default config and syncs editor', () => {
-    const editorSpy = jasmine.createSpyObj<JsonConfigEditorComponent>('JsonConfigEditorComponent', ['updateJsonFromConfig']);
+    const editorSpy = jasmine.createSpyObj<JsonConfigEditorComponent>(
+      'JsonConfigEditorComponent',
+      ['updateJsonFromConfig'],
+    );
     component.jsonEditor = editorSpy;
     component.editedConfig = { sections: [{ id: 'x', rows: [] }] } as any;
 
     component.onReset();
 
     expect(component.editedConfig).toEqual(createDefaultFormConfig());
-    expect(editorSpy.updateJsonFromConfig).toHaveBeenCalledWith(component.editedConfig);
+    expect(editorSpy.updateJsonFromConfig).toHaveBeenCalledWith(
+      component.editedConfig,
+    );
   });
 
   it('onSave persists config via service and emits', () => {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.config-editor.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.config-editor.spec.ts
@@ -14,10 +14,25 @@ describe('PraxisDynamicForm openConfigEditor', () => {
   let layoutService: jasmine.SpyObj<FormLayoutService>;
 
   beforeEach(async () => {
-    const crud = jasmine.createSpyObj('GenericCrudService', ['configure', 'configureEndpoints', 'getSchema', 'get', 'create', 'update']);
-    layoutService = jasmine.createSpyObj('FormLayoutService', ['saveLayout', 'loadLayout']);
-    const contextService = jasmine.createSpyObj('FormContextService', ['setAvailableFields', 'setFormRules']);
-    windowService = jasmine.createSpyObj('PraxisResizableWindowService', ['open']);
+    const crud = jasmine.createSpyObj('GenericCrudService', [
+      'configure',
+      'configureEndpoints',
+      'getSchema',
+      'get',
+      'create',
+      'update',
+    ]);
+    layoutService = jasmine.createSpyObj('FormLayoutService', [
+      'saveLayout',
+      'loadLayout',
+    ]);
+    const contextService = jasmine.createSpyObj('FormContextService', [
+      'setAvailableFields',
+      'setFormRules',
+    ]);
+    windowService = jasmine.createSpyObj('PraxisResizableWindowService', [
+      'open',
+    ]);
 
     await TestBed.configureTestingModule({
       imports: [PraxisDynamicForm, DynamicFieldLoaderDirective],
@@ -25,8 +40,8 @@ describe('PraxisDynamicForm openConfigEditor', () => {
         { provide: GenericCrudService, useValue: crud },
         { provide: FormLayoutService, useValue: layoutService },
         { provide: FormContextService, useValue: contextService },
-        { provide: PraxisResizableWindowService, useValue: windowService }
-      ]
+        { provide: PraxisResizableWindowService, useValue: windowService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PraxisDynamicForm);
@@ -46,7 +61,10 @@ describe('PraxisDynamicForm openConfigEditor', () => {
 
     expect(windowService.open).toHaveBeenCalled();
     expect(component.config).toEqual(returned);
-    expect(layoutService.saveLayout).toHaveBeenCalledWith('f1', component.layout as any);
+    expect(layoutService.saveLayout).toHaveBeenCalledWith(
+      'f1',
+      component.layout as any,
+    );
   });
 
   it('ignores close event without result', () => {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
@@ -10,11 +10,18 @@ describe('PraxisDynamicForm', () => {
   let crudService: jasmine.SpyObj<GenericCrudService<any>>;
 
   beforeEach(async () => {
-    crudService = jasmine.createSpyObj('GenericCrudService', ['configure', 'configureEndpoints', 'getSchema', 'get', 'create', 'update']);
+    crudService = jasmine.createSpyObj('GenericCrudService', [
+      'configure',
+      'configureEndpoints',
+      'getSchema',
+      'getById',
+      'create',
+      'update',
+    ]);
 
     await TestBed.configureTestingModule({
       imports: [PraxisDynamicForm, DynamicFieldLoaderDirective],
-      providers: [{ provide: GenericCrudService, useValue: crudService }]
+      providers: [{ provide: GenericCrudService, useValue: crudService }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PraxisDynamicForm);
@@ -31,15 +38,27 @@ describe('PraxisDynamicForm', () => {
   });
 
   it('altera para modo edit ao receber resourceId', () => {
-    crudService.get.and.returnValue(of({ id: 1, nome: 'Teste' }));
+    crudService.getById.and.returnValue(of({ id: 1, nome: 'Teste' }));
     component.mode = 'edit';
     component.resourceId = 1;
     component.resourcePath = 'usuarios';
     crudService.getSchema.and.returnValue(of([]));
-    component.ngOnChanges({ resourcePath: { currentValue: 'usuarios', previousValue: undefined, firstChange: true, isFirstChange: () => true }, resourceId: { currentValue: 1, previousValue: undefined, firstChange: true, isFirstChange: () => true } });
-    expect(crudService.get).toHaveBeenCalled();
+    component.ngOnChanges({
+      resourcePath: {
+        currentValue: 'usuarios',
+        previousValue: undefined,
+        firstChange: true,
+        isFirstChange: () => true,
+      },
+      resourceId: {
+        currentValue: 1,
+        previousValue: undefined,
+        firstChange: true,
+        isFirstChange: () => true,
+      },
+    });
+    expect(crudService.getById).toHaveBeenCalled();
   });
-
 
   it('mostra botão de edição quando editModeEnabled é verdadeiro', () => {
     const schema = [{ name: 'nome', controlType: 'input' }];
@@ -47,7 +66,9 @@ describe('PraxisDynamicForm', () => {
     component.resourcePath = 'usuarios';
     component.editModeEnabled = true;
     fixture.detectChanges();
-    const button = fixture.nativeElement.querySelector('button[mat-icon-button]');
+    const button = fixture.nativeElement.querySelector(
+      'button[mat-icon-button]',
+    );
     expect(button).toBeTruthy();
   });
 
@@ -72,11 +93,12 @@ describe('PraxisDynamicForm', () => {
     crudService.create.and.returnValue(of({ id: 1 } as any));
     const submitSpy = jasmine.createSpy('submit');
     component.formSubmit.subscribe(submitSpy);
-    component['fieldMetadata'] = [{ name: 'nome', controlType: 'input' } as any];
+    component['fieldMetadata'] = [
+      { name: 'nome', controlType: 'input' } as any,
+    ];
     (component as any).buildForm();
     component.form.setValue({ nome: 'Teste' });
     component.onSubmit();
     expect(submitSpy).toHaveBeenCalled();
   });
-
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
@@ -7,19 +7,39 @@ import {
   OnDestroy,
   OnInit,
   SimpleChanges,
-  ChangeDetectorRef
+  ChangeDetectorRef,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { GenericCrudService, FieldMetadata, mapFieldDefinitionsToMetadata, EndpointConfig } from '@praxis/core';
+import {
+  GenericCrudService,
+  FieldMetadata,
+  mapFieldDefinitionsToMetadata,
+  EndpointConfig,
+} from '@praxis/core';
 import { DynamicFieldLoaderDirective } from '@praxis/dynamic-fields';
-import { FormConfig, FormLayout, FormSubmitEvent, FormReadyEvent, FormValueChangeEvent, FormSection, FormRow, FormColumn, PraxisResizableWindowService } from '@praxis/core';
+import {
+  FormConfig,
+  FormLayout,
+  FormSubmitEvent,
+  FormReadyEvent,
+  FormValueChangeEvent,
+  FormSection,
+  FormRow,
+  FormColumn,
+  PraxisResizableWindowService,
+} from '@praxis/core';
 import { FormLayoutService } from './services/form-layout.service';
 import { FormContextService } from './services/form-context.service';
 import { PraxisDynamicFormConfigEditor } from './praxis-dynamic-form-config-editor';
@@ -28,9 +48,19 @@ import { PraxisDynamicFormConfigEditor } from './praxis-dynamic-form-config-edit
   selector: 'praxis-dynamic-form',
   standalone: true,
   providers: [GenericCrudService],
-  imports: [CommonModule, ReactiveFormsModule, DynamicFieldLoaderDirective, MatIconModule, MatButtonModule],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    DynamicFieldLoaderDirective,
+    MatIconModule,
+    MatButtonModule,
+  ],
   template: `
-    <form [formGroup]="form" (ngSubmit)="onSubmit()" class="praxis-dynamic-form">
+    <form
+      [formGroup]="form"
+      (ngSubmit)="onSubmit()"
+      class="praxis-dynamic-form"
+    >
       <ng-container *ngFor="let section of config.sections">
         <div class="form-section">
           <h3 *ngIf="section.title">{{ section.title }}</h3>
@@ -39,24 +69,41 @@ import { PraxisDynamicFormConfigEditor } from './praxis-dynamic-form-config-edit
               <ng-container
                 dynamicFieldLoader
                 [fields]="getColumnFields(column)"
-                [formGroup]="form">
+                [formGroup]="form"
+              >
               </ng-container>
             </div>
           </div>
         </div>
       </ng-container>
       <div class="form-actions">
-        <button type="submit" mat-raised-button color="primary" [disabled]="form.invalid">
+        <button
+          type="submit"
+          mat-raised-button
+          color="primary"
+          [disabled]="form.invalid"
+        >
           {{ mode === 'edit' ? 'Atualizar' : 'Criar' }}
         </button>
 
-        <button *ngIf="editModeEnabled" type="button" mat-icon-button (click)="openConfigEditor()">
+        <button
+          *ngIf="editModeEnabled"
+          type="button"
+          mat-icon-button
+          (click)="openConfigEditor()"
+        >
           <mat-icon>settings</mat-icon>
         </button>
       </div>
     </form>
   `,
-  styles: [`:host{display:block;}`]
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+    `,
+  ],
 })
 export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
   @Input() resourcePath?: string;
@@ -100,7 +147,8 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
     private fb: FormBuilder,
     private cdr: ChangeDetectorRef,
     private layoutService: FormLayoutService,
-    private contextService: FormContextService
+    private contextService: FormContextService,
+    private windowService: PraxisResizableWindowService,
   ) {
     this.form = this.fb.group({});
   }
@@ -125,31 +173,47 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
   }
 
   private loadSchema(): void {
-    this.crud.getSchema().pipe(takeUntil(this.destroy$)).subscribe(defs => {
-      this.fieldMetadata = mapFieldDefinitionsToMetadata(defs);
-      this.buildForm();
-      if (this.pendingEntityId != null) {
-        this.loadEntity();
-      }
-      this.cdr.detectChanges();
-    });
+    this.crud
+      .getSchema()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((defs) => {
+        this.fieldMetadata = mapFieldDefinitionsToMetadata(defs);
+        this.buildForm();
+        if (this.pendingEntityId != null) {
+          this.loadEntity();
+        }
+        this.cdr.detectChanges();
+      });
   }
 
   private loadEntity(): void {
-    if (this.pendingEntityId == null) { return; }
-    this.crud.getById(this.pendingEntityId).pipe(takeUntil(this.destroy$)).subscribe((data: any) => {
-      this.form.patchValue(data);
-    });
+    if (this.pendingEntityId == null) {
+      return;
+    }
+    this.crud
+      .getById(this.pendingEntityId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((data: any) => {
+        this.form.patchValue(data);
+      });
   }
 
   private buildForm(): void {
     const controls: any = {};
     for (const field of this.fieldMetadata) {
       const validators = [];
-      if (field.required) { validators.push(Validators.required); }
-      if (field.validators?.minLength) { validators.push(Validators.minLength(field.validators.minLength)); }
-      if (field.validators?.maxLength) { validators.push(Validators.maxLength(field.validators.maxLength)); }
-      if (field.validators?.pattern) { validators.push(Validators.pattern(field.validators.pattern)); }
+      if (field.required) {
+        validators.push(Validators.required);
+      }
+      if (field.validators?.minLength) {
+        validators.push(Validators.minLength(field.validators.minLength));
+      }
+      if (field.validators?.maxLength) {
+        validators.push(Validators.maxLength(field.validators.maxLength));
+      }
+      if (field.validators?.pattern) {
+        validators.push(Validators.pattern(field.validators.pattern));
+      }
       controls[field.name] = [field.defaultValue ?? null, validators];
     }
     this.form = this.fb.group(controls);
@@ -164,12 +228,12 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
 
     this.form.valueChanges
       .pipe(takeUntil(this.destroy$))
-      .subscribe(values => {
+      .subscribe((values) => {
         this.valueChange.emit({
           formData: values,
           changedFields: Object.keys(values),
           isValid: this.form.valid,
-          entityId: this.resourceId ?? undefined
+          entityId: this.resourceId ?? undefined,
         });
       });
 
@@ -178,7 +242,7 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
       fieldsMetadata: this.fieldMetadata,
       layout: this.layout,
       hasEntity: this.resourceId != null,
-      entityId: this.resourceId ?? undefined
+      entityId: this.resourceId ?? undefined,
     });
   }
 
@@ -196,16 +260,19 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
    * Generates a FormConfig from FieldMetadata array
    * Groups fields by their 'group' property or creates a single default section
    */
-  private generateFormConfigFromMetadata(fields: FieldMetadata[], options?: {
-    fieldsPerRow?: number;
-    defaultSectionTitle?: string;
-  }): FormConfig {
+  private generateFormConfigFromMetadata(
+    fields: FieldMetadata[],
+    options?: {
+      fieldsPerRow?: number;
+      defaultSectionTitle?: string;
+    },
+  ): FormConfig {
     const fieldsPerRow = options?.fieldsPerRow ?? 2;
     const defaultSectionTitle = options?.defaultSectionTitle ?? 'Informações';
 
     // Group fields by their 'group' property
     const groupedFields = new Map<string, FieldMetadata[]>();
-    
+
     for (const field of fields) {
       const groupName = field.group || 'default';
       if (!groupedFields.has(groupName)) {
@@ -221,16 +288,17 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
 
     // Create sections from grouped fields
     const sections: FormSection[] = [];
-    
+
     groupedFields.forEach((groupFields, groupName) => {
-      const sectionTitle = groupName === 'default' 
-        ? defaultSectionTitle 
-        : this.capitalizeFirstLetter(groupName);
+      const sectionTitle =
+        groupName === 'default'
+          ? defaultSectionTitle
+          : this.capitalizeFirstLetter(groupName);
 
       sections.push({
         id: groupName,
         title: sectionTitle,
-        rows: this.createRowsFromFields(groupFields, fieldsPerRow)
+        rows: this.createRowsFromFields(groupFields, fieldsPerRow),
       });
     });
 
@@ -240,18 +308,21 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
   /**
    * Creates rows from a list of fields, organizing them into columns
    */
-  private createRowsFromFields(fields: FieldMetadata[], fieldsPerRow: number = 2): FormRow[] {
+  private createRowsFromFields(
+    fields: FieldMetadata[],
+    fieldsPerRow: number = 2,
+  ): FormRow[] {
     const rows: FormRow[] = [];
-    
+
     for (let i = 0; i < fields.length; i += fieldsPerRow) {
       const rowFields = fields.slice(i, i + fieldsPerRow);
-      const columns: FormColumn[] = rowFields.map(field => ({
-        fields: [field.name]
+      const columns: FormColumn[] = rowFields.map((field) => ({
+        fields: [field.name],
       }));
-      
+
       rows.push({ columns });
     }
-    
+
     return rows;
   }
 
@@ -263,32 +334,78 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
   }
 
   getColumnFields(column: { fields: string[] }): FieldMetadata[] {
-    return this.fieldMetadata.filter(f => column.fields.includes(f.name));
+    return this.fieldMetadata.filter((f) => column.fields.includes(f.name));
   }
 
   onSubmit(): void {
-    if (this.form.invalid) { return; }
+    if (this.form.invalid) {
+      return;
+    }
     const formData = this.form.value;
-    const operation: 'create' | 'update' = this.mode === 'edit' && this.resourceId != null ? 'update' : 'create';
+    const operation: 'create' | 'update' =
+      this.mode === 'edit' && this.resourceId != null ? 'update' : 'create';
 
-    this.formSubmit.emit({ stage: 'before', formData, isValid: true, operation, entityId: this.resourceId ?? undefined });
+    this.formSubmit.emit({
+      stage: 'before',
+      formData,
+      isValid: true,
+      operation,
+      entityId: this.resourceId ?? undefined,
+    });
 
-    const req$ = operation === 'update'
-      ? this.crud.update(this.resourceId!, formData)
-      : this.crud.create(formData);
+    const req$ =
+      operation === 'update'
+        ? this.crud.update(this.resourceId!, formData)
+        : this.crud.create(formData);
 
     req$.pipe(takeUntil(this.destroy$)).subscribe({
-      next: result => {
-        this.formSubmit.emit({ stage: 'after', formData, isValid: true, operation, entityId: this.resourceId ?? undefined, result });
+      next: (result) => {
+        this.formSubmit.emit({
+          stage: 'after',
+          formData,
+          isValid: true,
+          operation,
+          entityId: this.resourceId ?? undefined,
+          result,
+        });
       },
-      error: error => {
-        this.formSubmit.emit({ stage: 'error', formData, isValid: false, operation, entityId: this.resourceId ?? undefined, error });
-      }
+      error: (error) => {
+        this.formSubmit.emit({
+          stage: 'error',
+          formData,
+          isValid: false,
+          operation,
+          entityId: this.resourceId ?? undefined,
+          error,
+        });
+      },
     });
   }
 
   openConfigEditor(): void {
-    this.configChange.emit(this.config);
+    const configCopy = JSON.parse(JSON.stringify(this.config)) as FormConfig;
+
+    const ref = this.windowService.open({
+      title: 'Configuração do Formulário Dinâmico',
+      contentComponent: PraxisDynamicFormConfigEditor,
+      data: configCopy,
+      initialWidth: '90vw',
+      initialHeight: '90vh',
+      minWidth: '320px',
+      minHeight: '600px',
+      autoCenterAfterResize: false,
+      enableTouch: true,
+      disableResize: false,
+      disableMaximize: false,
+    });
+
+    ref.closed.pipe(takeUntil(this.destroy$)).subscribe((result) => {
+      if (result) {
+        this.config = result as FormConfig;
+        this.configChange.emit(this.config);
+      }
+    });
+
     if (this.formId && this.layout) {
       this.layoutService.saveLayout(this.formId, this.layout);
     }


### PR DESCRIPTION
## Summary
- use window service to open the config editor
- update tests to match new functionality
- fix failing specs for layout editor and dynamic form
- format config editor tests

## Testing
- `npx ng test praxis-dynamic-form --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688cd9782cfc8328b2608f09d27f45a4