### PR TITLE
fix(dynamic-fields): improve material color picker

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/index.ts
@@ -1,0 +1,1 @@
+export * from './material-colorpicker.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
+import { MaterialColorPickerComponent } from './material-colorpicker.component';
+
+describe('MaterialColorPickerComponent', () => {
+  let component: MaterialColorPickerComponent;
+  let fixture: ComponentFixture<MaterialColorPickerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialColorPickerComponent, FormsModule, ReactiveFormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialColorPickerComponent);
+    component = fixture.componentInstance;
+    component.metadata.set({
+      label: 'Favorite color',
+      required: true,
+    } as any);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate color value changes from native picker', () => {
+    const control = new FormControl('');
+    component.registerOnChange(control.setValue.bind(control));
+    const nativeInput: HTMLInputElement =
+      fixture.nativeElement.querySelector('input[type="color"]');
+    nativeInput.value = '#123456';
+    nativeInput.dispatchEvent(new Event('change'));
+    expect(control.value).toBe('#123456');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.ts
@@ -1,0 +1,154 @@
+import { Component, ElementRef, ViewChild, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+
+import { MaterialColorPickerMetadata } from '@praxis/core';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Basic color picker component leveraging the native input type="color".
+ *
+ * Renders a text field displaying the selected color value and a palette
+ * icon that opens the browser's color picker. This acts as a starting point
+ * for a more advanced color selection experience.
+ */
+@Component({
+  selector: 'pdx-material-colorpicker',
+  standalone: true,
+  template: `
+    <mat-form-field
+      [appearance]="materialAppearance()"
+      [color]="materialColor()"
+      [class]="componentCssClasses()"
+    >
+      <mat-label>{{ metadata()?.label || 'Color' }}</mat-label>
+
+      <span
+        matPrefix
+        class="pdx-color-preview"
+        [style.background]="internalControl.value || '#000000'"
+        aria-hidden="true"
+      ></span>
+
+      <input
+        matInput
+        [formControl]="internalControl"
+        [required]="metadata()?.required || false"
+        [readonly]="metadata()?.readonly || false"
+        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
+      />
+
+      <button
+        mat-icon-button
+        matSuffix
+        type="button"
+        (click)="openPicker()"
+        [disabled]="internalControl.disabled || metadata()?.readonly || false"
+        [attr.aria-label]="metadata()?.ariaLabel ? metadata()!.ariaLabel + ' color palette' : 'Open color palette'"
+      >
+        <mat-icon>palette</mat-icon>
+      </button>
+
+      <input
+        #picker
+        type="color"
+        class="pdx-hidden-input"
+        (change)="onNativeColorChange($event)"
+      />
+
+      <mat-error
+        *ngIf="
+          errorMessage() &&
+          internalControl.invalid &&
+          (internalControl.dirty || internalControl.touched)
+        "
+        >
+        {{ errorMessage() }}
+      </mat-error>
+
+      <mat-hint
+        *ngIf="metadata()?.hint && !hasValidationError()"
+        [align]="metadata()?.hintAlign || 'start'"
+        >
+        {{ metadata()!.hint }}
+      </mat-hint>
+    </mat-form-field>
+  `,
+  styles: [
+    `
+      .pdx-color-preview {
+        width: 24px;
+        height: 24px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        display: inline-block;
+        margin-right: 8px;
+      }
+      .pdx-hidden-input {
+        display: none;
+      }
+    `,
+  ],
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule,
+    ReactiveFormsModule,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MaterialColorPickerComponent),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"colorPicker"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class MaterialColorPickerComponent extends SimpleBaseInputComponent {
+  @ViewChild('picker') private pickerRef!: ElementRef<HTMLInputElement>;
+
+  /** Applies component metadata with strong typing. */
+  setInputMetadata(metadata: MaterialColorPickerMetadata): void {
+    this.setMetadata(metadata);
+    if (metadata.disabled) {
+      this.internalControl.disable();
+    } else {
+      this.internalControl.enable();
+    }
+  }
+
+  /** Opens the native color picker dialog. */
+  openPicker(): void {
+    if (
+      this.pickerRef &&
+      !this.metadata()?.readonly &&
+      !this.internalControl.disabled
+    ) {
+      this.pickerRef.nativeElement.value =
+        this.internalControl.value || '#000000';
+      this.pickerRef.nativeElement.click();
+    }
+  }
+
+  /** Handles color selection from the native input. */
+  onNativeColorChange(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.setValue(value);
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-material-colorpicker'];
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
@@ -325,6 +325,13 @@ export class ComponentRegistryService implements IComponentRegistry {
     // HTML5 color input
     this.register(FieldControlTypeEnum.COLOR_INPUT, colorInputFactory);
 
+    // Material color picker
+    const colorPickerFactory = () =>
+      import('../../components/material-colorpicker/material-colorpicker.component').then(
+        (m) => m.MaterialColorPickerComponent,
+      );
+    this.register(FieldControlTypeEnum.COLOR_PICKER, colorPickerFactory);
+
     // HTML5 date input
     this.register(FieldControlTypeEnum.DATE_INPUT, dateInputFactory);
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
@@ -37,6 +37,7 @@ export * from './lib/components/time-input/time-input.component';
 export * from './lib/components/material-timepicker/material-timepicker.component';
 export * from './lib/components/url-input/url-input.component';
 export * from './lib/components/week-input/week-input.component';
+export * from './lib/components/material-colorpicker/material-colorpicker.component';
 
 // Services
 export * from './lib/services/action-resolver.service';


### PR DESCRIPTION
## Summary
- honor disabled metadata and sync native picker with control value
- replace experimental control flow with ngIf and add ARIA attributes for better accessibility

## Testing
- `npx ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform. Please, set "CHROME_BIN" env variable.)*
- `CI=true npx ng build praxis-dynamic-fields` *(fails: Cannot destructure property 'pos' of 'file.referencedFiles[index]' as it is undefined.)*

------
https://chatgpt.com/codex/tasks/task_e_6897839c77b8832890ec8dfb35188d69