### PR TITLE
feat(dynamic-fields): add url and week input components

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/metadata/field-control-type.constants.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/metadata/field-control-type.constants.ts
@@ -27,13 +27,16 @@ export const FieldControlType = {
   COLOR_GRADIENT: 'colorGradient',
   COLOR_PALETTE: 'colorPalette',
   COLOR_PICKER: 'colorPicker',
+  COLOR_INPUT: 'color',
   CONTEXT_MENU: 'contextMenu',
   CONVERSATIONAL_UI: 'conversationalUI',
   CURRENCY_INPUT: 'currency',
+  DATE_INPUT: 'dateInput',
   DATE_PICKER: 'date',
   DATE_RANGE: 'dateRange',
   DATE_TIME_PICKER: 'dateTime',
   DATE_TIME_RANGE: 'dateTimeRange',
+  DATETIME_LOCAL_INPUT: 'dateTimeLocal',
   DIALOG: 'dialog',
   DRAWER: 'drawer',
   DROP_DOWN_TREE: 'dropDownTree',
@@ -52,6 +55,7 @@ export const FieldControlType = {
   LIST_VIEW: 'listView',
   MAP: 'map',
   MASKED_TEXT_BOX: 'maskedTextBox',
+  MONTH_INPUT: 'month',
   MULTI_COLUMN_COMBO_BOX: 'multiColumnComboBox',
   MULTI_SELECT: 'multiSelect',
   MULTI_SELECT_TREE: 'multiSelectTree',
@@ -74,6 +78,7 @@ export const FieldControlType = {
   RICH_TEXT_EDITOR: 'richTextEditor',
   RIPPLE: 'ripple',
   SCROLL_VIEW: 'scrollView',
+  SEARCH_INPUT: 'search',
   SELECT: 'select',
   SIGNATURE: 'signature',
   SLIDER: 'slider',
@@ -87,6 +92,7 @@ export const FieldControlType = {
   SVG_ICON: 'svgIcon',
   TABS: 'tabs',
   TEXTAREA: 'textarea',
+  TIME_INPUT: 'time',
   TIME_PICKER: 'timePicker',
   TIMELINE: 'timeline',
   TOGGLE: 'toggle',
@@ -95,7 +101,9 @@ export const FieldControlType = {
   TREE_VIEW: 'treeView',
   TYPOGRAPHY: 'typography',
   URL_INPUT: 'url',
+  WEEK_INPUT: 'week',
   WINDOW: 'window',
 } as const;
 
-export type FieldControlType = typeof FieldControlType[keyof typeof FieldControlType];
+export type FieldControlType =
+  (typeof FieldControlType)[keyof typeof FieldControlType];

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/material-field-metadata.interface.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/material-field-metadata.interface.ts
@@ -1,9 +1,9 @@
 /**
  * @fileoverview Specialized metadata interfaces for Angular Material components
- * 
+ *
  * This file extends the base FieldMetadata interface with component-specific
  * properties for each Material Design component type.
- * 
+ *
  * Each interface follows the pattern:
  * - Extends FieldMetadata
  * - Adds component-specific properties
@@ -11,7 +11,10 @@
  * - Supports Material Design 3 specifications
  */
 
-import { FieldMetadata, FieldControlType } from './component-metadata.interface';
+import {
+  FieldMetadata,
+  FieldControlType,
+} from './component-metadata.interface';
 import { ThemePalette } from '@angular/material/core';
 import { ValidationErrors } from '@angular/forms';
 
@@ -43,18 +46,15 @@ export interface ValidationContext {
  * Type-safe validation result
  * Can return null (valid), string (error message), or ValidationErrors object
  */
-export type ValidationResult = 
-  | null 
-  | string 
-  | ValidationErrors;
+export type ValidationResult = null | string | ValidationErrors;
 
 /**
  * Enhanced validator function with proper typing
  * Replaces the generic (value: any, context?: any) => boolean | string | null
  */
 export type ValidatorFunction = (
-  value: any, 
-  context: ValidationContext
+  value: any,
+  context: ValidationContext,
 ) => ValidationResult | Promise<ValidationResult>;
 
 /**
@@ -78,8 +78,30 @@ export interface EnhancedValidationConfig {
 // =============================================================================
 
 /**
+ * Base interface for all Material input-like components.
+ *
+ * Centraliza propriedades compartilhadas entre os 13 componentes de input
+ * planejados (color, date, datetime-local, email, month, number, password,
+ * search, tel, text, time, url e week). Interfaces especializadas devem
+ * estender esta base e definir `controlType` e `inputType` apropriados.
+ */
+export interface BaseMaterialInputMetadata extends FieldMetadata {
+  /** Máximo de caracteres permitidos */
+  maxLength?: number;
+
+  /** Mínimo de caracteres exigidos */
+  minLength?: number;
+
+  /** Dica para autofill do navegador */
+  autocomplete?: string;
+
+  /** Atributo nativo readonly do input */
+  readonly?: boolean;
+}
+
+/**
  * Specialized metadata for Material Input components.
- * 
+ *
  * Interface baseada na especificação oficial do Angular Material Input (matInput directive).
  * Projetada especificamente para ambientes corporativos com foco em:
  * - Validação robusta e estados de erro customizáveis
@@ -87,9 +109,9 @@ export interface EnhancedValidationConfig {
  * - Suporte completo aos tipos HTML5 oficialmente suportados
  * - Acessibilidade WCAG 2.1 AA automática
  * - Recursos empresariais como readonly, disabled interactive, autofill
- * 
+ *
  * @see https://material.angular.dev/components/input/api - Documentação oficial
- * 
+ *
  * @example Configuração típica corporativa
  * ```typescript
  * const corporateEmailInput: MaterialInputMetadata = {
@@ -108,7 +130,7 @@ export interface EnhancedValidationConfig {
  *   showCharacterCount: true
  * };
  * ```
- * 
+ *
  * @example Input numérico para formulários financeiros
  * ```typescript
  * const financialInput: MaterialInputMetadata = {
@@ -126,12 +148,12 @@ export interface EnhancedValidationConfig {
  * };
  * ```
  */
-export interface MaterialInputMetadata extends FieldMetadata {
+export interface MaterialInputMetadata extends BaseMaterialInputMetadata {
   controlType: typeof FieldControlType.INPUT;
-  
-  /** 
+
+  /**
    * HTML5 input type - APENAS tipos oficialmente suportados pelo matNativeControl
-   * 
+   *
    * Tipos suportadas conforme documentação oficial:
    * - 'text': Texto padrão (mais comum em corporativo)
    * - 'email': Validação automática de email + teclado mobile otimizado
@@ -146,71 +168,44 @@ export interface MaterialInputMetadata extends FieldMetadata {
    * - 'month': Seletor de mês/ano
    * - 'week': Seletor de semana
    * - 'color': Seletor de cor nativo
-   * 
+   *
    * ⚠️ IMPORTANTE: Usar tipos não suportados causará erro "Input type isn't supported by matInput"
-   * 
+   *
    * @default 'text'
    */
-  inputType?: 'text' | 'email' | 'password' | 'tel' | 'url' | 'search' | 'number' |
-              'date' | 'datetime-local' | 'time' | 'month' | 'week' | 'color';
-  
-  /** 
-   * Atributo HTML maxlength - Comprimento máximo permitido
-   * 
-   * Integração automática com:
-   * - Validação do Angular Forms (maxlength validator)
-   * - Contador de caracteres visual (se showCharacterCount = true)
-   * - Acessibilidade (aria-* automático)
-   * 
-   * Comum em cenários corporativos:
-   * - Campos de descrição: 500-1000 caracteres
-   * - Códigos/IDs: 10-20 caracteres  
-   * - Nomes: 50-100 caracteres
-   */
-  maxLength?: number;
-  
-  /** 
-   * Atributo HTML minlength - Comprimento mínimo exigido
-   * 
-   * Essencial para:
-   * - Senhas corporativas (mínimo 8-12 caracteres)
-   * - Códigos de identificação
-   * - Validação de qualidade de dados
-   */
-  minLength?: number;
-  
-  /** 
-   * Atributo HTML autocomplete - Integração com autofill do navegador
-   * 
-   * Valores comuns para ambiente corporativo:
-   * - 'email': Email institucional
-   * - 'name': Nome completo  
-   * - 'organization': Nome da empresa
-   * - 'tel': Telefone corporativo
-   * - 'url': Website da empresa
-   * - 'username': Login/usuário
-   * - 'new-password': Nova senha
-   * - 'current-password': Senha atual
-   * - 'off': Desabilitar autofill (dados sensíveis)
-   * 
-   * @see https://html.spec.whatwg.org/multipage/forms.html#autofilling-form-controls
-   */
-  autocomplete?: string;
-  
-  /** 
+  inputType?:
+    | 'text'
+    | 'email'
+    | 'password'
+    | 'tel'
+    | 'url'
+    | 'search'
+    | 'number'
+    | 'date'
+    | 'datetime-local'
+    | 'time'
+    | 'month'
+    | 'week'
+    | 'color';
+
+  // maxLength, minLength e autocomplete foram movidos para
+  // BaseMaterialInputMetadata para eliminar duplicação entre
+  // componentes especializados.
+
+  /**
    * Atributo HTML spellcheck - Verificação ortográfica
-   * 
+   *
    * Configuração recomendada:
    * - true: Campos de texto livre (comentários, descrições)
    * - false: Códigos, emails, URLs, senhas, dados técnicos
-   * 
+   *
    * @default true (comportamento padrão do navegador)
    */
   spellcheck?: boolean;
-  
-  /** 
+
+  /**
    * Transformação de texto via CSS text-transform
-   * 
+   *
    * Aplicações corporativas:
    * - 'uppercase': Códigos, siglas, placas
    * - 'lowercase': URLs, emails padronizados
@@ -218,10 +213,10 @@ export interface MaterialInputMetadata extends FieldMetadata {
    * - 'none': Texto livre, preservar entrada do usuário
    */
   textTransform?: 'none' | 'uppercase' | 'lowercase' | 'capitalize';
-  
-  /** 
+
+  /**
    * HTML inputmode - Otimização de teclado mobile
-   * 
+   *
    * Essencial para apps corporativas mobile:
    * - 'text': Teclado padrão com predição
    * - 'numeric': Apenas números (0-9)
@@ -230,40 +225,47 @@ export interface MaterialInputMetadata extends FieldMetadata {
    * - 'email': Layout otimizado para email
    * - 'url': Layout para URLs
    * - 'search': Layout de busca
-   * 
+   *
    * ⚠️ Não confundir com inputType - inputMode é só visual mobile
    */
-  inputMode?: 'text' | 'numeric' | 'decimal' | 'tel' | 'email' | 'url' | 'search';
-  
-  /** 
+  inputMode?:
+    | 'text'
+    | 'numeric'
+    | 'decimal'
+    | 'tel'
+    | 'email'
+    | 'url'
+    | 'search';
+
+  /**
    * Foco automático no carregamento do componente
-   * 
+   *
    * Usar com cuidado em ambientes corporativos:
    * ✅ Bom: Primeiro campo de formulários de login
    * ✅ Bom: Campo de busca em páginas de consulta
    * ❌ Evitar: Formulários longos (UX ruim)
    * ❌ Evitar: Múltiplos campos com autoFocus
-   * 
+   *
    * Chama automaticamente o método focus() do Material Input
    */
   autoFocus?: boolean;
-  
-  /** 
+
+  /**
    * Exibir contador de caracteres visual
-   * 
+   *
    * Renderizado como mat-hint align="end" automático
    * Funciona em conjunto com maxLength para mostrar "N / Max"
-   * 
+   *
    * Útil para:
    * - Campos com limite rígido (descrições, comentários)
    * - Feedback visual em tempo real
    * - Compliance com guidelines de UX corporativo
    */
   showCharacterCount?: boolean;
-  
-  /** 
+
+  /**
    * Configuração de botão "limpar" integrado
-   * 
+   *
    * Implementado como mat-icon-button no suffix do mat-form-field
    * Comum em:
    * - Campos de busca corporativa
@@ -284,67 +286,55 @@ export interface MaterialInputMetadata extends FieldMetadata {
     /** Show only when field has value */
     showOnlyWhenFilled?: boolean;
   };
-  
+
   // =============================================================================
   // PROPRIEDADES NATIVAS DO MATERIAL INPUT (conforme API oficial)
   // =============================================================================
-  
-  /** 
-   * Estado readonly nativo do Material Input
-   * 
-   * Diferente de disabled:
-   * - readonly: Visível, copiável, mas não editável
-   * - disabled: Acinzentado, não focável, não copiável
-   * 
-   * Uso corporativo:
-   * - Exibir dados calculados
-   * - Mostrar informações de referência
-   * - Workflows de aprovação (dados já submetidos)
-   * 
-   * @see MatInput.readonly property
-   */
-  readonly?: boolean;
-  
-  /** 
+
+  /**
    * Manter interatividade quando disabled
-   * 
+   *
    * ⚠️ NÃO IMPLEMENTADO: Funcionalidade planejada mas não desenvolvida
    * Será implementada em versão futura
-   * 
+   *
    * @todo Implementar na próxima iteração
    * @see MatInput.disabledInteractive property
    */
   disabledInteractive?: boolean;
-  
-  /** 
+
+  /**
    * Estratégia customizada para exibição de erros
-   * 
+   *
    * ⚠️ PARCIALMENTE IMPLEMENTADO: Interface existe mas lógica não aplicada
    * Atualmente usa apenas comportamento padrão do Material
-   * 
+   *
    * @todo Implementar ErrorStateMatcher na próxima iteração
    * @see MatInput.errorStateMatcher property
    */
-  errorStateMatcher?: 'default' | 'showOnDirtyAndInvalid' | 'showOnSubmitted' | 'showImmediately';
-  
+  errorStateMatcher?:
+    | 'default'
+    | 'showOnDirtyAndInvalid'
+    | 'showOnSubmitted'
+    | 'showImmediately';
+
   // =============================================================================
   // INTEGRAÇÃO COM MAT-FORM-FIELD (recursos automáticos)
   // =============================================================================
-  
-  /** 
+
+  /**
    * Texto de prefixo (antes do input)
-   * 
+   *
    * Renderizado como <mat-icon matPrefix> ou <span matPrefix>
    * Exemplos corporativos:
    * - Símbolos monetários: 'R$', '$', '€'
-   * - Códigos: 'REF:', 'ID:'  
+   * - Códigos: 'REF:', 'ID:'
    * - Ícones: 'person', 'email', 'phone'
    */
   prefix?: string;
-  
-  /** 
+
+  /**
    * Texto de sufixo (após o input)
-   * 
+   *
    * Renderizado como <mat-icon matSuffix> ou <span matSuffix>
    * Exemplos corporativos:
    * - Unidades: 'kg', 'm²', '%'
@@ -352,26 +342,26 @@ export interface MaterialInputMetadata extends FieldMetadata {
    * - Status: Ícones de validação
    */
   suffix?: string;
-  
-  /** 
+
+  /**
    * Texto de dica contextual
-   * 
+   *
    * Renderizado como <mat-hint>
    * Posicionamento automático ou customizável
-   * 
+   *
    * Boas práticas corporativas:
    * - Exemplo de formato esperado
    * - Instruções de preenchimento
    * - Limitações ou regras de negócio
    */
   hint?: string;
-  
-  /** 
+
+  /**
    * Alinhamento da dica (hint)
-   * 
+   *
    * - 'start': Alinhado à esquerda
    * - 'end': Alinhado à direita (comum para contadores)
-   * 
+   *
    * @default 'start'
    */
   hintAlign?: 'start' | 'end';
@@ -379,10 +369,10 @@ export interface MaterialInputMetadata extends FieldMetadata {
   // =============================================================================
   // PROPRIEDADES ÓRFÃS IMPLEMENTADAS - Alinhamento com componentes
   // =============================================================================
-  
-  /** 
+
+  /**
    * Configuração de aparência Material Design
-   * 
+   *
    * Propriedades usadas pelos componentes mas que estavam ausentes da interface.
    * Adicionadas para alinhamento entre interface e implementação.
    */
@@ -398,32 +388,32 @@ export interface MaterialInputMetadata extends FieldMetadata {
     /** Ocultar marcador de obrigatório */
     hideRequiredMarker?: boolean;
   };
-  
-  /** 
+
+  /**
    * Ícone de prefixo (usado pela implementação)
    * Renderizado como mat-icon matPrefix
    */
   prefixIcon?: string;
-  
-  /** 
+
+  /**
    * Ícone de sufixo (usado pela implementação)
    * Renderizado como mat-icon matSuffix
    */
   suffixIcon?: string;
-  
-  /** 
+
+  /**
    * Valor mínimo para inputs numéricos
    * Usado pela implementação em inputs type="number"
    */
   min?: number;
-  
-  /** 
+
+  /**
    * Valor máximo para inputs numéricos
    * Usado pela implementação em inputs type="number"
    */
   max?: number;
-  
-  /** 
+
+  /**
    * Incremento para inputs numéricos
    * Usado pela implementação em inputs type="number"
    */
@@ -438,7 +428,7 @@ export interface MaterialInputMetadata extends FieldMetadata {
 
 /**
  * Specialized metadata for Material Textarea components.
- * 
+ *
  * Interface baseada na especificação oficial do Angular Material Textarea (matInput directive).
  * Projetada para ambientes corporativos com foco em:
  * - Entrada de texto multi-linha com controle preciso de dimensionamento
@@ -446,10 +436,10 @@ export interface MaterialInputMetadata extends FieldMetadata {
  * - Integração completa com mat-form-field (mesmos recursos do input)
  * - Validação robusta para campos de texto longo
  * - Recursos empresariais específicos para formulários complexos
- * 
+ *
  * @see https://material.angular.dev/components/input/api - Documentação oficial
  * @see https://material.angular.dev/cdk/text-field/api - CDK TextareaAutosize
- * 
+ *
  * @example Configuração típica para comentários corporativos
  * ```typescript
  * const commentTextarea: MaterialTextareaMetadata = {
@@ -468,7 +458,7 @@ export interface MaterialInputMetadata extends FieldMetadata {
  *   hint: 'Máximo 1000 caracteres. Use linguagem profissional.'
  * };
  * ```
- * 
+ *
  * @example Configuração para código/texto técnico
  * ```typescript
  * const codeTextarea: MaterialTextareaMetadata = {
@@ -488,94 +478,94 @@ export interface MaterialInputMetadata extends FieldMetadata {
  */
 export interface MaterialTextareaMetadata extends FieldMetadata {
   controlType: typeof FieldControlType.TEXTAREA;
-  
-  /** 
+
+  /**
    * Número de linhas visíveis iniciais
-   * 
+   *
    * Define a altura inicial do textarea em linhas de texto.
    * Funciona como o atributo HTML rows padrão.
-   * 
+   *
    * Configurações comuns corporativas:
    * - Comentários curtos: 2-3 linhas
-   * - Descrições médias: 4-6 linhas  
+   * - Descrições médias: 4-6 linhas
    * - Texto longo: 8-12 linhas
    * - Código/JSON: 10-20 linhas
-   * 
+   *
    * @default 4 (padrão do navegador)
    */
   rows?: number;
-  
-  /** 
+
+  /**
    * Número máximo de linhas para auto-resize
-   * 
+   *
    * Trabalha em conjunto com autoSize=true e cdkTextareaAutosize.
    * Evita que o textarea cresça infinitamente, mantendo a UX controlada.
-   * 
+   *
    * Importante para:
    * - Layouts responsivos (não quebrar design)
    * - Performance (textareas muito grandes são lentos)
    * - UX consistente em diferentes dispositivos
-   * 
+   *
    * @see CDK TextareaAutosize cdkAutosizeMaxRows
    */
   maxRows?: number;
-  
-  /** 
+
+  /**
    * Número mínimo de linhas para auto-resize
-   * 
+   *
    * Trabalha com autoSize=true para garantir altura mínima.
    * Evita que textarea fique muito pequeno quando vazio.
-   * 
+   *
    * Geralmente menor que rows:
    * - minRows: altura quando vazio
    * - rows: altura inicial com conteúdo
    * - maxRows: altura máxima permitida
    */
   minRows?: number;
-  
-  /** 
+
+  /**
    * Comportamento de redimensionamento manual
-   * 
+   *
    * Controla se usuário pode redimensionar manualmente:
    * - 'none': Sem redimensionamento (padrão Material)
    * - 'vertical': Apenas altura (mais comum)
    * - 'horizontal': Apenas largura (raro)
    * - 'both': Altura e largura (evitar em layouts fixos)
    * - 'auto': Baseado no CSS/browser default
-   * 
+   *
    * ✅ Recomendado: 'vertical' para ambiente corporativo
    * ❌ Evitar: 'horizontal'/'both' (quebra layout responsivo)
    */
   resize?: 'none' | 'both' | 'horizontal' | 'vertical' | 'auto';
-  
-  /** 
+
+  /**
    * Auto-redimensionamento baseado no conteúdo
-   * 
+   *
    * Usa CDK TextareaAutosize para crescer/diminuir automaticamente.
    * Muito útil para UX moderna e formulários dinâmicos.
-   * 
+   *
    * Benefícios corporativos:
    * - UX fluida (não precisa scroll interno)
    * - Melhor para mobile/tablet
    * - Adapta a quantidade de conteúdo
-   * 
+   *
    * Cuidados:
    * - Usar sempre com maxRows definido
    * - Testar em diferentes dispositivos
    * - Pode impactar performance com muito texto
-   * 
+   *
    * @see CDK cdkTextareaAutosize directive
    */
   autoSize?: boolean;
-  
-  /** 
+
+  /**
    * Comprimento máximo de caracteres
-   * 
+   *
    * Idêntico ao input, mas importante para textareas:
    * - Integração com showCharacterCount
    * - Validação automática do Angular Forms
    * - Feedback visual em tempo real
-   * 
+   *
    * Limites comuns corporativos:
    * - Comentários: 500-1000 caracteres
    * - Descrições: 1000-2000 caracteres
@@ -584,62 +574,62 @@ export interface MaterialTextareaMetadata extends FieldMetadata {
    */
   maxLength?: number;
 
-  /** 
+  /**
    * Comprimento mínimo de caracteres
    * Funciona idêntico ao MaterialInputMetadata
    */
   minLength?: number;
-  
-  /** 
+
+  /**
    * Exibir contador de caracteres
-   * 
+   *
    * Ainda mais importante em textarea que em input:
    * - Usuários digitam mais texto
    * - Harder to estimate character count visually
    * - Critical for compliance/business rules
-   * 
+   *
    * Renderizado como mat-hint align="end"
    * Formato: "N / MaxLength" ou "N characters"
    */
   showCharacterCount?: boolean;
-  
-  /** 
+
+  /**
    * Comportamento de quebra de linha
-   * 
+   *
    * Atributo HTML wrap:
    * - 'soft': Quebra visual, mas não insere \n no valor (padrão)
    * - 'hard': Quebra visual E insere \n no valor (raro)
    * - 'off': Sem quebra automática, scroll horizontal
-   * 
+   *
    * Uso corporativo:
    * - 'soft': Texto natural, comentários, descrições
    * - 'off': Código, URLs, dados estruturados
    * - 'hard': Raramente usado (compatibilidade legacy)
-   * 
+   *
    * @default 'soft'
    */
   wrap?: 'soft' | 'hard' | 'off';
-  
-  /** 
+
+  /**
    * Verificação ortográfica (idêntico ao input)
-   * 
+   *
    * Ainda mais relevante para textarea:
    * - Mais texto = mais chance de erros
    * - Importante para textos corporativos profissionais
-   * 
+   *
    * @default true
    */
   spellcheck?: boolean;
-  
-  /** 
+
+  /**
    * Estado readonly (idêntico ao input)
    * @see MaterialInputMetadata.readonly
    */
   readonly?: boolean;
 
-  /** 
+  /**
    * Foco automático (herdado, usar com cautela)
-   * 
+   *
    * Menos comum em textarea:
    * - Geralmente não é o primeiro campo
    * - Pode ser intrusivo (abre teclado mobile)
@@ -647,29 +637,33 @@ export interface MaterialTextareaMetadata extends FieldMetadata {
    */
   autoFocus?: boolean;
 
-  /** 
+  /**
    * Texto de dica contextual (idêntico ao input)
    * @see MaterialInputMetadata.hint
    */
   hint?: string;
 
-  /** 
+  /**
    * Estratégia de exibição de erros (herdado)
-   * 
+   *
    * Para textareas, considerar:
    * - 'showOnDirtyAndInvalid': Melhor para textos longos
    * - Usuários gastam mais tempo digitando
    * - Validação imediata pode ser intrusiva
    */
-  errorStateMatcher?: 'default' | 'showOnDirtyAndInvalid' | 'showOnSubmitted' | 'showImmediately';
+  errorStateMatcher?:
+    | 'default'
+    | 'showOnDirtyAndInvalid'
+    | 'showOnSubmitted'
+    | 'showImmediately';
 
-  /** 
+  /**
    * Número de colunas para textarea
    * Controla largura inicial em caracteres
    */
   cols?: number;
-  
-  /** 
+
+  /**
    * Configuração de aparência Material Design
    * Idêntica ao MaterialInputMetadata para consistência
    */
@@ -680,13 +674,13 @@ export interface MaterialTextareaMetadata extends FieldMetadata {
     subscriptSizing?: 'fixed' | 'dynamic';
     hideRequiredMarker?: boolean;
   };
-  
-  /** 
+
+  /**
    * Ícone de prefixo (usado pela implementação)
    */
   prefixIcon?: string;
-  
-  /** 
+
+  /**
    * Ícone de sufixo (usado pela implementação)
    */
   suffixIcon?: string;
@@ -698,24 +692,24 @@ export interface MaterialTextareaMetadata extends FieldMetadata {
 }
 
 /**
- * Specialized metadata for Material Numeric Input components.
- * 
- * Handles number input with formatting, step controls,
- * and range validation specific to numeric values.
+ * Metadata for `<input type="number">` rendered via Material directives.
+ *
+ * Planejamento para o futuro `NumberInputComponent`, com suporte a
+ * formatação, incremento e validação de faixa numérica.
  */
-export interface MaterialNumericMetadata extends FieldMetadata {
+export interface MaterialNumericMetadata extends BaseMaterialInputMetadata {
   controlType: typeof FieldControlType.NUMERIC_TEXT_BOX;
   inputType: 'number';
-  
+
   /** Minimum allowed value */
   min?: number;
-  
+
   /** Maximum allowed value */
   max?: number;
-  
+
   /** Step increment for number controls */
   step?: number;
-  
+
   /** Number formatting options */
   numberFormat?: {
     /** Decimal places to display */
@@ -735,13 +729,15 @@ export interface MaterialNumericMetadata extends FieldMetadata {
 
 /**
  * Specialized metadata for Material Select components.
- * 
+ *
  * Handles dropdown selection with single/multiple values,
  * option groups, and dynamic data loading.
  */
 export interface MaterialSelectMetadata extends FieldMetadata {
-  controlType: typeof FieldControlType.SELECT | typeof FieldControlType.MULTI_SELECT;
-  
+  controlType:
+    | typeof FieldControlType.SELECT
+    | typeof FieldControlType.MULTI_SELECT;
+
   /** Selection options */
   selectOptions?: Array<{
     value: any;
@@ -751,57 +747,57 @@ export interface MaterialSelectMetadata extends FieldMetadata {
     disabled?: boolean;
     group?: string;
   }>;
-  
+
   /** Enable multiple selection */
   multiple?: boolean;
-  
+
   /** Enable option search/filter */
   searchable?: boolean;
-  
+
   /** Show "Select All" option for multiple */
   selectAll?: boolean;
-  
+
   /** Maximum number of selections (for multiple) */
   maxSelections?: number;
 }
 
 /**
  * Specialized metadata for Material Checkbox components.
- * 
+ *
  * Handles boolean values with indeterminate state support
  * and checkbox group functionality.
  */
 export interface MaterialCheckboxMetadata extends FieldMetadata {
   controlType: typeof FieldControlType.CHECKBOX;
-  
+
   /** Checkbox label position */
   labelPosition?: 'before' | 'after';
-  
+
   /** Enable indeterminate state */
   indeterminate?: boolean;
-  
+
   /** Checkbox color theme */
   color?: ThemePalette;
-  
+
   /** Link text for checkbox with clickable link */
   linkText?: string;
-  
+
   /** URL for checkbox link */
   linkUrl?: string;
-  
+
   /** Link target (_blank or _self) */
   linkTarget?: '_blank' | '_self';
 }
 
 /**
  * Specialized metadata for Material Radio Button components.
- * 
+ *
  * Handles single selection from a group of options
  * with horizontal/vertical layout support.
  */
 export interface MaterialRadioMetadata extends FieldMetadata {
   controlType: typeof FieldControlType.RADIO;
-  
+
   /** Radio button options */
   radioOptions: Array<{
     value: any;
@@ -810,72 +806,74 @@ export interface MaterialRadioMetadata extends FieldMetadata {
     description?: string;
     disabled?: boolean;
   }>;
-  
+
   /** Layout direction */
   layout?: 'horizontal' | 'vertical';
-  
+
   /** Radio button color theme */
   color?: ThemePalette;
 }
 
 /**
  * Specialized metadata for Material Date Picker components.
- * 
+ *
  * Handles date selection with calendar popup,
  * date range selection, and validation.
  */
 export interface MaterialDatepickerMetadata extends FieldMetadata {
-  controlType: typeof FieldControlType.DATE_PICKER | typeof FieldControlType.DATE_RANGE;
-  
+  controlType:
+    | typeof FieldControlType.DATE_PICKER
+    | typeof FieldControlType.DATE_RANGE;
+
   /** Date format for display */
   dateFormat?: string;
-  
+
   /** Minimum selectable date */
   minDate?: Date | string;
-  
+
   /** Maximum selectable date */
   maxDate?: Date | string;
-  
+
   /** Start view (month, year, multi-year) */
   startView?: 'month' | 'year' | 'multi-year';
-  
+
   /** Enable date range selection */
   range?: boolean;
 }
 
 /**
  * Specialized metadata for Material Button components.
- * 
+ *
  * Handles action buttons with various styles,
  * icons, and click behaviors.
  */
 export interface MaterialButtonMetadata extends FieldMetadata {
   controlType: typeof FieldControlType.BUTTON;
-  
+
   /** Button style variant */
   variant?: 'raised' | 'stroked' | 'flat' | 'icon' | 'fab' | 'mini-fab';
-  
+
   /** Button color theme */
   color?: ThemePalette;
-  
+
   /** Button icon */
   icon?: string;
-  
+
   /** Icon position */
   buttonIconPosition?: 'before' | 'after';
-  
+
   /** Button action/command */
   action?: string;
-  
+
   /** Disable button ripple effect */
   disableRipple?: boolean;
-  
+
   /** Confirmation message for destructive actions */
   confirmationMessage?: string;
-  
+
   /** Confirmation dialog title */
   confirmationTitle?: string;
-  
+
   /** Custom confirmation dialog buttons */
   confirmationButtons?: {
     confirm: string;
@@ -886,15 +884,15 @@ export interface MaterialButtonMetadata extends FieldMetadata {
 // =============================================================================
 // FUTURE COMPONENT INTERFACES - PLANNING STAGE
 // =============================================================================
-// 
+//
 // ⚠️ IMPORTANTE: Estas interfaces foram criadas para definir a API futura
 // dos componentes, mas os componentes físicos ainda NÃO foram implementados.
-// 
+//
 // Status atual:
 // - ✅ Interface de metadata definida
 // - ❌ Componente físico não implementado
 // - ❌ Não registrado no ComponentRegistry
-// 
+//
 // Para usar essas interfaces, será necessário implementar os componentes
 // correspondentes em praxis-dynamic-fields/src/lib/components/
 // =============================================================================
@@ -909,16 +907,16 @@ export interface MaterialButtonMetadata extends FieldMetadata {
  */
 export interface MaterialToggleMetadata extends FieldMetadata {
   controlType: typeof FieldControlType.TOGGLE;
-  
+
   /** Toggle color theme */
   color?: ThemePalette;
-  
+
   /** Toggle label position */
   labelPosition?: 'before' | 'after';
-  
+
   /** Hide toggle thumb icon */
   hideIcon?: boolean;
-  
+
   /** Disable toggle ripple effect */
   disableRipple?: boolean;
 }
@@ -933,133 +931,133 @@ export interface MaterialToggleMetadata extends FieldMetadata {
  */
 export interface MaterialSliderMetadata extends FieldMetadata {
   controlType: typeof FieldControlType.SLIDER;
-  
+
   /** Minimum value */
   min?: number;
-  
+
   /** Maximum value */
   max?: number;
-  
+
   /** Step increment */
   step?: number;
-  
+
   /** Show value label */
   thumbLabel?: boolean;
-  
+
   /** Slider orientation */
   vertical?: boolean;
-  
+
   /** Slider color theme */
   color?: ThemePalette;
-  
+
   /** Show tick marks */
   tickInterval?: number | 'auto';
-  
+
   /** Invert slider direction */
   invert?: boolean;
 }
 
 /**
  * Specialized metadata for Material Time Picker components.
- * 
+ *
  * ⚠️ COMPONENTE NÃO IMPLEMENTADO - Interface de planejamento
- * 
+ *
  * Para implementar: criar MaterialTimePickerComponent em components/material-timepicker/
  * e registrar no ComponentRegistryService
- * 
+ *
  * Handles time selection with clock interface.
  */
 export interface MaterialTimePickerMetadata extends FieldMetadata {
   controlType: typeof FieldControlType.TIME_PICKER;
-  
+
   /** Time format (12 or 24 hour) */
   timeFormat?: 12 | 24;
-  
+
   /** Minimum selectable time */
   minTime?: string;
-  
+
   /** Maximum selectable time */
   maxTime?: string;
-  
+
   /** Time step in minutes */
   stepMinute?: number;
-  
+
   /** Show seconds selector */
   showSeconds?: boolean;
-  
+
   /** Default time to show when opening */
   defaultTime?: string;
 }
 
 /**
  * Specialized metadata for Material Rating components.
- * 
+ *
  * ⚠️ COMPONENTE NÃO IMPLEMENTADO - Interface de planejamento
- * 
+ *
  * Para implementar: criar MaterialRatingComponent em components/material-rating/
  * e registrar no ComponentRegistryService
- * 
+ *
  * Handles star rating or numeric rating selection.
  */
 export interface MaterialRatingMetadata extends FieldMetadata {
   controlType: typeof FieldControlType.RATING;
-  
+
   /** Maximum rating value */
   max?: number;
-  
+
   /** Rating precision (0.1, 0.5, 1) */
   precision?: number;
-  
+
   /** Rating icon (default: star) */
   icon?: string;
-  
+
   /** Empty icon (default: star_border) */
   emptyIcon?: string;
-  
+
   /** Rating color theme */
   color?: ThemePalette;
-  
+
   /** Enable half-star ratings */
   allowHalf?: boolean;
-  
+
   /** Read-only mode */
   readonly?: boolean;
-  
+
   /** Rating size */
   size?: 'small' | 'medium' | 'large';
 }
 
 /**
  * Specialized metadata for Material Color Picker components.
- * 
+ *
  * ⚠️ COMPONENTE NÃO IMPLEMENTADO - Interface de planejamento
- * 
+ *
  * Para implementar: criar MaterialColorPickerComponent em components/material-colorpicker/
  * e registrar no ComponentRegistryService
- * 
+ *
  * Handles color selection with various picker interfaces.
  */
 export interface MaterialColorPickerMetadata extends FieldMetadata {
   controlType: typeof FieldControlType.COLOR_PICKER;
-  
+
   /** Color picker format */
   format?: 'hex' | 'rgb' | 'hsl' | 'hsv';
-  
+
   /** Show alpha/transparency slider */
   showAlpha?: boolean;
-  
+
   /** Predefined color palette */
   presetColors?: string[];
-  
+
   /** Allow custom colors */
   allowCustomColors?: boolean;
-  
+
   /** Color picker variant */
   variant?: 'compact' | 'default' | 'block';
-  
+
   /** Show color input field */
   showInput?: boolean;
-  
+
   /** Show color preview */
   showPreview?: boolean;
 }
@@ -1067,16 +1065,16 @@ export interface MaterialColorPickerMetadata extends FieldMetadata {
 // =============================================================================
 // SPECIALIZED COMPONENT INTERFACES - PLANNING STAGE
 // =============================================================================
-// 
+//
 // ⚠️ IMPORTANTE: Estas interfaces especializadas foram criadas para estender
 // funcionalidades dos componentes base, mas os componentes especializados
 // ainda NÃO foram implementados.
-// 
+//
 // Status atual:
 // - ✅ Interface de metadata definida
 // - ❌ Componente especializado não implementado
 // - ❌ Atualmente usa MaterialInputComponent genérico
-// 
+//
 // Estes tipos são registrados no ComponentRegistry mas apontam para
 // MaterialInputComponent. Para funcionalidade completa, implementar
 // componentes especializados correspondentes.
@@ -1090,115 +1088,221 @@ export interface MaterialColorPickerMetadata extends FieldMetadata {
  *
  * Handles monetary values with currency formatting and validation.
  */
-export interface MaterialCurrencyMetadata extends FieldMetadata {
+export interface MaterialCurrencyMetadata extends BaseMaterialInputMetadata {
   controlType: typeof FieldControlType.CURRENCY_INPUT;
   inputType: 'text';
-  
-  // Common input properties
-  maxLength?: number;
-  minLength?: number;
-  autocomplete?: string;
-  readonly?: boolean;
-  placeholder?: string;
-  hint?: string;
-  
+
   /** Currency code (USD, EUR, BRL, etc.) */
   currency: string;
-  
+
   /** Currency symbol position */
   currencyPosition?: 'before' | 'after';
-  
+
   /** Number of decimal places */
   decimalPlaces?: number;
-  
+
   /** Locale for formatting */
   locale?: string;
-  
+
   /** Allow negative values */
   allowNegative?: boolean;
-  
+
   /** Thousands separator */
   thousandsSeparator?: string;
-  
+
   /** Decimal separator */
   decimalSeparator?: string;
 }
 
 /**
  * Specialized metadata for Material Email Input components.
- * 
+ *
  * ⚠️ COMPONENTE ESPECIALIZADO NÃO IMPLEMENTADO - Interface de planejamento
- * 
+ *
  * Atualmente: EMAIL_INPUT → MaterialInputComponent (genérico)
  * Para implementar: criar MaterialEmailComponent em components/material-email/
- * 
+ *
  * Handles email addresses with validation and suggestions.
  */
-export interface MaterialEmailMetadata extends FieldMetadata {
+export interface MaterialEmailMetadata extends BaseMaterialInputMetadata {
   controlType: typeof FieldControlType.EMAIL_INPUT;
   inputType: 'email';
-  
-  // Common input properties
-  maxLength?: number;
-  minLength?: number;
-  autocomplete?: string;
-  readonly?: boolean;
-  placeholder?: string;
-  hint?: string;
-  
+
   /** Enable email domain suggestions */
   domainSuggestions?: string[];
-  
+
   /** Validate email format on blur */
   validateOnBlur?: boolean;
-  
+
   /** Show validation icon */
   showValidationIcon?: boolean;
-  
+
   /** Allow multiple emails (comma-separated) */
   multiple?: boolean;
-  
+
   /** Email separator for multiple emails */
   separator?: string;
 }
 
 /**
  * Specialized metadata for Material Phone Input components.
- * 
+ *
  * ⚠️ COMPONENTE ESPECIALIZADO NÃO IMPLEMENTADO - Interface de planejamento
- * 
+ *
  * Atualmente: PHONE → MaterialInputComponent (genérico)
  * Para implementar: criar MaterialPhoneComponent em components/material-phone/
- * 
+ *
  * Handles phone numbers with international formatting.
  */
-export interface MaterialPhoneMetadata extends FieldMetadata {
+export interface MaterialPhoneMetadata extends BaseMaterialInputMetadata {
   controlType: typeof FieldControlType.PHONE;
   inputType: 'tel';
-  
-  // Common input properties
-  maxLength?: number;
-  minLength?: number;
-  autocomplete?: string;
-  readonly?: boolean;
-  placeholder?: string;
-  hint?: string;
-  
+
   /** Default country code */
   defaultCountry?: string;
-  
+
   /** Allowed country codes */
   allowedCountries?: string[];
-  
+
   /** Show country selector */
   showCountrySelector?: boolean;
-  
+
   /** Phone number format */
   phoneFormat?: 'national' | 'international' | 'e164';
-  
+
   /** Enable auto-formatting while typing */
   autoFormat?: boolean;
-  
+
   /** Validate phone number */
   validatePhoneNumber?: boolean;
+}
+
+/**
+ * Metadata for Material Password Input components.
+ *
+ * TODO: Implement show/hide toggle and strength indicator.
+ */
+export interface MaterialPasswordMetadata extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.PASSWORD;
+  inputType: 'password';
+}
+
+/**
+ * Metadata for Material URL Input components.
+ *
+ * TODO: Add URL validation and preview options.
+ */
+export interface MaterialUrlInputMetadata extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.URL_INPUT;
+  inputType: 'url';
+}
+
+/**
+ * Metadata for Material Search Input components.
+ *
+ * TODO: Integrate with search handlers and clear button.
+ */
+export interface MaterialSearchInputMetadata extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.SEARCH_INPUT;
+  inputType: 'search';
+}
+
+/**
+ * Metadata for Material Date Input components.
+ *
+ * Supports native `min` and `max` attributes for constraining the
+ * selectable date range.
+ */
+export interface MaterialDateInputMetadata extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.DATE_INPUT;
+  inputType: 'date';
+  /** Minimum selectable date in ISO format (YYYY-MM-DD). */
+  min?: string;
+  /** Maximum selectable date in ISO format (YYYY-MM-DD). */
+  max?: string;
+}
+
+/**
+ * Metadata for Material Datetime Local Input components.
+ *
+ * Supports native `min`, `max` and `step` attributes for constraining
+ * selectable date-time ranges.
+ *
+ * TODO: Handle timezone conversion.
+ */
+export interface MaterialDatetimeLocalInputMetadata
+  extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.DATETIME_LOCAL_INPUT;
+  inputType: 'datetime-local';
+  /** Minimum selectable date-time in ISO format (YYYY-MM-DDTHH:mm). */
+  min?: string;
+  /** Maximum selectable date-time in ISO format (YYYY-MM-DDTHH:mm). */
+  max?: string;
+  /** Step for minute increments in seconds. */
+  step?: number;
+}
+
+/**
+ * Metadata for Material Email Input components.
+ *
+ * Provides configuration for email fields with native autocomplete and
+ * validation.
+ */
+export interface MaterialEmailInputMetadata extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.EMAIL_INPUT;
+  inputType: 'email';
+}
+
+/**
+ * Metadata for Material Month Input components.
+ *
+ * TODO: Validate month format and provide display options.
+ */
+export interface MaterialMonthInputMetadata extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.MONTH_INPUT;
+  inputType: 'month';
+  /** Minimum selectable month in ISO format (YYYY-MM). */
+  min?: string;
+  /** Maximum selectable month in ISO format (YYYY-MM). */
+  max?: string;
+}
+
+/**
+ * Metadata for Material Week Input components.
+ *
+ * TODO: Validate ISO week format and boundaries.
+ */
+export interface MaterialWeekInputMetadata extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.WEEK_INPUT;
+  inputType: 'week';
+  /** Minimum selectable week in ISO format (YYYY-Www). */
+  min?: string;
+  /** Maximum selectable week in ISO format (YYYY-Www). */
+  max?: string;
+}
+
+/**
+ * Metadata for Material Color Input components.
+ *
+ * TODO: Add color preview or palette integration.
+ */
+export interface MaterialColorInputMetadata extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.COLOR_INPUT;
+  inputType: 'color';
+}
+
+/**
+ * Metadata for Material Time Input components.
+ *
+ * TODO: Provide min/max and step configuration.
+ */
+export interface MaterialTimeInputMetadata extends BaseMaterialInputMetadata {
+  controlType: typeof FieldControlType.TIME_INPUT;
+  inputType: 'time';
+  /** Minimum time value in 24h format (HH:mm). */
+  min?: string;
+  /** Maximum time value in 24h format (HH:mm). */
+  max?: string;
+  /** Step for minute increments in seconds. */
+  step?: number;
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/color-input/color-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/color-input/color-input.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { ColorInputComponent } from './color-input.component';
+
+describe('ColorInputComponent', () => {
+  let component: ColorInputComponent;
+  let fixture: ComponentFixture<ColorInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ColorInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ColorInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Favorite color',
+      required: true,
+      inputType: 'color',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate color value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '#ff0000';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('#ff0000');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/color-input/color-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/color-input/color-input.component.ts
@@ -1,0 +1,113 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialColorInputMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML color inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="color">` element
+ * with basic validation and hint support. Built on top of the
+ * `SimpleBaseInputComponent` to leverage common functionality such as
+ * reactive forms integration and error handling.
+ */
+@Component({
+  selector: 'pdx-color-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Color' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">{{
+          metadata()!.hint
+        }}</mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ColorInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"color"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class ColorInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-color-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialColorInputMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/color-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/color-input/index.ts
@@ -1,0 +1,1 @@
+export * from './color-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/date-input/date-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/date-input/date-input.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { DateInputComponent } from './date-input.component';
+
+describe('DateInputComponent', () => {
+  let component: DateInputComponent;
+  let fixture: ComponentFixture<DateInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DateInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DateInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Birthday',
+      required: true,
+      inputType: 'date',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate date value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '2024-05-01';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('2024-05-01');
+  });
+
+  it('should validate date format', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = 'invalid';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '2024-05-01';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/date-input/date-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/date-input/date-input.component.ts
@@ -1,0 +1,119 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialDateInputMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML date inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="date">` element
+ * with basic validation and hint support. Built on top of the
+ * `SimpleBaseInputComponent` to leverage common functionality such as
+ * reactive forms integration and error handling.
+ */
+@Component({
+  selector: 'pdx-date-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Date' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [min]="metadata()?.min || null"
+        [max]="metadata()?.max || null"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">{{
+          metadata()!.hint
+        }}</mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => DateInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"dateInput"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class DateInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    this.internalControl.addValidators(
+      Validators.pattern(/^\d{4}-\d{2}-\d{2}$/),
+    );
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-date-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialDateInputMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/date-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/date-input/index.ts
@@ -1,0 +1,1 @@
+export * from './date-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/datetime-local-input/datetime-local-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/datetime-local-input/datetime-local-input.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { DatetimeLocalInputComponent } from './datetime-local-input.component';
+
+describe('DatetimeLocalInputComponent', () => {
+  let component: DatetimeLocalInputComponent;
+  let fixture: ComponentFixture<DatetimeLocalInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DatetimeLocalInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatetimeLocalInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Meeting time',
+      required: true,
+      inputType: 'datetime-local',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate datetime value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '2024-05-01T12:30';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('2024-05-01T12:30');
+  });
+
+  it('should validate datetime format', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = 'invalid';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '2024-05-01T12:30';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/datetime-local-input/datetime-local-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/datetime-local-input/datetime-local-input.component.ts
@@ -1,0 +1,118 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialDatetimeLocalInputMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML datetime-local inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="datetime-local">`
+ * element with basic validation and hint support.
+ */
+@Component({
+  selector: 'pdx-datetime-local-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Datetime' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [min]="metadata()?.min || null"
+        [max]="metadata()?.max || null"
+        [step]="metadata()?.step || null"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">
+          {{ metadata()!.hint }}
+        </mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => DatetimeLocalInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"dateTimeLocal"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class DatetimeLocalInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    this.internalControl.addValidators(
+      Validators.pattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/),
+    );
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-datetime-local-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialDatetimeLocalInputMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/datetime-local-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/datetime-local-input/index.ts
@@ -1,0 +1,1 @@
+export * from './datetime-local-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/email-input/email-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/email-input/email-input.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { EmailInputComponent } from './email-input.component';
+
+describe('EmailInputComponent', () => {
+  let component: EmailInputComponent;
+  let fixture: ComponentFixture<EmailInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EmailInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmailInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Email',
+      required: true,
+      inputType: 'email',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate email value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = 'user@example.com';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('user@example.com');
+  });
+
+  it('should validate email format', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = 'invalid';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = 'valid@example.com';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/email-input/email-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/email-input/email-input.component.ts
@@ -1,0 +1,120 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialEmailInputMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML email inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="email">` element
+ * with basic validation and hint support. Built on top of the
+ * `SimpleBaseInputComponent` to leverage common functionality such as
+ * reactive forms integration and error handling.
+ */
+@Component({
+  selector: 'pdx-email-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Email' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [placeholder]="metadata()?.placeholder || ''"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [autocomplete]="metadata()?.autocomplete || 'off'"
+        [spellcheck]="metadata()?.spellcheck ?? false"
+        [maxlength]="metadata()?.maxLength || null"
+        [minlength]="metadata()?.minLength || null"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">{{
+          metadata()!.hint
+        }}</mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => EmailInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"email"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class EmailInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    this.internalControl.addValidators(Validators.email);
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-email-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialEmailInputMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/email-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/email-input/index.ts
@@ -1,0 +1,1 @@
+export * from './email-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/month-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/month-input/index.ts
@@ -1,0 +1,1 @@
+export * from './month-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/month-input/month-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/month-input/month-input.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { MonthInputComponent } from './month-input.component';
+
+describe('MonthInputComponent', () => {
+  let component: MonthInputComponent;
+  let fixture: ComponentFixture<MonthInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MonthInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MonthInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Month',
+      required: true,
+      inputType: 'month',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate month value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '2024-05';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('2024-05');
+  });
+
+  it('should validate month format', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = '2024-13';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '2024-05';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/month-input/month-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/month-input/month-input.component.ts
@@ -1,0 +1,117 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialMonthInputMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML month inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="month">` element
+ * with optional min/max constraints, basic validation and hint support.
+ * Built on top of the `SimpleBaseInputComponent` to reuse core features
+ * like reactive forms integration and error handling.
+ */
+@Component({
+  selector: 'pdx-month-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Month' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [min]="metadata()?.min || null"
+        [max]="metadata()?.max || null"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">
+          {{ metadata()!.hint }}
+        </mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MonthInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"month"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class MonthInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    this.internalControl.addValidators(Validators.pattern(/^\d{4}-\d{2}$/));
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-month-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialMonthInputMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/number-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/number-input/index.ts
@@ -1,0 +1,1 @@
+export * from './number-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/number-input/number-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/number-input/number-input.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { NumberInputComponent } from './number-input.component';
+
+describe('NumberInputComponent', () => {
+  let component: NumberInputComponent;
+  let fixture: ComponentFixture<NumberInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NumberInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NumberInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Age',
+      required: true,
+      inputType: 'number',
+      min: 0,
+      max: 120,
+      step: 1,
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate numeric value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '42';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('42');
+  });
+
+  it('should enforce min and max validators', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = '-1';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '121';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '50';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/number-input/number-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/number-input/number-input.component.ts
@@ -1,0 +1,127 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialNumericMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML number inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="number">` element
+ * with basic validation and hint support. Built on top of the
+ * `SimpleBaseInputComponent` to leverage common functionality such as
+ * reactive forms integration and error handling.
+ */
+@Component({
+  selector: 'pdx-number-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Number' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [placeholder]="metadata()?.placeholder || ''"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [min]="metadata()?.min ?? null"
+        [max]="metadata()?.max ?? null"
+        [step]="metadata()?.step ?? null"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">{{
+          metadata()!.hint
+        }}</mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => NumberInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"numericTextBox"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class NumberInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    this.internalControl.addValidators(Validators.pattern(/^\d*(\.\d+)?$/));
+    const min = this.metadata()?.min;
+    const max = this.metadata()?.max;
+    if (min !== undefined) {
+      this.internalControl.addValidators(Validators.min(min));
+    }
+    if (max !== undefined) {
+      this.internalControl.addValidators(Validators.max(max));
+    }
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-number-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialNumericMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/password-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/password-input/index.ts
@@ -1,0 +1,1 @@
+export * from './password-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/password-input/password-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/password-input/password-input.component.spec.ts
@@ -1,0 +1,44 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { PasswordInputComponent } from './password-input.component';
+
+describe('PasswordInputComponent', () => {
+  let component: PasswordInputComponent;
+  let fixture: ComponentFixture<PasswordInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PasswordInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PasswordInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Password',
+      required: true,
+      inputType: 'password',
+      controlType: 'password',
+    } as any);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate password value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = 'secret';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('secret');
+  });
+
+  it('should render input type password', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    expect(input.type).toBe('password');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/password-input/password-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/password-input/password-input.component.ts
@@ -1,0 +1,110 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialPasswordMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for password fields.
+ *
+ * Renders a `<mat-form-field>` wrapping an `<input type="password">` element
+ * and leverages `SimpleBaseInputComponent` for common functionality such as
+ * validation, hint display and reactive forms integration.
+ */
+@Component({
+  selector: 'pdx-password-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Password' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [placeholder]="metadata()?.placeholder || ''"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [attr.autocomplete]="metadata()?.autocomplete || 'off'"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">
+          {{ metadata()!.hint }}
+        </mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => PasswordInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"password"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class PasswordInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-password-input'];
+  }
+
+  /** Applies typed metadata to the component. */
+  setInputMetadata(metadata: MaterialPasswordMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/phone-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/phone-input/index.ts
@@ -1,0 +1,1 @@
+export * from './phone-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/phone-input/phone-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/phone-input/phone-input.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { PhoneInputComponent } from './phone-input.component';
+
+describe('PhoneInputComponent', () => {
+  let component: PhoneInputComponent;
+  let fixture: ComponentFixture<PhoneInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PhoneInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PhoneInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Phone',
+      required: true,
+      inputType: 'tel',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate phone value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '1234567890';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('1234567890');
+  });
+
+  it('should validate required field', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '5551234567';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+
+  it('should validate phone format', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = 'invalid!';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '+55 (11) 99999-8888';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/phone-input/phone-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/phone-input/phone-input.component.ts
@@ -1,0 +1,116 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialPhoneMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for telephone numbers.
+ *
+ * Renders a `<mat-form-field>` wrapping an `<input type="tel">` element with
+ * Material styling. Built on top of `SimpleBaseInputComponent` to leverage
+ * reactive forms integration, hint/error messaging and validation hooks.
+ */
+@Component({
+  selector: 'pdx-phone-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Phone' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [placeholder]="metadata()?.placeholder || ''"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [autocomplete]="metadata()?.autocomplete || 'tel'"
+        [type]="inputType()"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">{{
+          metadata()!.hint
+        }}</mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => PhoneInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"phone"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class PhoneInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    this.internalControl.addValidators(Validators.pattern(/^[0-9()+\-\s]*$/));
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-phone-input'];
+  }
+
+  /** Applies strongly typed metadata to the component. */
+  setInputMetadata(metadata: MaterialPhoneMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/search-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/search-input/index.ts
@@ -1,0 +1,1 @@
+export * from './search-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/search-input/search-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/search-input/search-input.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { SearchInputComponent } from './search-input.component';
+
+describe('SearchInputComponent', () => {
+  let component: SearchInputComponent;
+  let fixture: ComponentFixture<SearchInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SearchInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Search',
+      inputType: 'search',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate search value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = 'query';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('query');
+  });
+});
+

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/search-input/search-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/search-input/search-input.component.ts
@@ -1,0 +1,117 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialSearchInputMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML search inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="search">` element
+ * with Material styling and basic validation support. Built on top of the
+ * `SimpleBaseInputComponent` to leverage common functionality such as reactive
+ * forms integration and error handling.
+ */
+@Component({
+  selector: 'pdx-search-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Search' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [placeholder]="metadata()?.placeholder || ''"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [autocomplete]="metadata()?.autocomplete || 'off'"
+        [spellcheck]="metadata()?.spellcheck ?? true"
+        [type]="inputType()"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">{{
+          metadata()!.hint
+        }}</mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => SearchInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"search"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class SearchInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-search-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialSearchInputMetadata): void {
+    this.setMetadata(metadata);
+  }
+}
+

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/text-input/text-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/text-input/text-input.component.ts
@@ -93,7 +93,7 @@ import { SimpleBaseInputComponent, BaseValidationConfig } from '../../base/simpl
   ],
   host: {
     '[class]': 'componentCssClasses()',
-    '[attr.data-field-type]': '"text-input"',
+    '[attr.data-field-type]': '"input"',
     '[attr.data-field-name]': 'metadata()?.name',
     '[attr.data-component-id]': 'componentId()'
   }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/time-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/time-input/index.ts
@@ -1,0 +1,1 @@
+export * from './time-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/time-input/time-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/time-input/time-input.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { TimeInputComponent } from './time-input.component';
+
+describe('TimeInputComponent', () => {
+  let component: TimeInputComponent;
+  let fixture: ComponentFixture<TimeInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TimeInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TimeInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Time',
+      required: true,
+      inputType: 'time',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate time value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '12:34';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('12:34');
+  });
+
+  it('should validate required field', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '08:00';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+
+  it('should validate time format', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = 'invalid';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '09:15';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/time-input/time-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/time-input/time-input.component.ts
@@ -1,0 +1,118 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialTimeInputMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML time inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="time">` element
+ * with optional min/max/step constraints, basic validation and hint support.
+ * Built on top of the `SimpleBaseInputComponent` to reuse core features
+ * like reactive forms integration and error handling.
+ */
+@Component({
+  selector: 'pdx-time-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Time' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [min]="metadata()?.min || null"
+        [max]="metadata()?.max || null"
+        [step]="metadata()?.step || null"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">
+          {{ metadata()!.hint }}
+        </mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TimeInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"time"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class TimeInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    this.internalControl.addValidators(Validators.pattern(/^\d{2}:\d{2}$/));
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-time-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialTimeInputMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/url-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/url-input/index.ts
@@ -1,0 +1,1 @@
+export * from './url-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/url-input/url-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/url-input/url-input.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { UrlInputComponent } from './url-input.component';
+
+describe('UrlInputComponent', () => {
+  let component: UrlInputComponent;
+  let fixture: ComponentFixture<UrlInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UrlInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UrlInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Website',
+      required: true,
+      inputType: 'url',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate url value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = 'https://example.com';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('https://example.com');
+  });
+
+  it('should validate url format', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = 'ftp://invalid';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = 'https://valid.com';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/url-input/url-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/url-input/url-input.component.ts
@@ -1,0 +1,120 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialUrlInputMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML URL inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="url">` element
+ * with basic validation and hint support. Built on top of the
+ * `SimpleBaseInputComponent` to leverage common functionality such as
+ * reactive forms integration and error handling.
+ */
+@Component({
+  selector: 'pdx-url-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'URL' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [placeholder]="metadata()?.placeholder || ''"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [autocomplete]="metadata()?.autocomplete || 'off'"
+        [spellcheck]="metadata()?.spellcheck ?? false"
+        [maxlength]="metadata()?.maxLength || null"
+        [minlength]="metadata()?.minLength || null"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">
+          {{ metadata()!.hint }}
+        </mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => UrlInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"url"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class UrlInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    this.internalControl.addValidators(Validators.pattern(/^https?:\/\//i));
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-url-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialUrlInputMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/week-input/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/week-input/index.ts
@@ -1,0 +1,1 @@
+export * from './week-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/week-input/week-input.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/week-input/week-input.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { WeekInputComponent } from './week-input.component';
+
+describe('WeekInputComponent', () => {
+  let component: WeekInputComponent;
+  let fixture: ComponentFixture<WeekInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WeekInputComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WeekInputComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Week',
+      required: true,
+      inputType: 'week',
+      min: '2024-W01',
+      max: '2024-W52',
+    });
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate week value changes', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '2024-W10';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe('2024-W10');
+  });
+
+  it('should validate week format', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+
+    input.value = '2024-13';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeFalse();
+
+    input.value = '2024-W10';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.valid).toBeTrue();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/week-input/week-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/week-input/week-input.component.ts
@@ -1,0 +1,117 @@
+import { Component, forwardRef, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialWeekInputMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Specialized input component for HTML week inputs.
+ *
+ * Renders a `<mat-form-field>` containing an `<input type="week">` element
+ * with optional min/max constraints, basic validation and hint support.
+ * Built on top of the `SimpleBaseInputComponent` to reuse core features
+ * like reactive forms integration and error handling.
+ */
+@Component({
+  selector: 'pdx-week-input',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Week' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [type]="inputType()"
+        [min]="metadata()?.min || null"
+        [max]="metadata()?.max || null"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (focus)="handleFocus()"
+        (blur)="handleBlur()"
+        (input)="handleInput($event)"
+      />
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">
+          {{ metadata()!.hint }}
+        </mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => WeekInputComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"week"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class WeekInputComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  override ngOnInit(): void {
+    this.internalControl.addValidators(Validators.pattern(/^\d{4}-W\d{2}$/));
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-week-input'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialWeekInputMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/directives/dynamic-field-loader.directive.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/directives/dynamic-field-loader.directive.spec.ts
@@ -1,19 +1,24 @@
 /**
  * @fileoverview Testes unitários para DynamicFieldLoaderDirective
- * 
+ *
  * Testa renderização dinâmica de campos, integração com ComponentRegistryService,
  * validação de inputs e emissão de outputs.
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, DebugElement } from '@angular/core';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { DynamicFieldLoaderDirective } from './dynamic-field-loader.directive';
 import { ComponentRegistryService } from '../services/component-registry/component-registry.service';
-import { MaterialInputComponent } from '../components/material-input/material-input.component';
+import { TextInputComponent } from '../components/text-input/text-input.component';
 import { MaterialButtonComponent } from '../components/material-button/material-button.component';
 import { FieldMetadata } from '@praxis/core';
 
@@ -24,16 +29,17 @@ import { FieldMetadata } from '@praxis/core';
 @Component({
   template: `
     <form [formGroup]="testForm">
-      <ng-container 
-        dynamicFieldLoader 
-        [fields]="fields" 
+      <ng-container
+        dynamicFieldLoader
+        [fields]="fields"
         [formGroup]="testForm"
-        (componentsCreated)="onComponentsCreated($event)">
+        (componentsCreated)="onComponentsCreated($event)"
+      >
       </ng-container>
     </form>
   `,
   standalone: true,
-  imports: [ReactiveFormsModule, DynamicFieldLoaderDirective]
+  imports: [ReactiveFormsModule, DynamicFieldLoaderDirective],
 })
 class TestHostComponent {
   testForm: FormGroup;
@@ -57,7 +63,7 @@ class MockComponentRegistryService {
   async getComponent(controlType: string): Promise<any> {
     switch (controlType) {
       case 'input':
-        return MaterialInputComponent;
+        return TextInputComponent;
       case 'button':
         return MaterialButtonComponent;
       default:
@@ -82,24 +88,22 @@ describe('DynamicFieldLoaderDirective', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        TestHostComponent,
-        NoopAnimationsModule,
-        ReactiveFormsModule
-      ],
+      imports: [TestHostComponent, NoopAnimationsModule, ReactiveFormsModule],
       providers: [
         {
           provide: ComponentRegistryService,
-          useClass: MockComponentRegistryService
-        }
-      ]
+          useClass: MockComponentRegistryService,
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;
     registryService = TestBed.inject(ComponentRegistryService);
 
-    const directiveEl = fixture.debugElement.query(By.directive(DynamicFieldLoaderDirective));
+    const directiveEl = fixture.debugElement.query(
+      By.directive(DynamicFieldLoaderDirective),
+    );
     directive = directiveEl.injector.get(DynamicFieldLoaderDirective);
   });
 
@@ -126,7 +130,7 @@ describe('DynamicFieldLoaderDirective', () => {
     it('should throw error when fields is null', () => {
       component.fields = null as any;
       component.testForm = new FormBuilder().group({});
-      
+
       expect(() => {
         fixture.detectChanges();
       }).toThrowError('[DynamicFieldLoader] Input "fields" is required');
@@ -135,7 +139,7 @@ describe('DynamicFieldLoaderDirective', () => {
     it('should throw error when formGroup is null', () => {
       component.fields = [];
       component.testForm = null as any;
-      
+
       expect(() => {
         fixture.detectChanges();
       }).toThrowError('[DynamicFieldLoader] Input "formGroup" is required');
@@ -144,7 +148,7 @@ describe('DynamicFieldLoaderDirective', () => {
     it('should throw error when fields is not an array', () => {
       component.fields = {} as any;
       component.testForm = new FormBuilder().group({});
-      
+
       expect(() => {
         fixture.detectChanges();
       }).toThrowError('[DynamicFieldLoader] Input "fields" must be an array');
@@ -153,28 +157,28 @@ describe('DynamicFieldLoaderDirective', () => {
     it('should throw error when field is missing name', () => {
       component.fields = [{ controlType: 'input' } as any];
       component.testForm = new FormBuilder().group({});
-      
+
       expect(() => {
         fixture.detectChanges();
-      }).toThrowError('Field at index 0 must have a \'name\' property');
+      }).toThrowError("Field at index 0 must have a 'name' property");
     });
 
     it('should throw error when field is missing controlType', () => {
       component.fields = [{ name: 'test' } as any];
       component.testForm = new FormBuilder().group({});
-      
+
       expect(() => {
         fixture.detectChanges();
-      }).toThrowError('Field \'test\' must have a \'controlType\' property');
+      }).toThrowError("Field 'test' must have a 'controlType' property");
     });
 
     it('should throw error for duplicate field names', () => {
       component.fields = [
         { name: 'test', controlType: 'input' },
-        { name: 'test', controlType: 'button' }
+        { name: 'test', controlType: 'button' },
       ] as FieldMetadata[];
       component.testForm = new FormBuilder().group({});
-      
+
       expect(() => {
         fixture.detectChanges();
       }).toThrowError('Duplicate field names are not allowed: test');
@@ -192,18 +196,18 @@ describe('DynamicFieldLoaderDirective', () => {
           name: 'email',
           label: 'Email',
           controlType: 'input',
-          required: true
+          required: true,
         },
         {
           name: 'submit',
           label: 'Submit',
-          controlType: 'button'
-        }
+          controlType: 'button',
+        },
       ] as FieldMetadata[];
 
       component.testForm = new FormBuilder().group({
         email: ['', [Validators.required, Validators.email]],
-        submit: ['']
+        submit: [''],
       });
     });
 
@@ -224,7 +228,7 @@ describe('DynamicFieldLoaderDirective', () => {
       const emailComponent = component.createdComponents.get('email');
       const submitComponent = component.createdComponents.get('submit');
 
-      expect(emailComponent.componentType).toBe(MaterialInputComponent);
+      expect(emailComponent.componentType).toBe(TextInputComponent);
       expect(submitComponent.componentType).toBe(MaterialButtonComponent);
     });
 
@@ -264,12 +268,12 @@ describe('DynamicFieldLoaderDirective', () => {
         {
           name: 'unknown',
           label: 'Unknown',
-          controlType: 'unknownType'
-        }
+          controlType: 'unknownType',
+        } as any,
       ] as FieldMetadata[];
 
       component.testForm = new FormBuilder().group({
-        unknown: ['']
+        unknown: [''],
       });
 
       spyOn(console, 'warn');
@@ -277,25 +281,29 @@ describe('DynamicFieldLoaderDirective', () => {
       await fixture.whenStable();
 
       expect(console.warn).toHaveBeenCalledWith(
-        jasmine.stringContaining('No component found for controlType \'unknownType\'')
+        jasmine.stringContaining(
+          "No component found for controlType 'unknownType'",
+        ),
       );
       expect(component.createdComponents.size).toBe(0);
     });
 
     it('should handle registry errors gracefully', async () => {
-      spyOn(registryService, 'getComponent').and.rejectWith(new Error('Registry error'));
+      spyOn(registryService, 'getComponent').and.rejectWith(
+        new Error('Registry error'),
+      );
       spyOn(console, 'error');
 
       component.fields = [
         {
           name: 'test',
           label: 'Test',
-          controlType: 'input'
-        }
+          controlType: 'input',
+        },
       ] as FieldMetadata[];
 
       component.testForm = new FormBuilder().group({
-        test: ['']
+        test: [''],
       });
 
       try {
@@ -317,12 +325,12 @@ describe('DynamicFieldLoaderDirective', () => {
         {
           name: 'test',
           label: 'Test',
-          controlType: 'input'
-        }
+          controlType: 'input',
+        },
       ] as FieldMetadata[];
 
       component.testForm = new FormBuilder().group({
-        test: ['']
+        test: [''],
       });
     });
 
@@ -338,8 +346,8 @@ describe('DynamicFieldLoaderDirective', () => {
         {
           name: 'newField',
           label: 'New Field',
-          controlType: 'button'
-        }
+          controlType: 'button',
+        },
       ] as FieldMetadata[];
 
       component.testForm.addControl('newField', new FormBuilder().control(''));
@@ -357,20 +365,24 @@ describe('DynamicFieldLoaderDirective', () => {
 
       const oldFormGroup = component.testForm;
       component.testForm = new FormBuilder().group({
-        test: ['new value']
+        test: ['new value'],
       });
 
       fixture.detectChanges();
       await fixture.whenStable();
 
       const testComponent = component.createdComponents.get('test');
-      expect(testComponent.instance.formControl()).not.toBe(oldFormGroup.get('test'));
-      expect(testComponent.instance.formControl()).toBe(component.testForm.get('test'));
+      expect(testComponent.instance.formControl()).not.toBe(
+        oldFormGroup.get('test'),
+      );
+      expect(testComponent.instance.formControl()).toBe(
+        component.testForm.get('test'),
+      );
     });
 
     it('should clean up components on destroy', () => {
       fixture.detectChanges();
-      
+
       const destroySpy = jasmine.createSpy('destroy');
       if (component.createdComponents) {
         component.createdComponents.forEach((ref: any) => {
@@ -381,7 +393,9 @@ describe('DynamicFieldLoaderDirective', () => {
       fixture.destroy();
 
       if (component.createdComponents) {
-        expect(destroySpy).toHaveBeenCalledTimes(component.createdComponents.size);
+        expect(destroySpy).toHaveBeenCalledTimes(
+          component.createdComponents.size,
+        );
       }
     });
   });
@@ -396,18 +410,18 @@ describe('DynamicFieldLoaderDirective', () => {
         {
           name: 'email',
           label: 'Email',
-          controlType: 'input'
+          controlType: 'input',
         },
         {
           name: 'submit',
           label: 'Submit',
-          controlType: 'button'
-        }
+          controlType: 'button',
+        },
       ] as FieldMetadata[];
 
       component.testForm = new FormBuilder().group({
         email: [''],
-        submit: ['']
+        submit: [''],
       });
 
       fixture.detectChanges();
@@ -419,7 +433,7 @@ describe('DynamicFieldLoaderDirective', () => {
       const nonExistentComponent = directive.getComponent('nonexistent');
 
       expect(emailComponent).toBeDefined();
-      expect(emailComponent!.componentType).toBe(MaterialInputComponent);
+      expect(emailComponent!.componentType).toBe(TextInputComponent);
       expect(nonExistentComponent).toBeUndefined();
     });
 
@@ -434,12 +448,12 @@ describe('DynamicFieldLoaderDirective', () => {
 
     it('should provide refresh method', async () => {
       const initialSize = component.createdComponents.size;
-      
+
       // Modificar fields externamente
       component.fields.push({
         name: 'newField',
         label: 'New Field',
-        controlType: 'input'
+        controlType: 'input',
       } as FieldMetadata);
 
       component.testForm.addControl('newField', new FormBuilder().control(''));
@@ -466,7 +480,7 @@ describe('DynamicFieldLoaderDirective', () => {
       fixture.detectChanges();
 
       expect(console.warn).toHaveBeenCalledWith(
-        '[DynamicFieldLoader] Fields array is empty - no components will be rendered'
+        '[DynamicFieldLoader] Fields array is empty - no components will be rendered',
       );
     });
 
@@ -475,8 +489,8 @@ describe('DynamicFieldLoaderDirective', () => {
         {
           name: 'missingControl',
           label: 'Missing Control',
-          controlType: 'input'
-        }
+          controlType: 'input',
+        },
       ] as FieldMetadata[];
 
       component.testForm = new FormBuilder().group({}); // FormGroup sem o control
@@ -486,7 +500,9 @@ describe('DynamicFieldLoaderDirective', () => {
       await fixture.whenStable();
 
       expect(console.warn).toHaveBeenCalledWith(
-        jasmine.stringContaining('FormControl for field \'missingControl\' not found in FormGroup')
+        jasmine.stringContaining(
+          "FormControl for field 'missingControl' not found in FormGroup",
+        ),
       );
     });
 
@@ -495,12 +511,12 @@ describe('DynamicFieldLoaderDirective', () => {
         {
           name: 'test',
           label: 'Test',
-          controlType: 'input'
-        }
+          controlType: 'input',
+        },
       ] as FieldMetadata[];
 
       component.testForm = new FormBuilder().group({
-        test: ['']
+        test: [''],
       });
 
       spyOn(console, 'debug');
@@ -513,7 +529,7 @@ describe('DynamicFieldLoaderDirective', () => {
       await fixture.whenStable();
 
       expect(console.debug).toHaveBeenCalledWith(
-        '[DynamicFieldLoader] Waiting for current rendering to complete...'
+        '[DynamicFieldLoader] Waiting for current rendering to complete...',
       );
     });
   });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
@@ -4,7 +4,10 @@
  */
 
 import { Injectable } from '@angular/core';
-import { FieldControlType as FieldControlTypeEnum, type FieldControlType } from '@praxis/core';
+import {
+  FieldControlType as FieldControlTypeEnum,
+  type FieldControlType,
+} from '@praxis/core';
 import {
   IComponentRegistry,
   ComponentRegistration,
@@ -12,18 +15,20 @@ import {
   ComponentLoadResult,
   CACHE_TTL,
   MAX_LOAD_ATTEMPTS,
-  RETRY_DELAY
+  RETRY_DELAY,
 } from './component-registry.interface';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ComponentRegistryService implements IComponentRegistry {
-
   /**
    * Registro interno de componentes
    */
-  private readonly registry = new Map<FieldControlType, ComponentRegistration>();
+  private readonly registry = new Map<
+    FieldControlType,
+    ComponentRegistration
+  >();
 
   constructor() {
     this.initializeDefaultComponents();
@@ -38,7 +43,7 @@ export class ComponentRegistryService implements IComponentRegistry {
    */
   register<T>(
     type: FieldControlType,
-    factory: () => Promise<import('@angular/core').Type<T>>
+    factory: () => Promise<import('@angular/core').Type<T>>,
   ): void {
     this.registry.set(type, { factory });
   }
@@ -47,13 +52,17 @@ export class ComponentRegistryService implements IComponentRegistry {
    * Obtém um componente registrado com cache inteligente
    * Handles both string literals and enum values for backward compatibility
    */
-  async getComponent<T>(type: FieldControlType | string): Promise<import('@angular/core').Type<T> | null> {
+  async getComponent<T>(
+    type: FieldControlType | string,
+  ): Promise<import('@angular/core').Type<T> | null> {
     // Normalize the type - convert string literals to enum values if needed
     const normalizedType = this.normalizeControlType(type);
 
     const registration = this.registry.get(normalizedType);
     if (!registration) {
-      console.warn(`[ComponentRegistry] Componente '${type}' (normalized: '${normalizedType}') não registrado`);
+      console.warn(
+        `[ComponentRegistry] Componente '${type}' (normalized: '${normalizedType}') não registrado`,
+      );
       return null;
     }
 
@@ -86,7 +95,7 @@ export class ComponentRegistryService implements IComponentRegistry {
    * Limpa o cache de todos os componentes
    */
   clearCache(): void {
-    this.registry.forEach(registration => {
+    this.registry.forEach((registration) => {
       registration.cached = undefined;
       registration.cachedAt = undefined;
       registration.loadAttempts = 0;
@@ -103,13 +112,14 @@ export class ComponentRegistryService implements IComponentRegistry {
    * Obtém estatísticas do registro
    */
   getStats(): RegistryStats {
-    const cachedCount = Array.from(this.registry.values())
-      .filter(reg => reg.cached).length;
+    const cachedCount = Array.from(this.registry.values()).filter(
+      (reg) => reg.cached,
+    ).length;
 
     return {
       registeredComponents: this.registry.size,
       cachedComponents: cachedCount,
-      registeredTypes: this.getRegisteredTypes()
+      registeredTypes: this.getRegisteredTypes(),
     };
   }
 
@@ -145,13 +155,13 @@ export class ComponentRegistryService implements IComponentRegistry {
         const component = await this.getComponent(type);
         results.push({
           component,
-          success: !!component
+          success: !!component,
         });
       } catch (error) {
         results.push({
           component: null,
           success: false,
-          error: error as Error
+          error: error as Error,
         });
       }
     }
@@ -167,15 +177,20 @@ export class ComponentRegistryService implements IComponentRegistry {
    * Normalizes control type to handle both string literals and enum values
    * This provides backward compatibility for existing code using string literals
    */
-  private normalizeControlType(type: FieldControlType | string): FieldControlType {
+  private normalizeControlType(
+    type: FieldControlType | string,
+  ): FieldControlType {
     // If it's already a valid enum value, return as-is
-    if (Object.values(FieldControlTypeEnum).includes(type as FieldControlType)) {
+    if (
+      Object.values(FieldControlTypeEnum).includes(type as FieldControlType)
+    ) {
       return type as FieldControlType;
     }
 
     // Try to find matching enum value by string comparison
-    const enumEntry = Object.entries(FieldControlTypeEnum).find(([key, value]) =>
-      value === type || key.toLowerCase() === String(type).toLowerCase()
+    const enumEntry = Object.entries(FieldControlTypeEnum).find(
+      ([key, value]) =>
+        value === type || key.toLowerCase() === String(type).toLowerCase(),
     );
 
     if (enumEntry) {
@@ -183,7 +198,9 @@ export class ComponentRegistryService implements IComponentRegistry {
     }
 
     // Fallback: return the original type (might cause issues but maintains compatibility)
-    console.warn(`[ComponentRegistry] Could not normalize control type: '${type}'`);
+    console.warn(
+      `[ComponentRegistry] Could not normalize control type: '${type}'`,
+    );
     return type as FieldControlType;
   }
 
@@ -195,27 +212,123 @@ export class ComponentRegistryService implements IComponentRegistry {
    * Registra componentes Material Design padrão
    */
   private initializeDefaultComponents(): void {
-    // TextInputComponent para todos os tipos de input text-based
-    const textInputFactory = () => import('../../components/text-input/text-input.component').then(m => m.TextInputComponent);
+    // TextInputComponent para inputs genéricos
+    const textInputFactory = () =>
+      import('../../components/text-input/text-input.component').then(
+        (m) => m.TextInputComponent,
+      );
+
+    // Specialized email input
+    const emailInputFactory = () =>
+      import('../../components/email-input/email-input.component').then(
+        (m) => m.EmailInputComponent,
+      );
+
+    // Specialized password input
+    const passwordInputFactory = () =>
+      import('../../components/password-input/password-input.component').then(
+        (m) => m.PasswordInputComponent,
+      );
+
+    // Specialized color input
+    const colorInputFactory = () =>
+      import('../../components/color-input/color-input.component').then(
+        (m) => m.ColorInputComponent,
+      );
+
+    // Specialized date input
+    const dateInputFactory = () =>
+      import('../../components/date-input/date-input.component').then(
+        (m) => m.DateInputComponent,
+      );
+
+    // Specialized datetime-local input
+    const datetimeLocalInputFactory = () =>
+      import(
+        '../../components/datetime-local-input/datetime-local-input.component'
+      ).then((m) => m.DatetimeLocalInputComponent);
+
+    // Specialized month input
+    const monthInputFactory = () =>
+      import('../../components/month-input/month-input.component').then(
+        (m) => m.MonthInputComponent,
+      );
+
+    // Specialized number input
+    const numberInputFactory = () =>
+      import('../../components/number-input/number-input.component').then(
+        (m) => m.NumberInputComponent,
+      );
+
+    // Specialized search input
+    const searchInputFactory = () =>
+      import('../../components/search-input/search-input.component').then(
+        (m) => m.SearchInputComponent,
+      );
+
+    // Specialized phone input
+    const phoneInputFactory = () =>
+      import('../../components/phone-input/phone-input.component').then(
+        (m) => m.PhoneInputComponent,
+      );
+
+    // Specialized time input
+    const timeInputFactory = () =>
+      import('../../components/time-input/time-input.component').then(
+        (m) => m.TimeInputComponent,
+      );
+
+    // HTML5 url input
+    const urlInputFactory = () =>
+      import('../../components/url-input/url-input.component').then(
+        (m) => m.UrlInputComponent,
+      );
+
+    // HTML5 week input
+    const weekInputFactory = () =>
+      import('../../components/week-input/week-input.component').then(
+        (m) => m.WeekInputComponent,
+      );
 
     // Input básico
     this.register(FieldControlTypeEnum.INPUT, textInputFactory);
 
-    // Variantes de input usando TextInputComponent
-    this.register(FieldControlTypeEnum.EMAIL_INPUT, textInputFactory);
-    this.register(FieldControlTypeEnum.PASSWORD, textInputFactory);
-    this.register(FieldControlTypeEnum.NUMERIC_TEXT_BOX, textInputFactory);
+    // Variantes de input especializadas
+    this.register(FieldControlTypeEnum.EMAIL_INPUT, emailInputFactory);
+    this.register(FieldControlTypeEnum.PASSWORD, passwordInputFactory);
+    this.register(FieldControlTypeEnum.NUMERIC_TEXT_BOX, numberInputFactory);
+    this.register(FieldControlTypeEnum.SEARCH_INPUT, searchInputFactory);
+    this.register(FieldControlTypeEnum.PHONE, phoneInputFactory);
+    this.register(FieldControlTypeEnum.TIME_INPUT, timeInputFactory);
+    this.register(FieldControlTypeEnum.URL_INPUT, urlInputFactory);
+    this.register(FieldControlTypeEnum.WEEK_INPUT, weekInputFactory);
+
+    // HTML5 color input
+    this.register(FieldControlTypeEnum.COLOR_INPUT, colorInputFactory);
+
+    // HTML5 date input
+    this.register(FieldControlTypeEnum.DATE_INPUT, dateInputFactory);
+
+    // HTML5 datetime-local input
+    this.register(
+      FieldControlTypeEnum.DATETIME_LOCAL_INPUT,
+      datetimeLocalInputFactory,
+    );
+
+    // HTML5 month input
+    this.register(FieldControlTypeEnum.MONTH_INPUT, monthInputFactory);
 
     // Mapeamentos para controlTypes do JSON Schema/OpenAPI
-    this.register('numericTextBox' as FieldControlType, textInputFactory);
-    this.register('phone' as FieldControlType, textInputFactory);
-    this.register('date' as FieldControlType, textInputFactory);
+    this.register('numericTextBox' as FieldControlType, numberInputFactory);
+    this.register('phone' as FieldControlType, phoneInputFactory);
+    this.register('date' as FieldControlType, dateInputFactory);
     this.register('checkbox' as FieldControlType, textInputFactory);
 
-    // // Textarea
-    this.register(
-      FieldControlTypeEnum.EMAIL_INPUT,
-      () => import('../../components/material-textarea/material-textarea.component').then(m => m.MaterialTextareaComponent)
+    // Textarea
+    this.register(FieldControlTypeEnum.TEXTAREA, () =>
+      import(
+        '../../components/material-textarea/material-textarea.component'
+      ).then((m) => m.MaterialTextareaComponent),
     );
     //
     // // Select
@@ -379,11 +492,17 @@ export class ComponentRegistryService implements IComponentRegistry {
   /**
    * Carrega componente com lógica de retry
    */
-  private async loadComponentWithRetry<T>(registration: ComponentRegistration, type: string): Promise<import('@angular/core').Type<T> | null> {
+  private async loadComponentWithRetry<T>(
+    registration: ComponentRegistration,
+    type: string,
+  ): Promise<import('@angular/core').Type<T> | null> {
     const attempts = registration.loadAttempts || 0;
 
     if (attempts >= MAX_LOAD_ATTEMPTS) {
-      console.error(`[ComponentRegistry] Máximo de tentativas atingido para '${type}'. Último erro:`, registration.lastError);
+      console.error(
+        `[ComponentRegistry] Máximo de tentativas atingido para '${type}'. Último erro:`,
+        registration.lastError,
+      );
       return null;
     }
 
@@ -394,7 +513,9 @@ export class ComponentRegistryService implements IComponentRegistry {
       // Delay entre tentativas (exceto primeira)
       if (attempts > 0) {
         await this.delay(RETRY_DELAY * attempts);
-        console.warn(`[ComponentRegistry] Tentativa ${attempts + 1}/${MAX_LOAD_ATTEMPTS} para carregar '${type}'`);
+        console.warn(
+          `[ComponentRegistry] Tentativa ${attempts + 1}/${MAX_LOAD_ATTEMPTS} para carregar '${type}'`,
+        );
       }
 
       const component = await registration.factory();
@@ -407,13 +528,17 @@ export class ComponentRegistryService implements IComponentRegistry {
 
       // Log apenas na primeira vez que carrega (não em cache hits subsequentes)
       if (attempts === 0) {
-        console.info(`[ComponentRegistry] ✅ Componente '${type}' carregado com sucesso`);
+        console.info(
+          `[ComponentRegistry] ✅ Componente '${type}' carregado com sucesso`,
+        );
       }
       return component as import('@angular/core').Type<T>;
-
     } catch (error) {
       registration.lastError = error as Error;
-      console.error(`[ComponentRegistry] Erro na tentativa ${attempts + 1} para '${type}':`, error);
+      console.error(
+        `[ComponentRegistry] Erro na tentativa ${attempts + 1} para '${type}':`,
+        error,
+      );
 
       // Se não é a última tentativa, tentar novamente
       if (attempts + 1 < MAX_LOAD_ATTEMPTS) {
@@ -436,6 +561,6 @@ export class ComponentRegistryService implements IComponentRegistry {
    * Utilitário para delay
    */
   private delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
@@ -14,7 +14,19 @@ export * from './lib/directives/dynamic-field-loader.directive';
 export * from './lib/components/material-button/material-button.component';
 export * from './lib/components/material-button/confirm-dialog.component';
 export * from './lib/components/text-input/text-input.component';
+export * from './lib/components/color-input/color-input.component';
+export * from './lib/components/date-input/date-input.component';
+export * from './lib/components/datetime-local-input/datetime-local-input.component';
+export * from './lib/components/email-input/email-input.component';
+export * from './lib/components/number-input/number-input.component';
+export * from './lib/components/month-input/month-input.component';
+export * from './lib/components/password-input/password-input.component';
+export * from './lib/components/search-input/search-input.component';
 export * from './lib/components/preload-status/preload-status.component';
+export * from './lib/components/phone-input/phone-input.component';
+export * from './lib/components/time-input/time-input.component';
+export * from './lib/components/url-input/url-input.component';
+export * from './lib/components/week-input/week-input.component';
 
 // Services
 export * from './lib/services/action-resolver.service';


### PR DESCRIPTION
## Summary
- enforce ISO formats for date, datetime-local, month, time and week inputs
- validate phone and URL values with regex patterns and constrain numbers using min/max validators
- expand unit tests to cover invalid input cases across the new components
- align data-field-type host attributes with FieldControlType enum values for consistent component identification

## Testing
- `npm install`
- `CHROME_BIN=/usr/bin/chromium-browser npx ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed. Please install it with: snap install chromium)*

------
https://chatgpt.com/codex/tasks/task_e_688e5f45ba588328bc738f3651fcb488