### PR TITLE
docs: add audit reports for text-input, material-select, checkbox group, button, textarea, timepicker, preload status wrappers

### DIFF
--- a/docs/audit/material-button.md
+++ b/docs/audit/material-button.md
@@ -1,0 +1,37 @@
+# Material Button Wrapper Audit
+
+## Current API
+
+### Inputs
+- _None exposed_. Configuration is provided via `setButtonMetadata(metadata: MaterialButtonMetadata)`.
+
+### Outputs
+- `actionExecuted` – emitted when a configured action completes.
+- `click` – emitted on button click.
+- `focusChange` – emitted when the button gains or loses focus.
+
+### Host bindings
+- `[class]`: `componentCssClasses()`
+- `data-field-type="button"`
+- `data-field-name`: `metadata()?.name`
+- `data-button-variant`: `buttonVariant()`
+- `data-component-id`: `componentId()`
+
+## Supported Angular Material Features
+- All Material variants: `basic`, `raised`, `stroked`, `flat`, `icon`, `fab`, `mini-fab`
+- Configurable `color`, `type` and `disableRipple`
+- Prefix icons, tooltips and loading spinner
+- Keyboard shortcuts via `KeyboardShortcutService`
+
+## Missing Features vs. MatButton
+- No bindings for `tabIndex`, `aria-pressed`, or other ARIA attributes
+- Lacks anchor (`<a mat-button>`) and `href` support
+- `matBadge`, `matMenuTriggerFor`, and tooltip `panelClass` not configurable
+- No outputs for focus/blur or toggle state changes
+
+## Recommended Actions
+- Expose `tabIndex`, `aria-*` attributes and anchor support
+- Allow passing extra Material directives like `matBadge` or `matMenuTriggerFor`
+- Surface tooltip `panelClass` and additional styling hooks
+- Emit focus/blur and pressed state changes for integrations
+

--- a/docs/audit/material-checkbox-group.md
+++ b/docs/audit/material-checkbox-group.md
@@ -1,0 +1,45 @@
+# Material Checkbox Group Wrapper Audit
+
+## Current API
+
+### Inputs
+
+- _None exposed_. Configuration is provided via `setSelectMetadata(metadata: MaterialCheckboxMetadata)`.
+
+### Outputs
+
+- `valueChange` – emitted when the internal value updates.
+- `focusChange` – emitted when the field gains or loses focus.
+- `searchTermChange` – emitted when the search text changes.
+- `selectionChange` – emitted after the selection is updated.
+- `optionSelected` – emitted when a particular option is picked.
+- `optionsLoaded` – emitted after remote options are fetched.
+
+### Host bindings
+
+- `[class]`: `componentCssClasses()`
+- `data-field-type="checkbox"`
+- `data-field-name`: `metadata()?.name`
+- `data-component-id`: `componentId()`
+
+## Supported Angular Material Features
+
+- Multiple selection with `selectAll` helper and `maxSelections` limit
+- Dynamic option loading through `resourcePath`
+- Checkbox theming via `color` and `labelPosition`
+- Horizontal or vertical layouts using `layout` metadata
+
+## Missing Features vs. MatCheckbox
+
+- `indeterminate` state and related `indeterminateChange` event
+- Native `change` output for individual checkboxes
+- `name`, `id`, `aria-*` attributes and `tabIndex`
+- `required`, `disableRipple`, `value`, `checked`, `inputId`
+- No support for projecting custom checkbox content (`ng-content`)
+
+## Recommended Actions
+
+- Surface MatCheckbox inputs like `indeterminate`, `disableRipple` and ARIA attributes
+- Emit `change`/`indeterminateChange` for each option selection
+- Allow passing names, ids and tabindex to individual checkboxes
+- Support content projection for custom checkbox labels and descriptions

--- a/docs/audit/material-select.md
+++ b/docs/audit/material-select.md
@@ -1,0 +1,45 @@
+# Material Select Wrapper Audit
+
+## Current API
+
+### Inputs
+
+- _None exposed_. Configuration is provided via `setSelectMetadata(metadata: SimpleSelectMetadata)`.
+
+### Outputs
+
+- `valueChange` – emitted when the internal value updates.
+- `focusChange` – emitted when the field gains or loses focus.
+- `searchTermChange` – emitted when the search text changes.
+- `selectionChange` – emitted after the selection is updated.
+- `optionSelected` – emitted when a particular option is picked.
+- `optionsLoaded` – emitted after remote options are fetched.
+
+### Host bindings
+
+- `[class]`: `componentCssClasses()`
+- `data-field-type="select"`
+- `data-field-name`: `metadata()?.name`
+- `data-component-id`: `componentId()`
+
+## Supported Angular Material Features
+
+- Placeholder, required and disabled states
+- Basic single-selection behaviour via `FormControl`
+- `mat-form-field` appearance and color bindings
+
+## Missing Features vs. MatSelect
+
+- `multiple` selections or select-all helpers
+- `compareWith` and custom value comparison
+- `panelClass`, `backdropClass`, `disableOptionCentering`, `panelWidth`
+- `errorStateMatcher`, `id`, `name`, `tabIndex`, `aria-*` attributes
+- Open/close events and `openedChange`
+- Projection slots like `mat-select-trigger` and `mat-optgroup`
+
+## Recommended Actions
+
+- Expose core MatSelect inputs such as `compareWith`, `panelClass` and ARIA attributes
+- Emit open/close related outputs to mirror MatSelect events
+- Support content projection for custom trigger and option grouping
+- Allow configuration of multiple selection when appropriate or document limitations

--- a/docs/audit/material-textarea.md
+++ b/docs/audit/material-textarea.md
@@ -1,0 +1,36 @@
+# Material Textarea Wrapper Audit
+
+## Current API
+
+### Inputs
+- _None exposed_. Configuration is provided via `setTextareaMetadata(metadata: MaterialTextareaMetadata)`.
+
+### Outputs
+- `valueChange` – emitted when the internal value updates.
+- `focusChange` – emitted when the field gains or loses focus.
+
+### Host bindings
+- `[class]`: `componentCssClasses()`
+- `data-field-type="textarea"`
+- `data-field-name`: `metadata()?.name`
+- `data-component-id`: `componentId()`
+
+## Supported Angular Material Features
+- `mat-form-field` appearance, color, `floatLabel` and `hideRequiredMarker`
+- Prefix/suffix icons and hint text
+- Character counter and validation messages via `mat-hint`/`mat-error`
+- Auto-resize with `cdkTextareaAutosize`
+- Placeholder, min/max length, `readonly`, `spellcheck`, rows/cols, `aria-describedby`
+
+## Missing Features vs. MatTextarea
+- No bindings for `name`, `id`, or `autocomplete`
+- Lacks `aria-label`, `aria-labelledby`, and `tabIndex`
+- Cannot project custom prefix/suffix content beyond icons
+- No outputs for `input`, `blur` or `keydown` events
+
+## Recommended Actions
+- Surface `name`, `id`, `autocomplete`, and ARIA attributes
+- Expose `tabIndex` and allow custom content projection
+- Emit native events such as `input` and `blur`
+- Support additional Material features like `matTextareaAutosize` options and theming hooks
+

--- a/docs/audit/material-timepicker.md
+++ b/docs/audit/material-timepicker.md
@@ -1,0 +1,36 @@
+# Material Timepicker Wrapper Audit
+
+## Current API
+
+### Inputs
+- _None exposed_. Configuration is provided via `setInputMetadata(metadata: MaterialTimepickerMetadata)`.
+
+### Outputs
+- `valueChange` – emitted when the internal value updates.
+- `focusChange` – emitted when the field gains or loses focus.
+- `validationChange` – emitted after asynchronous validation completes.
+
+### Host bindings
+- `[class]`: `componentCssClasses()`
+- `data-field-type="timePicker"`
+- `data-field-name`: `metadata()?.name`
+- `data-component-id`: `componentId()`
+
+## Supported Angular Material Features
+- `mat-timepicker` with configurable `interval`, `touchUi`, `format` and `showSeconds`
+- Min/max time, open-on-click and custom filter function
+- Prefix icon, hint text and validation messages
+- Step minute/second enforcement and ARIA labels
+
+## Missing Features vs. MatTimepicker
+- No outputs for `opened`/`closed` events
+- `panelClass`, `timepickerToggleIcon` and theming options not configurable
+- Lacks bindings for `tabIndex`, `aria-describedby`, or toggle button attributes
+- Cannot programmatically `open`/`close` the picker via metadata
+
+## Recommended Actions
+- Emit `opened`/`closed` events and expose programmatic control methods
+- Surface `panelClass`, toggle customization and additional styling hooks
+- Allow setting `tabIndex`, `aria-*` attributes and step granularity
+- Provide access to timepicker instance for advanced usage
+

--- a/docs/audit/preload-status.md
+++ b/docs/audit/preload-status.md
@@ -1,0 +1,31 @@
+# Preload Status Component Audit
+
+## Current API
+
+### Inputs
+- _None exposed_. Component consumes `ComponentPreloaderService` directly.
+
+### Outputs
+- _None emitted_. All interactions are internal.
+
+### Host bindings
+- _None defined_.
+
+## Supported Features
+- Displays overall preload progress and loaded/failed counts
+- Shows current component being preloaded
+- Manual reload and auto-update toggle controls
+- Uses Material Card, ProgressBar, Chips, Buttons and Icons for visualization
+
+## Missing Features
+- No inputs to customize labels, colors or polling interval
+- Does not emit events when reload or auto-update state changes
+- Lacks ARIA roles and attributes for assistive technologies
+- Styling and theming cannot be configured externally
+
+## Recommended Actions
+- Expose inputs for messages, theming and refresh interval
+- Emit outputs for status changes and user-triggered reloads
+- Add ARIA roles/attributes for accessibility
+- Allow external styling hooks or content projection for advanced customization
+

--- a/docs/audit/text-input.md
+++ b/docs/audit/text-input.md
@@ -1,0 +1,38 @@
+# Text Input Wrapper Audit
+
+## Current API
+
+### Inputs
+- _None exposed_. Configuration is provided via `setInputMetadata(metadata: MaterialInputMetadata)`.
+
+### Outputs
+- `valueChange` – emitted when the internal value updates.
+- `focusChange` – emitted when the field gains or loses focus.
+- `validationChange` – emitted after `validateField()` runs.
+
+### Host bindings
+- `[class]`: `componentCssClasses()`
+- `data-field-type="input"`
+- `data-field-name`: `metadata()?.name`
+- `data-component-id`: `componentId()`
+
+## Supported Angular Material Features
+- Placeholder, required, type, autocomplete, spellcheck, readonly
+- MaxLength/MinLength, aria-label, aria-required
+- Prefix/suffix icons, hint with alignment, character counter
+- `mat-form-field` appearance and color
+
+## Missing Features vs. MatInput / MatFormField
+- `name` and `id` attributes on the `<input>` element
+- `autoFocus` and `inputMode`
+- Text-based prefix/suffix and clear button
+- `floatLabel`, `subscriptSizing`, `hideRequiredMarker`
+- `errorStateMatcher` and `disabledInteractive`
+- `aria-describedby` / `aria-labelledby` handling
+- No support for projecting custom content (`ng-content`)
+
+## Recommended Actions
+- Expose and bind the missing attributes to the underlying `<input>` or `<mat-form-field>`
+- Implement clear button and text prefix/suffix slots
+- Surface material form-field options such as `floatLabel`
+- Wire up `errorStateMatcher` and ARIA descriptors for accessibility


### PR DESCRIPTION
## Summary
- document current API and gaps for text-input, material-select, material-checkbox-group, material-button, material-textarea, material-timepicker, and preload-status wrappers

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891035290d48328b3e96aae8ec8439a