### PR TITLE
feat: add auto-complete searchable select

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
@@ -4,6 +4,7 @@ import {
 } from './helpers/field-definition-mapper';
 import { FieldDefinition } from './models/field-definition.model';
 import { FieldMetadata } from './models/component-metadata.interface';
+import { FieldControlType } from './metadata/field-control-type.constants';
 
 describe('FieldDefinition to FieldMetadata mapper', () => {
   it('should map basic properties', () => {
@@ -91,5 +92,16 @@ describe('FieldDefinition to FieldMetadata mapper', () => {
     expect(meta.optionValueKey).toBe('id');
     expect(meta.filterCriteria).toEqual({ active: true });
     expect(meta.selectOptions?.[0]).toEqual({ value: '1', text: 'Open' });
+  });
+
+  it('should force searchable true for autoComplete control type', () => {
+    const def: FieldDefinition = {
+      name: 'city',
+      controlType: FieldControlType.AUTO_COMPLETE,
+    } as any;
+
+    const meta = mapFieldDefinitionToMetadata(def);
+
+    expect(meta.searchable).toBeTrue();
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
@@ -3,6 +3,7 @@ import {
   FieldMetadata,
   ValidatorOptions,
 } from '../models/component-metadata.interface';
+import { FieldControlType } from '../metadata/field-control-type.constants';
 
 /**
  * Convert a `FieldDefinition` coming from the backend schema into
@@ -48,6 +49,11 @@ export function mapFieldDefinitionToMetadata(
     if (value !== undefined) {
       (metadata as any)[prop] = value;
     }
+  }
+
+  // AutoComplete fields are always searchable
+  if (field.controlType === FieldControlType.AUTO_COMPLETE) {
+    metadata.searchable = true;
   }
 
   if (field.displayField) {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/README.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/README.md
@@ -43,7 +43,7 @@ O sistema usa as constantes do `@praxis/core` para garantir consistência:
 - `FieldControlType.CURRENCY_INPUT` - Campo monetário
 - `FieldControlType.NUMERIC_TEXT_BOX` - Campo numérico
 - `FieldControlType.MULTI_SELECT` - Seleção múltipla
-- `FieldControlType.AUTO_COMPLETE` - Auto completar
+- `FieldControlType.AUTO_COMPLETE` - Auto completar (busca habilitada por padrão)
 - `FieldControlType.DATE_TIME_PICKER` - Data e hora
 - `FieldControlType.DATE_RANGE` - Intervalo de datas
 - `FieldControlType.FILE_UPLOAD` - Upload de arquivos
@@ -52,6 +52,8 @@ O sistema usa as constantes do `@praxis/core` para garantir consistência:
 - `FieldControlType.TIME_PICKER` - Seletor de horário
 - `FieldControlType.RATING` - Classificação por estrelas
 - `FieldControlType.COLOR_PICKER` - Seletor de cores
+
+Campos com `FieldControlType.AUTO_COMPLETE` utilizam internamente o `MaterialSearchableSelectComponent`, habilitando busca automaticamente.
 
 ## 🧩 MaterialSelectComponent
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/USAGE-EXAMPLES.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/USAGE-EXAMPLES.md
@@ -164,9 +164,11 @@ export class EnterpriseFormComponent {
       {
         name: "position",
         label: "Cargo",
-        controlType: "select",
+        controlType: "autoComplete",
         required: true,
+        endpoint: "/api/positions",
         dependencyFields: ["department"],
+        // `searchable` é verdadeiro por padrão para autoComplete
       },
       {
         name: "startDate",

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed } from '@angular/core/testing';
+import { FieldControlType } from '@praxis/core';
+import { MaterialSearchableSelectComponent } from '../../components/material-searchable-select/material-searchable-select.component';
+import { ComponentRegistryService } from './component-registry.service';
+
+describe('ComponentRegistryService', () => {
+  let service: ComponentRegistryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ComponentRegistryService);
+  });
+
+  it('should resolve MaterialSearchableSelectComponent for AUTO_COMPLETE', async () => {
+    const component = await service.getComponent(
+      FieldControlType.AUTO_COMPLETE,
+    );
+    expect(component).toBe(MaterialSearchableSelectComponent);
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
@@ -375,6 +375,9 @@ export class ComponentRegistryService implements IComponentRegistry {
       searchableSelectFactory,
     );
 
+    // Alias for auto-complete fields
+    this.register(FieldControlTypeEnum.AUTO_COMPLETE, searchableSelectFactory);
+
     const asyncSelectFactory = () =>
       import(
         '../../components/material-async-select/material-async-select.component'


### PR DESCRIPTION
## Summary
- register auto-complete fields with MaterialSearchableSelectComponent
- mark auto-complete metadata as searchable by default
- document auto-complete usage and add unit tests

## Testing
- `CHROME_BIN=/tmp/chrome npx ng test praxis-core --watch=false --browsers=ChromeHeadless` *(fails: Angular requires Zone.js)*
- `CHROME_BIN=/tmp/chrome npx ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: Angular requires Zone.js)*

------
https://chatgpt.com/codex/tasks/task_e_68978a120e488328a577b7b0035e7a84