### PR TITLE
docs: deepen dynamic field wrapper audit reports

### DIFF
--- a/frontend-libs/praxis-ui-workspace/audit/color-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/color-input.md
@@ -1,0 +1,31 @@
+# pdx-color-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, prefixIcon, suffixIcon, required, readonly, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não há suporte a `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher`, `disabled` ou eventos nativos (`change`, `blur`).
+- Sem opção para valor padrão ou transparência.
+
+## Integridade do Código e Lógica de Negócio
+
+- `matInput` é usado apenas para estilização; campo não suporta placeholder.
+- Acessibilidade e personalização limitadas à base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Expor `disabled` e atributos ARIA adicionais.
+- Permitir configuração de valor inicial e eventos nativos.
+- Avaliar suporte a prefixos/sufixos customizados além de ícones.

--- a/frontend-libs/praxis-ui-workspace/audit/date-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/date-input.md
@@ -1,0 +1,31 @@
+# pdx-date-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, prefixIcon, suffixIcon, required, readonly, min, max, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não há exposição de `step`, `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher` ou `disabled` via metadados.
+- Eventos `change`/`blur` não são encaminhados ao exterior.
+
+## Integridade do Código e Lógica de Negócio
+
+- Validação fixa no formato `YYYY-MM-DD`.
+- Estilização e acessibilidade iguais às demais entradas baseadas em `SimpleBaseInputComponent`.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Permitir configuração de `step` e de estado `disabled`.
+- Expor atributos ARIA adicionais e eventos nativos.
+- Considerar suporte a formato local ou máscaras.

--- a/frontend-libs/praxis-ui-workspace/audit/datetime-local-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/datetime-local-input.md
@@ -1,0 +1,30 @@
+# pdx-datetime-local-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, prefixIcon, suffixIcon, required, readonly, min, max, step, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Falta suporte a `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher`, controle `disabled` e eventos `change`/`blur`.
+
+## Integridade do Código e Lógica de Negócio
+
+- Validação fixa no formato `YYYY-MM-DDTHH:MM`.
+- Estilização e acessibilidade limitadas pela base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Permitir configuração de atributos nativos adicionais e propagação de eventos.
+- Expor `disabled` e atributos ARIA extras.
+- Considerar suporte a segundos e fuso horário.

--- a/frontend-libs/praxis-ui-workspace/audit/email-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/email-input.md
@@ -1,0 +1,31 @@
+# pdx-email-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, prefixIcon, suffixIcon, required, autocomplete, spellcheck, readonly, minLength, maxLength, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não há suporte para `multiple`, `size`, `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher` ou controle `disabled` via metadados.
+- Eventos nativos (`change`, `blur`) não são expostos ao consumidor.
+
+## Integridade do Código e Lógica de Negócio
+
+- Validação baseada em `Validators.email`; demais padrões precisam ser configurados na classe base.
+- Mesmas limitações de estilização e acessibilidade do componente base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Expor `disabled`, `name` e atributos ARIA adicionais.
+- Permitir configuração de `multiple`, `inputmode` e tamanho.
+- Emitir eventos nativos para integração externa.

--- a/frontend-libs/praxis-ui-workspace/audit/material-async-select.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-async-select.md
@@ -1,0 +1,32 @@
+# pdx-material-async-select
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, required, disabled, hint, selectOptions/options, multiple, resourcePath, filterCriteria, optionLabelKey, optionValueKey, defaultValue.
+- **Outputs**: `valueChange`, `focusChange`, `selectionChange`, `optionSelected`, `optionsLoaded`.
+
+## Propriedades/eventos ausentes
+
+- Não mapeia atributos do `MatSelect` como `compareWith`, `disableRipple`, `panelClass`, `panelWidth`, `panelOpen`, `errorStateMatcher`, `name`, `id`, `tabIndex`, `aria-*`, `typeaheadDebounceInterval`, `disableOptionCentering` ou `scrollStrategy`.
+- Eventos `openedChange`, `closed` e `optionSelectionChanges` não são expostos.
+
+## Integridade do Código e Lógica de Negócio
+
+- Opções carregadas apenas ao abrir o painel, sem paginação ou busca configurável.
+- Estado de erro exibido como `mat-option` estático e sem mapeamento para mensagens personalizadas.
+- Estilização e acessibilidade limitadas; não há `panelClass` ou atributos ARIA.
+- Ausência de `compareWith` compromete seleção de objetos complexos.
+- Opções dinâmicas não possuem tratamento de erro ou estado de carregamento consistente.
+- Falta de revalidação do `defaultValue` quando a lista de opções é atualizada.
+
+## Cenários Corporativos e UX
+
+- Carência de suporte a grandes datasets (virtual scroll, paginação) comuns em ambientes corporativos.
+- Mensagens de vazio, carregamento e erro não são personalizáveis.
+- Acessibilidade limitada: navegação por teclado e atributos ARIA adicionais são necessários.
+
+## Ações recomendadas
+
+- Expor atributos e eventos nativos do `MatSelect` e permitir paginação/pesquisa remota.
+- Suportar `panelClass`, `ngClass` e mensagens de erro configuráveis.
+- Disponibilizar evento `openedChange` e opções de acessibilidade ARIA.

--- a/frontend-libs/praxis-ui-workspace/audit/material-button.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-button.md
@@ -1,0 +1,31 @@
+# pdx-material-button
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, variant, icon, color, tooltip, disabled, loading, confirm, action, shortcut.
+- **Outputs**: `clicked`, `actionExecuted`, `focus`, `blur`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe atributos nativos do `MatButton` como `type`, `href`, `tabIndex`, `aria-*`, `disableRipple`, `name`, `id`.
+- Eventos nativos como `mouseover`, `mouseleave` e teclas de atalho não são repassados.
+
+## Integridade do Código e Lógica de Negócio
+
+- Estilização limitada a classes pré-definidas; não há suporte a `ngClass`/`ngStyle` dinâmicos.
+- Conteúdo do botão restrito a texto e ícone único; não suporta projeção livre.
+- Ausência de `type` explícito pode causar submits indesejados.
+- Estado `disabled` não previne múltiplos cliques ou ações concorrentes.
+- Sem rastreabilidade de ações para auditoria ou logging.
+
+## Cenários Corporativos e UX
+
+- Falta de indicador de progresso ou confirmação visual para operações longas.
+- Tematização e tamanhos não seguem padrões corporativos por metadados.
+- Acessibilidade limitada: ausência de `aria-label` e suporte a atalhos de teclado.
+
+## Ações recomendadas
+
+- Mapear e repassar atributos do `MatButton`, incluindo `type`, `disableRipple` e atributos ARIA.
+- Expor eventos nativos de mouse e teclado.
+- Permitir projeção de conteúdo e customização de classes/estilos.

--- a/frontend-libs/praxis-ui-workspace/audit/material-checkbox-group.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-checkbox-group.md
@@ -1,0 +1,31 @@
+# pdx-material-checkbox-group
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, color, layout, checkboxOptions/options, selectAll, searchable, resourcePath, filterCriteria, optionLabelKey, optionValueKey, maxSelections.
+- **Outputs**: `valueChange`, `focusChange`, `selectionChange`, `optionsLoaded`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe atributos do `MatCheckbox` como `indeterminate`, `aria-label`, `aria-labelledby`, `disableRipple`, `tabIndex`.
+- Eventos nativos `change`/`indeterminateChange` não são repassados.
+
+## Integridade do Código e Lógica de Negócio
+
+- `selectAll` implementado sem estado indeterminado no checkbox mestre.
+- Sem suporte para `ngClass` ou `labelPosition` por opção individual.
+- Falta de controle de seleção mínima/máxima além do `maxSelections` informado.
+- Estado `disabled` não é propagado por opção e `indeterminate` não é suportado.
+- Regras de negócio específicas (ex.: dependências entre opções) não são tratadas.
+
+## Cenários Corporativos e UX
+
+- Listas extensas carecem de busca ou agrupamento para facilitar seleção.
+- Mensagens de erro e labels customizáveis são limitadas.
+- Navegação por teclado e leitura por screen readers podem ser melhoradas.
+
+## Ações recomendadas
+
+- Mapear e repassar atributos e eventos nativos para cada checkbox.
+- Implementar estado indeterminado e personalização por opção.
+- Permitir classes e estilos dinâmicos nas opções.

--- a/frontend-libs/praxis-ui-workspace/audit/material-date-range.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-date-range.md
@@ -1,0 +1,31 @@
+# pdx-material-date-range
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, required, readonly, prefixIcon, suffixIcon, startPlaceholder, endPlaceholder, minDate, maxDate, startAt, touchUi, dateFilter, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange`, `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe atributos do `MatDateRangeInput`/`MatDateRangePicker` como `color`, `disabled`, `panelClass`, `comparisonStart`, `comparisonEnd`, `openedStream`, `closedStream`.
+- Falta suporte a `tabIndex`, `aria-describedby` e métodos `open`/`close`.
+
+## Integridade do Código e Lógica de Negócio
+
+- Classes fixas; não há `ngClass` ou `panelClass` dinâmico para o range picker.
+- Sem projeção de conteúdo para prefix/suffix além de ícones.
+- Não valida se a data inicial é menor ou igual à final.
+- `min`, `max` e `dateFilter` do `MatDateRangeInput` não são expostos.
+- Estado `disabled` e `required` não sincroniza para ambos os campos.
+
+## Cenários Corporativos e UX
+
+- Falta de formatos e localizações customizáveis para padrões corporativos.
+- Ausência de feedback visual quando o intervalo é inválido.
+- Não há seleção rápida (hoje, última semana) típica em sistemas empresariais.
+
+## Ações recomendadas
+
+- Mapear atributos restantes do `MatDateRangePicker` e repassar eventos de abertura/fechamento.
+- Permitir personalização de classes/`panelClass` e atributos ARIA.
+- Suportar conteúdo customizado para prefixos e sufixos.

--- a/frontend-libs/praxis-ui-workspace/audit/material-datepicker.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-datepicker.md
@@ -1,0 +1,31 @@
+# pdx-material-datepicker
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, required, readonly, prefixIcon, suffixIcon, minDate, maxDate, startAt, startView, touchUi, dateFilter, hint, hintAlign, ariaLabel.
+- **Outputs**: `valueChange`, `focusChange`, `validationChange`, `dateChange`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe atributos do `MatDatepicker`/`MatDatepickerInput` como `color`, `panelClass`, `tabIndex`, `panelOpen`, `openedStream`, `closedStream`.
+- Não propaga métodos `open`/`close` nem eventos `monthSelected`/`yearSelected`.
+
+## Integridade do Código e Lógica de Negócio
+
+- Estilização restrita ao `mat-form-field`; sem `panelClass` ou `ngClass` dinâmico.
+- Entrada não repassa eventos nativos `input`/`change`.
+- `min`, `max` e `dateFilter` não são expostos via metadados.
+- Não há tratamento para datas inválidas digitadas manualmente.
+- Configuração de fuso horário e formatação depende do ambiente externo.
+
+## Cenários Corporativos e UX
+
+- Falta de atalhos de seleção rápida e suporte a calendários corporativos (feriados).
+- Mensagens de erro e formatação local não são personalizáveis.
+- Acessibilidade do calendário (atalhos, leitores de tela) é limitada.
+
+## Ações recomendadas
+
+- Mapear atributos e eventos faltantes, incluindo `open`/`close`.
+- Permitir customização de classes/painel e atributos ARIA.
+- Repassar eventos nativos do input.

--- a/frontend-libs/praxis-ui-workspace/audit/material-multi-select.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-multi-select.md
@@ -1,0 +1,32 @@
+# pdx-material-multi-select
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, required, disabled, hint, selectOptions/options, searchable, selectAll, maxSelections, resourcePath, filterCriteria, optionLabelKey, optionValueKey, defaultValue.
+- **Outputs**: `valueChange`, `focusChange`, `selectionChange`, `optionSelected`, `optionsLoaded`.
+
+## Propriedades/eventos ausentes
+
+- Falta suporte a atributos do `MatSelect` como `compareWith`, `disableRipple`, `panelClass`, `panelWidth`, `panelOpen`, `errorStateMatcher`, `name`, `id`, `tabIndex`, `aria-*`, `typeaheadDebounceInterval`, `disableOptionCentering` e `scrollStrategy`.
+- Eventos nativos `openedChange`, `closed` e `optionSelectionChanges` não são emitidos.
+
+## Integridade do Código e Lógica de Negócio
+
+- Metadado `searchable` é aceito, porém não há campo de busca no template.
+- Opção "Selecionar todos" e limite `maxSelections` implementados de forma estática.
+- Acessibilidade limitada e ausência de classes dinâmicas ou `panelClass`.
+- Ausência de `compareWith` compromete seleção de objetos complexos.
+- Opções dinâmicas não possuem tratamento de erro ou estado de carregamento consistente.
+- Falta de revalidação do `defaultValue` quando a lista de opções é atualizada.
+
+## Cenários Corporativos e UX
+
+- Carência de suporte a grandes datasets (virtual scroll, paginação) comuns em ambientes corporativos.
+- Mensagens de vazio, carregamento e erro não são personalizáveis.
+- Acessibilidade limitada: navegação por teclado e atributos ARIA adicionais são necessários.
+
+## Ações recomendadas
+
+- Expor atributos ausentes do `MatSelect` e eventos de abertura/fechamento.
+- Implementar busca interna e suporte configurável a `selectAll`/`maxSelections`.
+- Permitir `panelClass`, `ngClass` e personalização de opções via template.

--- a/frontend-libs/praxis-ui-workspace/audit/material-radio-group.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-radio-group.md
@@ -1,0 +1,30 @@
+# pdx-material-radio-group
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, color, layout, radioOptions/options, resourcePath, filterCriteria, optionLabelKey, optionValueKey.
+- **Outputs**: `valueChange`, `focusChange`, `selectionChange`, `optionsLoaded`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe atributos do `MatRadioGroup`/`MatRadioButton` como `name`, `aria-label`, `disableRipple`, `tabIndex`, `labelPosition` individual.
+- Eventos `change` nativo do `MatRadioGroup` não é repassado.
+
+## Integridade do Código e Lógica de Negócio
+
+- Não suporta ng-content para personalização de opções.
+- Estilização limitada, sem `ngClass` dinâmico no grupo ou opções.
+- Valor padrão não é revalidado ao atualizar opções.
+- Falta exposição de `name` e `aria-labelledby` para identificação adequada.
+- Não há regras para seleção obrigatória ou desabilitar opções condicionais.
+
+## Cenários Corporativos e UX
+
+- Ausência de layouts responsivos e controle de orientação via metadados.
+- Mensagens de erro e tooltips não são personalizáveis.
+- Navegação por teclado e foco visível precisam ser garantidos.
+
+## Ações recomendadas
+
+- Permitir configuração de atributos nativos (`name`, ARIA) e eventos.
+- Suportar customização de classes e projeção de conteúdo para opções.

--- a/frontend-libs/praxis-ui-workspace/audit/material-searchable-select.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-searchable-select.md
@@ -1,0 +1,32 @@
+# pdx-material-searchable-select
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, required, disabled, hint, selectOptions/options, multiple, selectAll, maxSelections, resourcePath, filterCriteria, optionLabelKey, optionValueKey, defaultValue.
+- **Outputs**: `valueChange`, `focusChange`, `selectionChange`, `optionSelected`, `optionsLoaded`, `searchTermChange`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe `compareWith`, `disableRipple`, `panelClass`, `panelWidth`, `panelOpen`, `errorStateMatcher`, `name`, `id`, `tabIndex`, `aria-*`, `typeaheadDebounceInterval`, `disableOptionCentering` e `scrollStrategy` do `MatSelect`.
+- Eventos `openedChange`, `closed` e `optionSelectionChanges` não estão disponíveis.
+
+## Integridade do Código e Lógica de Negócio
+
+- Campo de busca possui placeholder fixo e sem configuração de debounce.
+- Metadados `selectAll` e `maxSelections` não possuem implementação de UI.
+- Falta suporte a templates customizados e classes dinâmicas no painel de seleção.
+- Ausência de `compareWith` compromete seleção de objetos complexos.
+- Opções dinâmicas não possuem tratamento de erro ou estado de carregamento consistente.
+- Falta de revalidação do `defaultValue` quando a lista de opções é atualizada.
+
+## Cenários Corporativos e UX
+
+- Carência de suporte a grandes datasets (virtual scroll, paginação) comuns em ambientes corporativos.
+- Mensagens de vazio, carregamento e erro não são personalizáveis.
+- Acessibilidade limitada: navegação por teclado e atributos ARIA adicionais são necessários.
+
+## Ações recomendadas
+
+- Mapear atributos e eventos nativos do `MatSelect`, inclusive `openedChange` e `closed`.
+- Tornar configuráveis placeholder e debounce da busca; implementar `selectAll`/`maxSelections` no template.
+- Permitir customização de opções, `panelClass`, `ngClass` e atributos ARIA.

--- a/frontend-libs/praxis-ui-workspace/audit/material-select.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-select.md
@@ -1,0 +1,32 @@
+# pdx-material-select
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, required, disabled, hint, selectOptions/options, searchable, resourcePath, filterCriteria, optionLabelKey, optionValueKey, defaultValue.
+- **Outputs**: `valueChange`, `focusChange`, `selectionChange`, `optionSelected`, `optionsLoaded`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe atributos do `MatSelect` como `compareWith`, `disableRipple`, `panelClass`, `panelWidth`, `panelOpen`, `errorStateMatcher`, `name`, `id`, `tabIndex`, `aria-*`, `typeaheadDebounceInterval`, `disableOptionCentering` ou `scrollStrategy`.
+- Eventos nativos `openedChange`, `closed` e `optionSelectionChanges` não são repassados.
+
+## Integridade do Código e Lógica de Negócio
+
+- Estilização limitada ao `mat-form-field`; não há suporte para `panelClass` ou `ngClass` dinâmico no `mat-select`.
+- Acessibilidade restrita a `mat-label`, sem atributos ARIA adicionais.
+- Opções renderizadas apenas como texto, sem projeção de templates customizados.
+- Ausência de `compareWith` compromete seleção de objetos complexos.
+- Opções dinâmicas não possuem tratamento de erro ou estado de carregamento consistente.
+- Falta de revalidação do `defaultValue` quando a lista de opções é atualizada.
+
+## Cenários Corporativos e UX
+
+- Carência de suporte a grandes datasets (virtual scroll, paginação) comuns em ambientes corporativos.
+- Mensagens de vazio, carregamento e erro não são personalizáveis.
+- Acessibilidade limitada: navegação por teclado e atributos ARIA adicionais são necessários.
+
+## Ações recomendadas
+
+- Mapear e expor atributos e eventos faltantes do `MatSelect` via metadados.
+- Permitir customização de classes (`panelClass`, `ngClass`) e atributos ARIA.
+- Suportar projeção de conteúdo para `mat-select-trigger` e opções avançadas.

--- a/frontend-libs/praxis-ui-workspace/audit/material-textarea.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-textarea.md
@@ -1,0 +1,31 @@
+# pdx-material-textarea
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, required, readonly, hint, prefixIcon, suffixIcon, autoSize, maxLength, minLength, rows, cols, hintAlign, spellcheck, materialDesign.floatLabel, cssClass.
+- **Outputs**: `valueChange`, `focusChange`, `blur`, `input`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe atributos nativos do `<textarea>`/`MatInput` como `name`, `id`, `tabIndex`, `autocomplete`, `aria-*`, `disabled`, `errorStateMatcher`.
+- Eventos como `selectionChange`, `keydown`, `keyup` não são configuráveis.
+
+## Integridade do Código e Lógica de Negócio
+
+- Customização de classes limitada; não há `ngClass` dinâmico no `mat-form-field` ou no `<textarea>`.
+- Projeção de conteúdo restrita a ícones; sem suporte a prefix/suffix customizados.
+- Falta validação de tamanho máximo de conteúdo e número de linhas.
+- Estado `disabled` e contagem de caracteres não sincronizam com o `FormControl`.
+- Ausência de auto-resize configurável via metadados.
+
+## Cenários Corporativos e UX
+
+- Suporte limitado a redimensionamento controlado e atalhos de formatação.
+- Mensagens de erro e ajuda contextual não são customizáveis.
+- Não há mecanismos de sanitização para prevenir XSS em textos longos.
+
+## Ações recomendadas
+
+- Mapear atributos nativos e ARIA do textarea e `MatInput`.
+- Expor eventos adicionais e permitir injeção de classes/estilos.
+- Suportar prefixos/sufixos projetados e opções de auto-resize configuráveis.

--- a/frontend-libs/praxis-ui-workspace/audit/material-timepicker.md
+++ b/frontend-libs/praxis-ui-workspace/audit/material-timepicker.md
@@ -1,0 +1,31 @@
+# pdx-material-timepicker
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, required, readonly, prefixIcon, suffixIcon, min, max, stepMinute, stepSecond, interval, touchUi, format, showSeconds, timeFilter, timeOptions, hint, hintAlign, ariaLabel.
+- **Outputs**: `valueChange`, `focusChange`, `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe atributos do `MatTimepicker` como `color`, `panelClass`, `openOnFocus`, `openedStream`, `closedStream`.
+- Falta repasse de eventos nativos do input (`timeChange`, `timeInput`) e métodos `open`/`close`.
+
+## Integridade do Código e Lógica de Negócio
+
+- Estilização e classes do `mat-timepicker` não são configuráveis.
+- Falta suporte ARIA avançado e `tabIndex` para controle do input.
+- Não expõe formatos 12h/24h ou validação de faixas de horário.
+- Estado `disabled`/`required` não sincroniza com o input nativo.
+- Falta de integração com `FormControl` para horários inválidos.
+
+## Cenários Corporativos e UX
+
+- Necessidade de suporte a timezone e locale corporativo.
+- Ausência de atalhos rápidos e máscara de digitação.
+- Navegação por teclado e acessibilidade precisam de melhorias.
+
+## Ações recomendadas
+
+- Mapear atributos restantes do `MatTimepicker` e repassar eventos/controles.
+- Permitir customização de classes/painel e atributos ARIA.
+- Propagar eventos nativos do input de tempo.

--- a/frontend-libs/praxis-ui-workspace/audit/month-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/month-input.md
@@ -1,0 +1,30 @@
+# pdx-month-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, prefixIcon, suffixIcon, required, readonly, min, max, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não há suporte a `step`, `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher`, `disabled` ou eventos `change`/`blur`.
+
+## Integridade do Código e Lógica de Negócio
+
+- Validação fixa no formato `YYYY-MM`.
+- Estilização e acessibilidade limitadas à implementação base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Adicionar configuração de `step` e `disabled` via metadados.
+- Expor eventos nativos e atributos ARIA adicionais.
+- Considerar suporte a formatações regionais.

--- a/frontend-libs/praxis-ui-workspace/audit/number-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/number-input.md
@@ -1,0 +1,31 @@
+# pdx-number-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, prefixIcon, suffixIcon, required, readonly, min, max, step, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Faltam atributos do `MatInput` como `errorStateMatcher`, `name`, `id`, `tabIndex`, `inputmode`, `aria-describedby` e controle explícito de `disabled`.
+- Eventos nativos (`change`, `blur`) não são expostos.
+
+## Integridade do Código e Lógica de Negócio
+
+- Usa validação via `Validators.min`, `max` e `pattern` numérico, porém o pattern não é configurável.
+- Estilização e acessibilidade seguem as limitações do componente base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Permitir configuração de `inputmode`, `step` e `disabled` via metadados.
+- Propagar atributos ARIA adicionais e eventos nativos.
+- Tornar o pattern validável configurável.

--- a/frontend-libs/praxis-ui-workspace/audit/password-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/password-input.md
@@ -1,0 +1,31 @@
+# pdx-password-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, prefixIcon, suffixIcon, required, autocomplete, readonly, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe `minLength`, `maxLength`, `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher` ou `disabled` via metadados.
+- Falta evento para alternar visibilidade e não emite `change`/`blur` externamente.
+
+## Integridade do Código e Lógica de Negócio
+
+- Não há suporte a regras de força de senha ou projeção de prefixo/sufixo customizado.
+- Estilização e acessibilidade seguem limitações do componente base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Permitir configuração de tamanho mínimo/máximo e de `disabled`.
+- Expor eventos nativos e opcionalmente um toggle de visibilidade.
+- Expandir suporte a atributos ARIA e personalização de ícones.

--- a/frontend-libs/praxis-ui-workspace/audit/phone-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/phone-input.md
@@ -1,0 +1,31 @@
+# pdx-phone-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, prefixIcon, suffixIcon, required, autocomplete, readonly, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe atributos nativos como `pattern` configurável, `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher` ou `disabled` via metadados.
+- Falta propagação de eventos `change` e `blur`.
+
+## Integridade do Código e Lógica de Negócio
+
+- Validação fixa para dígitos e símbolos básicos; não há suporte a máscaras ou formatação internacional.
+- Acessibilidade e estilização seguem limitações da base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Permitir configuração de `pattern` e propagação de `disabled`.
+- Expor eventos nativos e atributos ARIA adicionais.
+- Considerar suporte a máscaras e formatação.

--- a/frontend-libs/praxis-ui-workspace/audit/preload-status.md
+++ b/frontend-libs/praxis-ui-workspace/audit/preload-status.md
@@ -1,0 +1,31 @@
+# pdx-preload-status
+
+## Lista de inputs/outputs atuais
+
+- **Inputs**: nenhum; o componente consome `ComponentPreloaderService` internamente.
+- **Outputs**: nenhum evento exposto.
+
+## Propriedades/eventos ausentes
+
+- Não permite customização de textos, cores ou ícones dos elementos `MatCard`, `MatProgressBar` e botões.
+- Não expõe eventos para acompanhar início/fim do preload ou ações de recarregar.
+
+## Integridade do Código e Lógica de Negócio
+
+- Componente voltado para debug com forte acoplamento ao serviço de preload.
+- Estilização e idioma fixos no template.
+- Forte acoplamento ao `ComponentPreloaderService` dificulta testes e manutenção.
+- Ausência de tratamento de erro ou timeout pode travar a interface.
+- Não diferencia estados de carregamento parcial ou total.
+
+## Cenários Corporativos e UX
+
+- Requer personalização de mensagens, cores e ícones para alinhamento com a identidade visual corporativa.
+- Falta mecanismo de retry ou acionamento de suporte.
+- Acessibilidade limitada: sem feedback textual para leitores de tela.
+
+## Ações recomendadas
+
+- Permitir configuração via inputs (títulos, labels, ícones).
+- Expor eventos de preload (`reload`, `statusChange`) para integração externa.
+- Internacionalizar strings e permitir classes/estilos customizados.

--- a/frontend-libs/praxis-ui-workspace/audit/search-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/search-input.md
@@ -1,0 +1,30 @@
+# pdx-search-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, prefixIcon, suffixIcon, required, autocomplete, spellcheck, readonly, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Atributos nativos como `incremental`, `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher` e `disabled` não são expostos.
+- Eventos `change`/`blur` não são propagados.
+
+## Integridade do Código e Lógica de Negócio
+
+- Não há suporte a customização de prefixo/sufixo além de ícones.
+- Estilização e acessibilidade limitadas à base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Mapear atributos nativos (`incremental`, `disabled`, `aria` extras).
+- Expor eventos nativos e permitir conteúdo customizado.

--- a/frontend-libs/praxis-ui-workspace/audit/summary.md
+++ b/frontend-libs/praxis-ui-workspace/audit/summary.md
@@ -1,0 +1,72 @@
+# Auditoria MatInput Wrappers
+
+## Componentes analisados
+
+text-input, number-input, email-input, password-input, url-input, search-input, phone-input, color-input, date-input, datetime-local-input, month-input, time-input, week-input.
+
+## Principais gaps identificados
+
+- Falta de paridade com `MatInput` para atributos como `disabled`, `name`, `id`, `tabIndex`, `inputmode`, `errorStateMatcher` e mapeamento completo de atributos ARIA.
+- Eventos nativos (`change`, `blur`) não são repassados pelos wrappers.
+- Prefixo e sufixo limitados a `mat-icon`, sem projeção de conteúdo customizado.
+- Validações específicas (patterns) fixas em diversos componentes.
+
+## Tarefas recomendadas
+
+1. Mapear e expor todos os atributos suportados pelo `MatInput` via metadados.
+2. Criar saídas para eventos `change` e `blur` e propagar o estado `disabled`.
+3. Centralizar suporte a atributos ARIA no `SimpleBaseInputComponent`.
+4. Permitir projeção de conteúdo customizado para prefixos/sufixos e classes dinâmicas (`ngClass`).
+5. Tornar validadores (`pattern`, `min`, `max`, `step`) configuráveis e consistentes.
+
+## Sugestões arquiteturais
+
+- Evoluir `SimpleBaseInputComponent` para concentrar mapeamento de atributos/ARIA comuns, reduzindo duplicação.
+- Criar camada de compatibilidade que facilite atualização conforme mudanças no Angular Material.
+- Documentar metadados suportados e adicionar testes de regressão para cada atributo exposto.
+
+# Auditoria MatSelect Wrappers
+
+## Componentes analisados
+
+material-select, material-multi-select, material-searchable-select, material-async-select.
+
+## Principais gaps identificados
+
+- Falta de paridade com `MatSelect` para atributos como `compareWith`, `panelClass`, `disableRipple`, `errorStateMatcher`, `tabIndex`, `name`, `id`, `aria-*`, `panelOpen` e opções de estratégia de rolagem.
+- Eventos `openedChange`, `closed` e `optionSelectionChanges` não são repassados pelos wrappers.
+- Metadados como `searchable`, `selectAll` e `maxSelections` possuem implementações inconsistentes.
+- Estilização restrita ao `mat-form-field`; não há suporte a `panelClass`, `ngClass` dinâmico ou projeção de templates.
+
+## Tarefas recomendadas
+
+1. Mapear e expor os atributos restantes do `MatSelect` via metadados.
+2. Criar saídas para eventos de abertura/fechamento e seleção nativa.
+3. Implementar busca integrada e suporte consistente a `selectAll`/`maxSelections`.
+4. Permitir customização de opções, `panelClass` e templates (`mat-select-trigger`).
+
+## Sugestões arquiteturais
+
+- Centralizar mapeamento de atributos `MatSelect` no `SimpleBaseSelectComponent`.
+- Adotar projeção de conteúdo para facilitar personalizações de opções e trigger.
+- Reutilizar lógica de carregamento remoto e busca entre componentes para reduzir duplicação.
+
+# Auditoria de outros componentes
+
+## Componentes analisados
+
+material-button, material-checkbox-group, material-radio-group, material-date-range, material-datepicker, material-textarea, material-timepicker, preload-status.
+
+## Principais gaps identificados
+
+- Atributos nativos e ARIA dos componentes Angular Material não expostos.
+- Eventos nativos como abertura/fechamento, mudança e teclado não são propagados.
+- Estilização limitada, sem `ngClass`/`panelClass` dinâmicos e pouca projeção de conteúdo.
+- `preload-status` acoplado ao serviço sem inputs ou outputs configuráveis.
+
+## Tarefas recomendadas
+
+1. Mapear e expor atributos e eventos nativos dos componentes Material utilizados.
+2. Permitir customização de classes/estilos e projeção de conteúdo.
+3. Desacoplar `preload-status` com inputs configuráveis e eventos de status.
+4. Adicionar testes cobrindo novos comportamentos.

--- a/frontend-libs/praxis-ui-workspace/audit/text-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/text-input.md
@@ -1,0 +1,33 @@
+# pdx-text-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, prefixIcon, suffixIcon, required, autocomplete, spellcheck, readonly, minLength, maxLength, ariaLabel, hint, hintAlign, showCharacterCount, defaultValue.
+- **Outputs**: `valueChange`, `focusChange` (herdados da base) e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe opções do `MatInput` como `errorStateMatcher`, `name`, `id`, `tabIndex`, `inputmode`, `aria-describedby` ou estado `disabled` via metadados.
+- Eventos nativos como `change`, `blur` e `input` não são emitidos externamente.
+
+## Integridade do Código e Lógica de Negócio
+
+- Estilização baseada em `[appearance]` e `[color]`, mas não há suporte a `floatLabel`, `subscriptSizing` ou `ngClass` dinâmico.
+- Acessibilidade limitada a `aria-label` e `aria-required`.
+- Prefixo/sufixo restritos a `mat-icon`, sem slots ng-content genéricos.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Mapear atributos faltantes do `MatInput` e permitir configuração via metadados.
+- Expor eventos `change`/`blur` e estado `disabled`.
+- Ampliar suporte a atributos ARIA (`aria-describedby`, `aria-invalid`).
+- Permitir projeção de conteúdo customizado para prefixos/sufixos e classes dinâmicas.

--- a/frontend-libs/praxis-ui-workspace/audit/time-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/time-input.md
@@ -1,0 +1,30 @@
+# pdx-time-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, prefixIcon, suffixIcon, required, readonly, min, max, step, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não expõe `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher`, `disabled` ou eventos `change`/`blur`.
+
+## Integridade do Código e Lógica de Negócio
+
+- Validação fixa no formato `HH:MM`.
+- Estilização e acessibilidade limitadas pela base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Expor atributos e eventos nativos adicionais.
+- Suportar `disabled` e atributos ARIA extra.
+- Considerar suporte a segundos e fuso horário.

--- a/frontend-libs/praxis-ui-workspace/audit/url-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/url-input.md
@@ -1,0 +1,31 @@
+# pdx-url-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, placeholder, prefixIcon, suffixIcon, required, autocomplete, spellcheck, readonly, minLength, maxLength, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Não disponibiliza `pattern` configurável, `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher` ou `disabled` via metadados.
+- Eventos `change` e `blur` não são repassados.
+
+## Integridade do Código e Lógica de Negócio
+
+- Utiliza `Validators.pattern` fixo para URLs iniciando com http/https.
+- Estilização e ARIA seguem restrições do componente base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Tornar o pattern de validação configurável e expor atributos nativos.
+- Suportar propagação de `disabled` e eventos adicionais.
+- Expandir mapeamento de atributos ARIA.

--- a/frontend-libs/praxis-ui-workspace/audit/week-input.md
+++ b/frontend-libs/praxis-ui-workspace/audit/week-input.md
@@ -1,0 +1,30 @@
+# pdx-week-input
+
+## Lista de inputs/outputs atuais
+
+- **Metadados**: label, prefixIcon, suffixIcon, required, readonly, min, max, ariaLabel, hint, hintAlign.
+- **Outputs**: `valueChange`, `focusChange` e `validationChange`.
+
+## Propriedades/eventos ausentes
+
+- Ausência de `step`, `name`, `id`, `tabIndex`, `aria-describedby`, `errorStateMatcher`, controle `disabled` e eventos `change`/`blur`.
+
+## Integridade do Código e Lógica de Negócio
+
+- Validação fixa no formato `YYYY-Www`.
+- Mesmas limitações de estilização e acessibilidade da base.
+- Validações e estado desabilitado dependem do FormControl; o wrapper não sincroniza mudanças em tempo real.
+- Falta de normalização ou mascaramento para garantir padrões corporativos.
+- Ausência de hooks para regras de negócio adicionais ou auditoria.
+
+## Cenários Corporativos e UX
+
+- Mensagens de erro, internacionalização e acessibilidade limitadas.
+- Necessidade de máscaras e formatações para entradas sensíveis (CNPJ, CPF, datas).
+- Navegação por teclado e feedback visual podem ser aprimorados.
+
+## Ações recomendadas
+
+- Permitir configuração de `step` e `disabled` via metadados.
+- Expor atributos ARIA adicionais e eventos nativos.
+- Considerar suporte a formatações regionais.


### PR DESCRIPTION
## Summary
- expand audit files with code/business logic integrity checks and corporate UX considerations
- capture additional Angular Material gaps across dynamic field wrappers

## Testing
- `npx prettier --write frontend-libs/praxis-ui-workspace/audit/*.md`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_689132017fa083288679c95ec66fab42