### PR TITLE
fix: use compile-time constants for API routes

### DIFF
--- a/docs/config/rotas-e-documentacao.md
+++ b/docs/config/rotas-e-documentacao.md
@@ -40,7 +40,7 @@ Ao acessar o Swagger UI, cada grupo aparece como uma seção separada. Isso faci
 
 Componente auxiliar que implementa `SmartInitializingSingleton`. Após a inicialização do contexto Spring, ele executa diversas verificações:
 
-1. Confere se todos os grupos declarados em `ApiRouteDefinitions` possuem beans correspondentes em `OpenApiGroupsConfig`.
+1. Confere se todos os grupos declarados em `ApiRouteDefinitions` possuem beans correspondentes em `OpenApiGroupsConfig` e se cada `*_GROUP` tem um `*_PATH` associado cujo valor contém o nome do grupo.
 2. Detecta sobreposição de rotas entre diferentes grupos.
 3. Emite avisos caso alguma classe `@RestController` não esteja coberta por nenhum grupo.
 

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/ApiRouteDefinitions.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/ApiRouteDefinitions.java
@@ -1,15 +1,14 @@
 package com.example.praxis.common.config;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
+/**
+ * Centraliza as rotas utilizadas pela aplicação. Os valores são definidos como
+ * constantes de tempo de compilação para que possam ser utilizados em
+ * anotações como {@code @RequestMapping} sem causar erros de "attribute value
+ * must be constant".
+ */
+public final class ApiRouteDefinitions {
 
-public class ApiRouteDefinitions {
-
-    private static final Map<String, String> ROUTES = loadRoutes();
-    private static final String HR_BASE = ROUTES.getOrDefault("humanResources", "/api/human-resources");
+    private static final String HR_BASE = "/api/human-resources";
 
     // Users
     public static final String USERS_PATH = "/users";
@@ -52,19 +51,11 @@ public class ApiRouteDefinitions {
     public static final String HR_DEPENDENTES_TAG = "HR - Dependentes";
 
     // UI Wrappers Test
-    public static final String UI_WRAPPERS_TEST_PATH = ROUTES.getOrDefault("uiWrappersTest", "/api/ui-test/wrappers");
+    public static final String UI_WRAPPERS_TEST_PATH = "/api/ui-test/wrappers";
     public static final String UI_WRAPPERS_TEST_GROUP = "ui-wrappers-test";
     public static final String UI_WRAPPERS_TEST_TAG = "UI Wrappers Test";
 
     private ApiRouteDefinitions() {
         // Prevent instantiation
-    }
-
-    private static Map<String, String> loadRoutes() {
-        try (InputStream is = ApiRouteDefinitions.class.getClassLoader().getResourceAsStream("api-routes.json")) {
-            return new ObjectMapper().readValue(is, new TypeReference<>() {});
-        } catch (IOException e) {
-            throw new ExceptionInInitializerError("Failed to load api-routes.json" + e);
-        }
     }
 }

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/OpenApiGroupsValidator.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/common/config/OpenApiGroupsValidator.java
@@ -92,10 +92,17 @@ public class OpenApiGroupsValidator implements SmartInitializingSingleton {
                     String pathFieldName = field.getName().replace("_GROUP", "_PATH");
                     try {
                         Field pathField = ApiRouteDefinitions.class.getDeclaredField(pathFieldName);
-                        // Verificar se o GROUP está coerente com o PATH
+                        // Verificar se o PATH é coerente com o GROUP. A validação é
+                        // intencionalmente flexível para permitir cenários corporativos
+                        // onde o nome do grupo pode não coincidir exatamente com o
+                        // caminho. Ainda assim, é recomendado que o nome do grupo
+                        // apareça em alguma parte do path para facilitar a
+                        // manutenção.
                         String pathValue = (String) pathField.get(null);
-                        if (!normalizePath(pathValue).substring(1).equals(groupName)) {
-                            logger.warn("Inconsistência entre GROUP e PATH: {} não corresponde a {}",
+                        String normalizedPath = normalizePath(pathValue);
+                        if (!normalizedPath.contains(groupName)) {
+                            logger.warn(
+                                    "Inconsistência entre GROUP e PATH: {} não está contido em {}",
                                     groupName, pathValue);
                         }
                     } catch (NoSuchFieldException e) {

--- a/examples/praxis-backend-libs-sample-app/src/main/resources/api-routes.json
+++ b/examples/praxis-backend-libs-sample-app/src/main/resources/api-routes.json
@@ -1,5 +1,0 @@
-{
-  "apiBase": "/api",
-  "humanResources": "/api/human-resources",
-  "uiWrappersTest": "/api/ui-test/wrappers"
-}


### PR DESCRIPTION
## Summary
- replace runtime-loaded routes with compile-time constants in `ApiRouteDefinitions`
- refine `OpenApiGroupsValidator` to flexibly check group/path consistency and drop unused routes file

## Testing
- `./mvnw -f examples/praxis-backend-libs-sample-app/pom.xml test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689609c2d12c8328970e6f11c29ad999