### PR TITLE
Centralize API route config and add 404 logging

### DIFF
--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/ApiRouteDefinitions.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/ApiRouteDefinitions.java
@@ -1,6 +1,15 @@
 package com.example.praxis.common.config;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
 public class ApiRouteDefinitions {
+
+    private static final Map<String, String> ROUTES = loadRoutes();
+    private static final String HR_BASE = ROUTES.getOrDefault("humanResources", "/api/human-resources");
 
     // Users
     public static final String USERS_PATH = "/users";
@@ -8,46 +17,54 @@ public class ApiRouteDefinitions {
     public static final String USERS_TAG = "Users";
 
     // HR Cargos
-    public static final String HR_CARGOS_PATH = "/api/human-resources/cargos";
+    public static final String HR_CARGOS_PATH = HR_BASE + "/cargos";
     public static final String HR_CARGOS_GROUP = "cargos";
     public static final String HR_CARGOS_TAG = "HR - Cargos";
 
     // HR Departamentos
-    public static final String HR_DEPARTAMENTOS_PATH = "/api/human-resources/departamentos";
+    public static final String HR_DEPARTAMENTOS_PATH = HR_BASE + "/departamentos";
     public static final String HR_DEPARTAMENTOS_GROUP = "departamentos";
     public static final String HR_DEPARTAMENTOS_TAG = "HR - Departamentos";
 
     // HR Funcionarios
-    public static final String HR_FUNCIONARIOS_PATH = "/api/human-resources/funcionarios";
+    public static final String HR_FUNCIONARIOS_PATH = HR_BASE + "/funcionarios";
     public static final String HR_FUNCIONARIOS_GROUP = "funcionarios";
     public static final String HR_FUNCIONARIOS_TAG = "HR - Funcionarios";
 
     // HR Folhas de Pagamento
-    public static final String HR_FOLHAS_PAGAMENTO_PATH = "/api/human-resources/folhas-pagamento";
+    public static final String HR_FOLHAS_PAGAMENTO_PATH = HR_BASE + "/folhas-pagamento";
     public static final String HR_FOLHAS_PAGAMENTO_GROUP = "folhas-pagamento";
     public static final String HR_FOLHAS_PAGAMENTO_TAG = "HR - Folhas Pagamento";
 
     // HR Eventos de Folha
-    public static final String HR_EVENTOS_FOLHA_PATH = "/api/human-resources/eventos-folha";
+    public static final String HR_EVENTOS_FOLHA_PATH = HR_BASE + "/eventos-folha";
     public static final String HR_EVENTOS_FOLHA_GROUP = "eventos-folha";
     public static final String HR_EVENTOS_FOLHA_TAG = "HR - Eventos Folha";
 
     // HR Férias/Afastamentos
-    public static final String HR_FERIAS_AFASTAMENTOS_PATH = "/api/human-resources/ferias-afastamentos";
+    public static final String HR_FERIAS_AFASTAMENTOS_PATH = HR_BASE + "/ferias-afastamentos";
     public static final String HR_FERIAS_AFASTAMENTOS_GROUP = "ferias-afastamentos";
     public static final String HR_FERIAS_AFASTAMENTOS_TAG = "HR - Ferias Afastamentos";
 
     // HR Dependentes
-    public static final String HR_DEPENDENTES_PATH = "/api/human-resources/dependentes";
+    public static final String HR_DEPENDENTES_PATH = HR_BASE + "/dependentes";
     public static final String HR_DEPENDENTES_GROUP = "dependentes";
     public static final String HR_DEPENDENTES_TAG = "HR - Dependentes";
 
     // UI Wrappers Test
-    public static final String UI_WRAPPERS_TEST_PATH = "/api/ui-test/wrappers";
+    public static final String UI_WRAPPERS_TEST_PATH = ROUTES.getOrDefault("uiWrappersTest", "/api/ui-test/wrappers");
     public static final String UI_WRAPPERS_TEST_GROUP = "ui-wrappers-test";
     public static final String UI_WRAPPERS_TEST_TAG = "UI Wrappers Test";
 
     private ApiRouteDefinitions() {
         // Prevent instantiation
+    }
+
+    private static Map<String, String> loadRoutes() {
+        try (InputStream is = ApiRouteDefinitions.class.getClassLoader().getResourceAsStream("api-routes.json")) {
+            return new ObjectMapper().readValue(is, new TypeReference<>() {});
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError("Failed to load api-routes.json" + e);
+        }
     }
 }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/filter/NotFoundLoggingFilter.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/filter/NotFoundLoggingFilter.java
@@ -1,0 +1,29 @@
+package com.example.praxis.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class NotFoundLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(NotFoundLoggingFilter.class);
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        filterChain.doFilter(request, response);
+        if (response.getStatus() == HttpServletResponse.SC_NOT_FOUND) {
+            logger.warn("404 for {} {}", request.getMethod(), request.getRequestURI());
+        }
+    }
+}

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/uischema/controller/UiSchemaTestController.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/uischema/controller/UiSchemaTestController.java
@@ -3,9 +3,12 @@ package com.example.praxis.uischema.controller;
 import com.example.praxis.common.config.ApiRouteDefinitions;
 import com.example.praxis.uischema.dto.UiSchemaTestDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Controller que expõe os metadados do {@link UiSchemaTestDTO} para testes dos wrappers de UI.
@@ -25,5 +28,20 @@ public class UiSchemaTestController {
     public UiSchemaTestDTO getSchema() {
         return new UiSchemaTestDTO();
     }
-}
 
+    /**
+     * Redireciona para o endpoint global de schemas filtrados.
+     *
+     * @return resposta 302 com a localização do schema
+     */
+    @GetMapping("/schemas")
+    public ResponseEntity<Void> redirectToSchema() {
+        var location = UriComponentsBuilder.fromPath("/schemas/filtered")
+                .queryParam("path", ApiRouteDefinitions.UI_WRAPPERS_TEST_PATH)
+                .queryParam("operation", "get")
+                .queryParam("schemaType", "response")
+                .build()
+                .toUri();
+        return ResponseEntity.status(HttpStatus.FOUND).location(location).build();
+    }
+}

--- a/examples/praxis-backend-libs-sample-app/src/main/resources/api-routes.json
+++ b/examples/praxis-backend-libs-sample-app/src/main/resources/api-routes.json
@@ -1,0 +1,5 @@
+{
+  "apiBase": "/api",
+  "humanResources": "/api/human-resources",
+  "uiWrappersTest": "/api/ui-test/wrappers"
+}

--- a/frontend-libs/praxis-ui-workspace/api-routes.json
+++ b/frontend-libs/praxis-ui-workspace/api-routes.json
@@ -1,0 +1,5 @@
+{
+  "apiBase": "/api",
+  "humanResources": "/api/human-resources",
+  "uiWrappersTest": "/api/ui-test/wrappers"
+}

--- a/frontend-libs/praxis-ui-workspace/src/app/app.config.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/app.config.ts
@@ -3,15 +3,15 @@ import {
   LOCALE_ID,
   APP_INITIALIZER,
   provideBrowserGlobalErrorListeners,
-  provideZonelessChangeDetection
+  provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
-import {API_URL} from '@praxis/core';
-import {environment} from '../environments/environment';
-import {provideHttpClient} from '@angular/common/http';
-import {provideAnimationsAsync} from '@angular/platform-browser/animations/async';
+import { API_URL } from '@praxis/core';
+import { environment } from '../environments/environment';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 //import {MonacoEditorModule, provideMonacoEditor} from 'ngx-monaco-editor-v2';
 import {
   CurrencyPipe,
@@ -20,30 +20,41 @@ import {
   LowerCasePipe,
   PercentPipe,
   TitleCasePipe,
-  UpperCasePipe
+  UpperCasePipe,
 } from '@angular/common';
-import { initializeComponentSystem, configureDynamicFieldsLogger, LoggerPresets } from '@praxis/dynamic-fields';
+import {
+  initializeComponentSystem,
+  configureDynamicFieldsLogger,
+  LoggerPresets,
+} from '@praxis/dynamic-fields';
+import { notFoundLoggerInterceptor } from './core/interceptors/not-found-logger.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([notFoundLoggerInterceptor])),
     provideAnimationsAsync(),
     provideRouter(routes),
     { provide: API_URL, useValue: environment.apiUrl },
-    { provide: LOCALE_ID, useValue: "pt-BR" },
-    { 
-      provide: APP_INITIALIZER, 
+    { provide: LOCALE_ID, useValue: 'pt-BR' },
+    {
+      provide: APP_INITIALIZER,
       useFactory: () => {
         // Configurar logger para reduzir spam
         configureDynamicFieldsLogger(LoggerPresets.DEVELOPMENT);
         // Retornar a função de inicialização dos componentes
         return initializeComponentSystem();
-      }, 
-      multi: true 
+      },
+      multi: true,
     },
-    DatePipe,UpperCasePipe,DecimalPipe,CurrencyPipe,PercentPipe,LowerCasePipe,TitleCasePipe,
+    DatePipe,
+    UpperCasePipe,
+    DecimalPipe,
+    CurrencyPipe,
+    PercentPipe,
+    LowerCasePipe,
+    TitleCasePipe,
     // provideMonacoEditor({
     //   defaultOptions: {
     //     scrollBeyondLastLine: false,
@@ -58,5 +69,5 @@ export const appConfig: ApplicationConfig = {
     //     console.log('Monaco Editor carregado!');
     //   }
     // })
-  ]
+  ],
 };

--- a/frontend-libs/praxis-ui-workspace/src/app/core/interceptors/not-found-logger.interceptor.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/core/interceptors/not-found-logger.interceptor.ts
@@ -1,0 +1,13 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { tap } from 'rxjs/operators';
+
+export const notFoundLoggerInterceptor: HttpInterceptorFn = (req, next) =>
+  next(req).pipe(
+    tap({
+      error: (err) => {
+        if (err.status === 404) {
+          console.warn(`Request to ${req.url} returned 404`);
+        }
+      },
+    }),
+  );

--- a/frontend-libs/praxis-ui-workspace/src/app/features/ui-wrappers-test/ui-wrappers-test.component.html
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/ui-wrappers-test/ui-wrappers-test.component.html
@@ -8,7 +8,7 @@
   <mat-card-content>
     <praxis-dynamic-form
       formId="ui-wrappers-test"
-      resourcePath="/ui-test/wrappers"
+      [resourcePath]="resourcePath"
       [editModeEnabled]="true"
     ></praxis-dynamic-form>
   </mat-card-content>

--- a/frontend-libs/praxis-ui-workspace/src/app/features/ui-wrappers-test/ui-wrappers-test.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/ui-wrappers-test/ui-wrappers-test.component.spec.ts
@@ -18,4 +18,8 @@ describe('UiWrappersTestComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should resolve resourcePath from shared routes', () => {
+    expect((component as any).resourcePath).toBe('ui-test/wrappers');
+  });
 });

--- a/frontend-libs/praxis-ui-workspace/src/app/features/ui-wrappers-test/ui-wrappers-test.component.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/ui-wrappers-test/ui-wrappers-test.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { PraxisDynamicForm } from '@praxis/dynamic-form';
+import apiRoutes from '../../../../api-routes.json';
 
 @Component({
   selector: 'app-ui-wrappers-test',
@@ -10,4 +11,8 @@ import { PraxisDynamicForm } from '@praxis/dynamic-form';
   templateUrl: './ui-wrappers-test.component.html',
   styleUrl: './ui-wrappers-test.component.scss',
 })
-export class UiWrappersTestComponent {}
+export class UiWrappersTestComponent {
+  protected readonly resourcePath = apiRoutes.uiWrappersTest
+    .replace(apiRoutes.apiBase, '')
+    .replace(/^\/+/g, '');
+}

--- a/frontend-libs/praxis-ui-workspace/src/environments/environment.prod.ts
+++ b/frontend-libs/praxis-ui-workspace/src/environments/environment.prod.ts
@@ -1,8 +1,10 @@
 import { ApiUrlConfig } from '@praxis/core';
+import apiRoutes from '../../api-routes.json';
 
 export const environment = {
   production: true,
   apiUrl: {
-    default: { baseUrl: '/api', version: 'v1' }
-  } as ApiUrlConfig
+    default: { baseUrl: apiRoutes.apiBase, version: 'v1' },
+    humanResources: { baseUrl: apiRoutes.humanResources, version: 'v1' },
+  } as ApiUrlConfig,
 };

--- a/frontend-libs/praxis-ui-workspace/src/environments/environment.ts
+++ b/frontend-libs/praxis-ui-workspace/src/environments/environment.ts
@@ -1,8 +1,10 @@
 import { ApiUrlConfig } from '@praxis/core';
+import apiRoutes from '../../api-routes.json';
 
 export const environment = {
   production: false,
   apiUrl: {
-    default: { baseUrl: 'http://localhost:8087/api/human-resources', version: '' }
-  } as ApiUrlConfig
+    default: { baseUrl: apiRoutes.apiBase, version: '' },
+    humanResources: { baseUrl: apiRoutes.humanResources, version: '' },
+  } as ApiUrlConfig,
 };

--- a/frontend-libs/praxis-ui-workspace/tsconfig.json
+++ b/frontend-libs/praxis-ui-workspace/tsconfig.json
@@ -3,7 +3,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",  // Garante resolução correta dos caminhos relativos
+    "baseUrl": "./", // Garante resolução correta dos caminhos relativos
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": false,
@@ -14,9 +14,7 @@
     "experimentalDecorators": true,
     "paths": {
       "@praxis/core": ["projects/praxis-core/src/public-api.ts"],
-      "@praxis/table": [
-        "projects/praxis-table/src/public-api.ts"
-      ],
+      "@praxis/table": ["projects/praxis-table/src/public-api.ts"],
       "@praxis/dynamic-fields": [
         "projects/praxis-dynamic-fields/src/public-api.ts"
       ],
@@ -26,13 +24,12 @@
       "@praxis/visual-builder": [
         "projects/praxis-visual-builder/src/public-api.ts"
       ],
-      "@praxis/dynamic-form": [
-        "projects/praxis-dynamic-form/src/public-api.ts"
-      ]
+      "@praxis/dynamic-form": ["projects/praxis-dynamic-form/src/public-api.ts"]
     },
     "importHelpers": true,
     "target": "ES2022",
-    "module": "preserve"
+    "module": "preserve",
+    "resolveJsonModule": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
## Summary
- derive the UI wrappers test resource path from shared `api-routes.json`
- surface the shared API base config in both development and production environments
- document the resolved path in a unit test for UI wrapper form

## Testing
- `CI=true npm test` *(fails: No binary for Chrome browser on your platform)*
- `./mvnw -f examples/praxis-backend-libs-sample-app/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6895e13dcf4c83288ce359c6151c9d93