### PR TITLE
fix: normalize radio group control type

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { FieldControlType } from '@praxis/core';
 import { MaterialSearchableSelectComponent } from '../../components/material-searchable-select/material-searchable-select.component';
+import { MaterialRadioGroupComponent } from '../../components/material-radio-group/material-radio-group.component';
 import { ComponentRegistryService } from './component-registry.service';
 
 describe('ComponentRegistryService', () => {
@@ -16,5 +17,10 @@ describe('ComponentRegistryService', () => {
       FieldControlType.AUTO_COMPLETE,
     );
     expect(component).toBe(MaterialSearchableSelectComponent);
+  });
+
+  it('should normalize radioGroup alias to RADIO component', async () => {
+    const component = await service.getComponent('radioGroup');
+    expect(component).toBe(MaterialRadioGroupComponent);
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
@@ -187,10 +187,21 @@ export class ComponentRegistryService implements IComponentRegistry {
       return type as FieldControlType;
     }
 
+    const sanitized = String(type)
+      .toLowerCase()
+      .replace(/[-_\s]/g, '');
+    const synonyms: Record<string, FieldControlType> = {
+      radiogroup: FieldControlTypeEnum.RADIO,
+      checkboxgroup: FieldControlTypeEnum.CHECKBOX,
+    };
+
+    if (synonyms[sanitized]) {
+      return synonyms[sanitized];
+    }
+
     // Try to find matching enum value by string comparison
     const enumEntry = Object.entries(FieldControlTypeEnum).find(
-      ([key, value]) =>
-        value === type || key.toLowerCase() === String(type).toLowerCase(),
+      ([key, value]) => value === type || key.toLowerCase() === sanitized,
     );
 
     if (enumEntry) {
@@ -334,9 +345,9 @@ export class ComponentRegistryService implements IComponentRegistry {
 
     // Material color picker
     const colorPickerFactory = () =>
-      import('../../components/material-colorpicker/material-colorpicker.component').then(
-        (m) => m.MaterialColorPickerComponent,
-      );
+      import(
+        '../../components/material-colorpicker/material-colorpicker.component'
+      ).then((m) => m.MaterialColorPickerComponent);
     this.register(FieldControlTypeEnum.COLOR_PICKER, colorPickerFactory);
 
     // HTML5 date input


### PR DESCRIPTION
## Summary
- map radioGroup and checkboxGroup synonyms to existing control types
- test registry normalization for radioGroup

## Testing
- `npx ng test praxis-dynamic-fields --watch=false --browsers=ChromiumHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6897923e25108328b11231341deaedda