### PR TITLE
feat: add currency input component

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/index.ts
@@ -1,0 +1,1 @@
+export * from './material-currency.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+
+import { MaterialCurrencyComponent } from './material-currency.component';
+import { MaterialCurrencyMetadata } from '@praxis/core';
+
+describe('MaterialCurrencyComponent', () => {
+  let component: MaterialCurrencyComponent;
+  let fixture: ComponentFixture<MaterialCurrencyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialCurrencyComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialCurrencyComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Price',
+      currency: 'USD',
+      controlType: 'currency',
+    } as MaterialCurrencyMetadata);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display currency symbol', () => {
+    const symbolEl = fixture.nativeElement.querySelector('.currency-symbol');
+    expect(symbolEl.textContent.trim()).toContain('$');
+  });
+
+  it('should propagate numeric value changes', () => {
+    const control = new FormControl(0);
+    component.registerOnChange(control.setValue.bind(control));
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '123.45';
+    input.dispatchEvent(new Event('input'));
+    expect(control.value).toBe(123.45);
+  });
+
+  it('should format value on blur but keep numeric control value', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '1234.5';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+    expect(input.value).toBe('$1,234.50');
+    expect(component.internalControl.value).toBe(1234.5);
+  });
+
+  it('should allow negative numbers when configured', () => {
+    component.metadata.set({
+      label: 'Price',
+      currency: 'USD',
+      allowNegative: true,
+      controlType: 'currency',
+    } as MaterialCurrencyMetadata);
+    fixture.detectChanges();
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '-5';
+    input.dispatchEvent(new Event('input'));
+    expect(component.internalControl.value).toBe(-5);
+    expect(component.internalControl.valid).toBeTrue();
+  });
+
+  it('should mark control invalid for negative numbers when not allowed', () => {
+    const input: HTMLInputElement =
+      fixture.nativeElement.querySelector('input');
+    input.value = '-5';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(component.internalControl.valid).toBeFalse();
+  });
+
+  it('should place symbol after input when position is after', () => {
+    component.metadata.set({
+      label: 'Price',
+      currency: 'USD',
+      currencyPosition: 'after',
+      controlType: 'currency',
+    } as MaterialCurrencyMetadata);
+    fixture.detectChanges();
+    const prefix = fixture.nativeElement.querySelector(
+      '.mat-mdc-form-field-prefix .currency-symbol',
+    );
+    const suffix = fixture.nativeElement.querySelector(
+      '.mat-mdc-form-field-suffix .currency-symbol',
+    );
+    expect(prefix).toBeNull();
+    expect(suffix).not.toBeNull();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.ts
@@ -1,0 +1,206 @@
+import {
+  Component,
+  ElementRef,
+  ViewChild,
+  forwardRef,
+  computed,
+  output,
+  inject,
+} from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { CommonModule, CurrencyPipe } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import { MaterialCurrencyMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Input component for currency values with basic formatting support.
+ *
+ * Displays a currency symbol as prefix or suffix and validates numeric input.
+ */
+@Component({
+  selector: 'pdx-material-currency',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Amount' }}</mat-label>
+
+      @if (metadata()?.prefixIcon) {
+        <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
+      }
+
+      @if (currencyPosition() === 'before') {
+        <span matPrefix class="currency-symbol">{{ currencySymbol() }}</span>
+      }
+
+      <input
+        matInput
+        #currencyInput
+        type="text"
+        [formControl]="internalControl"
+        [placeholder]="metadata()?.placeholder || ''"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+        (input)="onInput($event)"
+        (focus)="onFocus()"
+        (blur)="onBlur()"
+      />
+
+      @if (currencyPosition() === 'after') {
+        <span matSuffix class="currency-symbol">{{ currencySymbol() }}</span>
+      }
+
+      @if (metadata()?.suffixIcon) {
+        <mat-icon matSuffix>{{ metadata()!.suffixIcon }}</mat-icon>
+      }
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <mat-error>{{ errorMessage() }}</mat-error>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <mat-hint [align]="metadata()?.hintAlign || 'start'">
+          {{ metadata()!.hint }}
+        </mat-hint>
+      }
+    </mat-form-field>
+  `,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    CurrencyPipe,
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MaterialCurrencyComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"currency"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class MaterialCurrencyComponent extends SimpleBaseInputComponent {
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  private readonly currencyPipe = inject(CurrencyPipe);
+
+  @ViewChild('currencyInput', { static: true })
+  private readonly inputRef!: ElementRef<HTMLInputElement>;
+
+  /** Currency code used for formatting. */
+  readonly currencyCode = computed(
+    () =>
+      (this.metadata() as MaterialCurrencyMetadata | null)?.currency || 'USD',
+  );
+
+  /** Position of the currency symbol relative to the input. */
+  readonly currencyPosition = computed(
+    () =>
+      (this.metadata() as MaterialCurrencyMetadata | null)?.currencyPosition ||
+      'before',
+  );
+
+  /** Decimal places used for formatting. */
+  readonly decimalPlaces = computed(
+    () =>
+      (this.metadata() as MaterialCurrencyMetadata | null)?.decimalPlaces ?? 2,
+  );
+
+  override ngOnInit(): void {
+    const allowNegative =
+      (this.metadata() as MaterialCurrencyMetadata | null)?.allowNegative ??
+      false;
+    const pattern = allowNegative ? /^-?\d*(\.\d*)?$/ : /^\d*(\.\d*)?$/;
+    this.internalControl.addValidators(Validators.pattern(pattern));
+    if (!allowNegative) {
+      this.internalControl.addValidators(Validators.min(0));
+    }
+    super.ngOnInit();
+    // Format default value if provided
+    queueMicrotask(() => this.onBlur());
+  }
+
+  /** Handles raw input and keeps numeric value in the control. */
+  onInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const number = Number(input.value.replace(/[^0-9.-]+/g, ''));
+    this.setValue(isNaN(number) ? null : number);
+  }
+
+  /** Removes formatting when focusing for easier editing. */
+  onFocus(): void {
+    this.handleFocus();
+    const value = this.internalControl.value;
+    this.inputRef.nativeElement.value = value === null ? '' : String(value);
+  }
+
+  /** Formats the current value using CurrencyPipe on blur. */
+  onBlur(): void {
+    this.handleBlur();
+    const value = this.internalControl.value;
+    if (value === null || value === undefined || value === '') {
+      return;
+    }
+    const formatted =
+      this.currencyPipe.transform(
+        value,
+        this.currencyCode(),
+        '',
+        `1.0-${this.decimalPlaces()}`,
+      ) ?? String(value);
+    this.inputRef.nativeElement.value = formatted;
+  }
+
+  /** Extracts the symbol for the configured currency. */
+  protected currencySymbol(): string {
+    const formatted = this.currencyPipe.transform(
+      0,
+      this.currencyCode(),
+      '',
+      `1.0-0`,
+    );
+    return formatted ? formatted.replace(/[0]/g, '').trim() : '$';
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-material-currency'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialCurrencyMetadata): void {
+    this.setMetadata(metadata);
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
@@ -272,6 +272,12 @@ export class ComponentRegistryService implements IComponentRegistry {
         (m) => m.NumberInputComponent,
       );
 
+    // Specialized currency input
+    const currencyInputFactory = () =>
+      import(
+        '../../components/material-currency/material-currency.component'
+      ).then((m) => m.MaterialCurrencyComponent);
+
     // Specialized search input
     const searchInputFactory = () =>
       import('../../components/search-input/search-input.component').then(
@@ -315,6 +321,7 @@ export class ComponentRegistryService implements IComponentRegistry {
     this.register(FieldControlTypeEnum.EMAIL_INPUT, emailInputFactory);
     this.register(FieldControlTypeEnum.PASSWORD, passwordInputFactory);
     this.register(FieldControlTypeEnum.NUMERIC_TEXT_BOX, numberInputFactory);
+    this.register(FieldControlTypeEnum.CURRENCY_INPUT, currencyInputFactory);
     this.register(FieldControlTypeEnum.SEARCH_INPUT, searchInputFactory);
     this.register(FieldControlTypeEnum.PHONE, phoneInputFactory);
     this.register(FieldControlTypeEnum.TIME_INPUT, timeInputFactory);

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
@@ -22,6 +22,7 @@ export * from './lib/components/material-date-range/material-date-range.componen
 export * from './lib/components/datetime-local-input/datetime-local-input.component';
 export * from './lib/components/email-input/email-input.component';
 export * from './lib/components/number-input/number-input.component';
+export * from './lib/components/material-currency/material-currency.component';
 export * from './lib/components/month-input/month-input.component';
 export * from './lib/components/password-input/password-input.component';
 export * from './lib/components/search-input/search-input.component';


### PR DESCRIPTION
## Summary
- add MaterialCurrencyComponent for formatted monetary inputs
- register currency component in dynamic registry
- expose component via public API
- refine currency formatting to keep numeric values and support negative validation

## Testing
- `CHROME_BIN=$(which chromium-browser) npx ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless requires chromium snap)*

------
https://chatgpt.com/codex/tasks/task_e_68978c34c5848328be9eb9ab30409872