### PR TITLE
feat: add material price range component

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
@@ -54,6 +54,22 @@ describe('FieldDefinition to FieldMetadata mapper', () => {
     expect(meta.options?.length).toBe(1);
   });
 
+  it('should map numeric range properties', () => {
+    const def: FieldDefinition = {
+      name: 'price',
+      controlType: FieldControlType.RANGE_SLIDER,
+      numericMin: 10,
+      numericMax: 100,
+      numericStep: 5,
+    } as any;
+
+    const meta = mapFieldDefinitionToMetadata(def) as any;
+
+    expect(meta.min).toBe(10);
+    expect(meta.max).toBe(100);
+    expect(meta.step).toBe(5);
+  });
+
   it('should map arrays', () => {
     const defs: FieldDefinition[] = [
       { name: 'a', controlType: 'input' },

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
@@ -51,6 +51,16 @@ export function mapFieldDefinitionToMetadata(
     }
   }
 
+  if (field.numericMin !== undefined) {
+    (metadata as any).min = field.numericMin;
+  }
+  if (field.numericMax !== undefined) {
+    (metadata as any).max = field.numericMax;
+  }
+  if (field.numericStep !== undefined) {
+    (metadata as any).step = field.numericStep;
+  }
+
   // AutoComplete fields are always searchable
   if (field.controlType === FieldControlType.AUTO_COMPLETE) {
     metadata.searchable = true;

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/component-metadata.interface.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/component-metadata.interface.ts
@@ -1,14 +1,14 @@
 /**
  * @fileoverview Base metadata interfaces for dynamic Angular Material components
- * 
+ *
  * This file implements a hierarchical system of metadata interfaces designed for
  * maximum flexibility, type safety, and Angular Material integration.
- * 
+ *
  * Architecture:
  * - ComponentMetadata (universal base)
- * - FieldMetadata (form fields)  
+ * - FieldMetadata (form fields)
  * - Specialized interfaces (MaterialInput, MaterialSelect, etc.)
- * 
+ *
  * Design Principles:
  * - Configuration over Code
  * - JSON serializable
@@ -29,10 +29,10 @@ export { FieldControlType, FieldDataType };
 
 /**
  * Universal base interface for all dynamic components.
- * 
+ *
  * Provides maximum extensibility through index signature while maintaining
  * essential metadata properties for component lifecycle management.
- * 
+ *
  * @example
  * ```typescript
  * const buttonMetadata: ComponentMetadata = {
@@ -46,38 +46,38 @@ export { FieldControlType, FieldDataType };
 export interface ComponentMetadata {
   /** Unique identifier for the component instance */
   id?: string;
-  
+
   /** Metadata schema version for migration support */
   version?: string;
-  
+
   /** Application context where component is used */
   context?: 'form' | 'filter' | 'table' | 'dialog' | 'standalone';
-  
+
   /** Timestamp when metadata was created */
   createdAt?: string;
-  
+
   /** Timestamp when metadata was last updated */
   updatedAt?: string;
-  
+
   /** Tags for categorization and filtering */
   tags?: string[];
-  
+
   /** Custom CSS classes to apply to the component */
   cssClass?: string;
-  
+
   /** Inline styles as CSS properties object */
   style?: Record<string, string>;
-  
+
   /** Data attributes for testing or analytics */
   dataAttributes?: Record<string, string>;
-  
+
   /** Extensibility: allow any additional properties */
   [key: string]: any;
 }
 
 /**
  * Enhanced validation configuration for comprehensive field validation.
- * 
+ *
  * Supports both built-in Angular validators and custom validation logic
  * with internationalization support for error messages.
  */
@@ -85,180 +85,183 @@ export interface ValidatorOptions {
   // =============================================================================
   // BASIC VALIDATORS
   // =============================================================================
-  
+
   /** Field is required */
   required?: boolean;
-  
+
   /** Custom message for required validation */
   requiredMessage?: string;
-  
+
   /** Minimum text length */
   minLength?: number;
-  
+
   /** Custom message for minLength validation */
   minLengthMessage?: string;
-  
+
   /** Maximum text length */
   maxLength?: number;
-  
+
   /** Custom message for maxLength validation */
   maxLengthMessage?: string;
-  
+
   /** Minimum numeric value */
   min?: number;
-  
+
   /** Custom message for min validation */
   minMessage?: string;
-  
+
   /** Maximum numeric value */
   max?: number;
-  
+
   /** Custom message for max validation */
   maxMessage?: string;
-  
+
   // =============================================================================
   // PATTERN VALIDATORS
   // =============================================================================
-  
+
   /** RegExp pattern for validation */
   pattern?: string | RegExp;
-  
+
   /** Custom message for pattern validation */
   patternMessage?: string;
-  
+
   /** Built-in email validation */
   email?: boolean;
-  
+
   /** Custom message for email validation */
   emailMessage?: string;
-  
+
   /** Built-in URL validation */
   url?: boolean;
-  
+
   /** Custom message for URL validation */
   urlMessage?: string;
-  
+
   // =============================================================================
   // ADVANCED VALIDATORS
   // =============================================================================
-  
+
   /** Custom synchronous validator function */
   customValidator?: (value: any, context?: any) => boolean | string | null;
-  
+
   /** Custom asynchronous validator function */
-  asyncValidator?: (value: any, context?: any) => Promise<boolean | string | null>;
-  
+  asyncValidator?: (
+    value: any,
+    context?: any,
+  ) => Promise<boolean | string | null>;
+
   /** Cross-field validation - must match another field */
   matchField?: string;
-  
+
   /** Custom message for field matching validation */
   matchFieldMessage?: string;
-  
+
   /** Unique value validation via API call */
   uniqueValidator?: (value: any) => Promise<boolean>;
-  
+
   /** Custom message for unique validation */
   uniqueMessage?: string;
-  
+
   /** Conditional validation rules */
   conditionalValidation?: {
     condition: (formValue: any) => boolean;
     validators: Omit<ValidatorOptions, 'conditionalValidation'>;
   }[];
-  
+
   /** Require checkbox to be checked (for checkbox fields) */
   requiredChecked?: boolean;
-  
+
   // =============================================================================
   // VALIDATION BEHAVIOR
   // =============================================================================
-  
+
   /** When to trigger validation */
   validationTrigger?: 'change' | 'blur' | 'submit' | 'immediate';
-  
+
   /** Debounce time for validation in milliseconds */
   validationDebounce?: number;
-  
+
   /** Show validation errors inline */
   showInlineErrors?: boolean;
-  
+
   /** Custom error display position */
   errorPosition?: 'bottom' | 'top' | 'tooltip';
 }
 
 /**
  * Configuration for field options in selection components.
- * 
+ *
  * Supports both static arrays and dynamic loading from APIs
  * with flexible data transformation capabilities.
  */
 export interface FieldOption {
   /** The actual value to be stored */
   value: any;
-  
+
   /** Display text shown to user */
   text: string;
-  
+
   /** Optional grouping for organized display */
   group?: string;
-  
+
   /** Whether this option is disabled */
   disabled?: boolean;
-  
+
   /** Additional data associated with option */
   data?: any;
-  
+
   /** CSS class for styling */
   cssClass?: string;
-  
+
   /** Alternative CSS class property name */
   class?: string;
-  
+
   /** Icon to display with option */
   icon?: string;
-  
+
   /** Tooltip text for option */
   tooltip?: string;
-  
+
   /** Detailed description for the option */
   description?: string;
 }
 
 /**
  * Angular Material specific styling and behavior options.
- * 
+ *
  * Covers appearance, theming, density, and interaction patterns
  * specific to Material Design 3 components.
  */
 export interface MaterialDesignConfig {
   /** Material appearance variant */
   appearance?: 'fill' | 'outline';
-  
+
   /** Material color theme */
   color?: 'primary' | 'accent' | 'warn';
-  
+
   /** Label floating behavior */
   floatLabel?: 'auto' | 'always';
-  
+
   /** Subscript sizing strategy */
   subscriptSizing?: 'fixed' | 'dynamic';
-  
+
   /** Hide required marker asterisk */
   hideRequiredMarker?: boolean;
-  
+
   /** Component density */
   density?: 'comfortable' | 'compact' | 'dense';
-  
+
   /** Disable ripple effects */
   disableRipple?: boolean;
-  
+
   /** Custom theme palette override */
   customPalette?: {
     primary?: string;
     accent?: string;
     warn?: string;
   };
-  
+
   /** Animation configuration */
   animations?: {
     disabled?: boolean;
@@ -273,10 +276,10 @@ export interface MaterialDesignConfig {
 
 /**
  * Comprehensive metadata interface for form fields.
- * 
+ *
  * This is the main interface that extends ComponentMetadata with field-specific
  * properties covering behavior, validation, data binding, and UI configuration.
- * 
+ *
  * @example
  * ```typescript
  * const emailField: FieldMetadata = {
@@ -301,176 +304,176 @@ export interface FieldMetadata extends ComponentMetadata {
   // =============================================================================
   // IDENTITY AND STRUCTURE
   // =============================================================================
-  
+
   /** Unique field identifier (required) */
   name: string;
-  
+
   /** Display label for the field */
   label: string;
-  
+
   /** Field control type for component resolution */
   controlType: FieldControlType;
-  
+
   /** Data type for processing and validation */
   dataType?: FieldDataType;
-  
+
   /** Display order in form */
   order?: number;
-  
+
   /** Logical grouping of related fields */
   group?: string;
-  
+
   /** Detailed description for tooltips */
   description?: string;
-  
+
   // =============================================================================
   // BEHAVIOR AND STATE
   // =============================================================================
-  
+
   /** Field is required */
   required?: boolean;
-  
+
   /** Field is disabled */
   disabled?: boolean;
-  
+
   /** Field is read-only */
   readOnly?: boolean;
-  
+
   /** Field is hidden from display */
   hidden?: boolean;
-  
+
   /** Default value when form initializes */
   defaultValue?: any;
-  
+
   /** Placeholder text for empty fields */
   placeholder?: string;
-  
+
   /** Help text displayed below field */
   hint?: string;
-  
+
   /** Tooltip text on hover */
   tooltip?: string;
-  
+
   // =============================================================================
   // VALIDATION CONFIGURATION
   // =============================================================================
-  
+
   /** Comprehensive validation rules */
   validators?: ValidatorOptions;
-  
+
   /** When to validate field changes */
   validationMode?: 'immediate' | 'blur' | 'submit';
-  
+
   /** Debounce time for validation (ms) */
   debounceTime?: number;
-  
+
   /** Validate uniqueness via API */
   unique?: boolean;
-  
+
   // =============================================================================
   // DATA BINDING AND OPTIONS
   // =============================================================================
-  
+
   /** Static options for selection fields */
   options?: FieldOption[];
-  
+
   /** API endpoint for dynamic data loading */
   endpoint?: string;
-  
+
   /** Field name for option values */
   valueField?: string;
-  
+
   /** Field name for option display text */
   displayField?: string;
-  
+
   /** Field name for option filtering */
   filterField?: string;
-  
+
   /** Additional query parameters for API calls */
   queryParams?: Record<string, any>;
-  
+
   /** Cache duration for remote data (ms) */
   cacheDuration?: number;
-  
+
   // =============================================================================
   // UI CONFIGURATION
   // =============================================================================
-  
+
   /** Field width specification */
   width?: string | number;
-  
+
   /** Use flexbox sizing */
   isFlex?: boolean;
-  
+
   /** Icons configuration */
   prefixIcon?: string;
   suffixIcon?: string;
   iconPosition?: 'start' | 'end';
   iconSize?: 'small' | 'medium' | 'large';
-  
+
   /** Input masking pattern */
   mask?: string;
-  
+
   /** Format for display values */
   format?: string;
-  
+
   /** Material Design specific configuration */
   materialDesign?: MaterialDesignConfig;
-  
+
   // =============================================================================
   // ADVANCED BEHAVIOR
   // =============================================================================
-  
+
   /** Fields this field depends on */
   dependencyFields?: string[];
-  
+
   /** Conditional required based on other fields */
   conditionalRequired?: string | ((formValue: any) => boolean);
-  
+
   /** Conditional visibility rules */
   conditionalDisplay?: string | ((formValue: any) => boolean);
-  
+
   /** Reset value when dependency changes */
   resetOnDependentChange?: boolean;
-  
+
   /** Allow inline editing in tables */
   inlineEditing?: boolean;
-  
+
   /** Transform value before display */
   transformDisplayValue?: (value: any) => any;
-  
+
   /** Transform value before saving */
   transformSaveValue?: (value: any) => any;
-  
+
   // =============================================================================
   // CONTEXT VISIBILITY
   // =============================================================================
-  
+
   /** Contexts where field should be visible */
   visibleIn?: Array<'form' | 'filter' | 'table' | 'dialog'>;
-  
+
   /** Hide in specific form contexts */
   formHidden?: boolean;
-  
+
   /** Hide in table contexts */
   tableHidden?: boolean;
-  
+
   /** Hide in filter contexts */
   filterHidden?: boolean;
-  
+
   // =============================================================================
   // ACCESSIBILITY
   // =============================================================================
-  
+
   /** ARIA label for screen readers */
   ariaLabel?: string;
-  
+
   /** ARIA described by element IDs */
   ariaDescribedBy?: string;
-  
+
   /** Tab index for keyboard navigation */
   tabIndex?: number;
-  
+
   /** Keyboard shortcuts */
   accessKey?: string;
 }
@@ -489,10 +492,10 @@ export interface FieldMetadata extends ComponentMetadata {
 
 /**
  * Date range value object for daterange control type.
- * 
+ *
  * Represents a date range selection with start and end dates,
  * commonly used in corporate reporting and analytics scenarios.
- * 
+ *
  * @example
  * ```typescript
  * const quarterRange: DateRangeValue = {
@@ -506,51 +509,64 @@ export interface FieldMetadata extends ComponentMetadata {
 export interface DateRangeValue {
   /** Start date of the range */
   startDate: Date | null;
-  
+
   /** End date of the range */
   endDate: Date | null;
-  
+
   /** Applied preset name if range was selected via preset */
   preset?: string;
-  
+
   /** Timezone context for the range */
   timezone?: string;
-  
+
   /** User-friendly label for the range */
   label?: string;
-  
+
   /** Whether this is a comparison range */
   isComparison?: boolean;
 }
 
 /**
+ * Numeric range value object for price range fields.
+ *
+ * Represents a monetary range with minimum and maximum values.
+ */
+export interface PriceRangeValue {
+  /** Lower bound of the range */
+  minPrice: number | null;
+
+  /** Upper bound of the range */
+  maxPrice: number | null;
+}
+
+/**
  * Corporate preset configuration for date ranges.
- * 
+ *
  * Defines common business date ranges used in enterprise applications
  * for reporting, analytics, and compliance purposes.
  */
 export interface DateRangePreset {
   /** Unique identifier for the preset */
   id: string;
-  
+
   /** Display label for the preset */
   label: string;
-  
+
   /** Icon to display with the preset */
   icon?: string;
-  
+
   /** Category for grouping presets */
   category?: 'standard' | 'fiscal' | 'custom' | 'comparison';
-  
+
   /** Function to calculate the date range */
   calculateRange: (referenceDate?: Date) => DateRangeValue;
-  
+
   /** Whether this preset is commonly used */
   isPopular?: boolean;
-  
+
   /** Tooltip description */
   description?: string;
-  
+
   /** Display order in preset list */
   order?: number;
 }
@@ -565,7 +581,16 @@ export type PartialFieldMetadata = Partial<FieldMetadata> & {
 };
 
 /** Helper type for required core field properties */
-export type CoreFieldMetadata = Pick<FieldMetadata, 'name' | 'label' | 'controlType'>;
+export type CoreFieldMetadata = Pick<
+  FieldMetadata,
+  'name' | 'label' | 'controlType'
+>;
 
 /** Helper type for field metadata without computed properties */
-export type SerializableFieldMetadata = Omit<FieldMetadata, 'conditionalRequired' | 'conditionalDisplay' | 'transformDisplayValue' | 'transformSaveValue'>;
+export type SerializableFieldMetadata = Omit<
+  FieldMetadata,
+  | 'conditionalRequired'
+  | 'conditionalDisplay'
+  | 'transformDisplayValue'
+  | 'transformSaveValue'
+>;

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/material-field-metadata.interface.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/material-field-metadata.interface.ts
@@ -928,6 +928,46 @@ export interface MaterialDateRangeMetadata extends FieldMetadata {
 }
 
 /**
+ * Metadata for a price range input using two currency fields.
+ */
+export interface MaterialPriceRangeMetadata extends FieldMetadata {
+  controlType: typeof FieldControlType.RANGE_SLIDER;
+
+  /** Minimum allowed value */
+  min?: number;
+
+  /** Maximum allowed value */
+  max?: number;
+
+  /** Step for value increments */
+  step?: number;
+
+  /** Currency code (USD, EUR, BRL, etc.) */
+  currency: string;
+
+  /** Currency symbol position */
+  currencyPosition?: 'before' | 'after';
+
+  /** Number of decimal places */
+  decimalPlaces?: number;
+
+  /** Allow negative values */
+  allowNegative?: boolean;
+
+  /** Placeholder for start input */
+  startPlaceholder?: string;
+
+  /** Placeholder for end input */
+  endPlaceholder?: string;
+
+  /** Label for start input */
+  startLabel?: string;
+
+  /** Label for end input */
+  endLabel?: string;
+}
+
+/**
  * Specialized metadata for Material Button components.
  *
  * Handles action buttons with various styles,

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-price-range/index.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-price-range/index.ts
@@ -1,0 +1,2 @@
+export * from './material-price-range.component';
+

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-price-range/material-price-range.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-price-range/material-price-range.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { MaterialPriceRangeComponent } from './material-price-range.component';
+import { MaterialPriceRangeMetadata, PriceRangeValue } from '@praxis/core';
+
+describe('MaterialPriceRangeComponent', () => {
+  let component: MaterialPriceRangeComponent;
+  let fixture: ComponentFixture<MaterialPriceRangeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MaterialPriceRangeComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MaterialPriceRangeComponent);
+    component = fixture.componentInstance;
+    component.setPriceRangeMetadata({
+      name: 'price',
+      label: 'Price',
+      controlType: 'rangeSlider' as any,
+      currency: 'USD',
+    } as MaterialPriceRangeMetadata);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should propagate value changes', () => {
+    const control = new FormControl<PriceRangeValue | null>(null);
+    component.registerOnChange(control.setValue.bind(control));
+    component.rangeGroup.setValue({ minPrice: 100, maxPrice: 200 });
+    expect(control.value).toEqual({ minPrice: 100, maxPrice: 200 });
+  });
+
+  it('should validate range boundaries', () => {
+    component.setPriceRangeMetadata({
+      name: 'price',
+      label: 'Price',
+      controlType: 'rangeSlider' as any,
+      currency: 'USD',
+      min: 0,
+      max: 500,
+    });
+    fixture.detectChanges();
+
+    component.rangeGroup.setValue({ minPrice: -10, maxPrice: 100 });
+    expect(component.rangeGroup.valid).toBeFalse();
+
+    component.rangeGroup.setValue({ minPrice: 100, maxPrice: 600 });
+    expect(component.rangeGroup.valid).toBeFalse();
+
+    component.rangeGroup.setValue({ minPrice: 100, maxPrice: 200 });
+    expect(component.rangeGroup.valid).toBeTrue();
+  });
+
+  it('should provide custom error messages', () => {
+    component.setPriceRangeMetadata({
+      name: 'price',
+      label: 'Price',
+      controlType: 'rangeSlider' as any,
+      currency: 'USD',
+      min: 0,
+      max: 500,
+    });
+    fixture.detectChanges();
+
+    component.rangeGroup.setValue({ minPrice: 400, maxPrice: 100 });
+    component.rangeGroup.updateValueAndValidity();
+    expect(component.errorMessage()).toBe(
+      'O valor inicial deve ser menor ou igual ao final',
+    );
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-price-range/material-price-range.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-price-range/material-price-range.component.ts
@@ -1,0 +1,213 @@
+import { Component, forwardRef, computed, OnInit, output } from '@angular/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  ValidationErrors,
+  FormGroup,
+  FormControl,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import {
+  MaterialPriceRangeMetadata,
+  PriceRangeValue,
+  FieldControlType,
+  MaterialCurrencyMetadata,
+} from '@praxis/core';
+import { MaterialCurrencyComponent } from '../material-currency/material-currency.component';
+import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+
+/**
+ * Component for selecting a price range using two currency inputs.
+ *
+ * Reuses `MaterialCurrencyComponent` for both the minimum and maximum
+ * values, keeping formatting and validation consistent.
+ */
+@Component({
+  selector: 'pdx-material-price-range',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MaterialCurrencyComponent],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MaterialPriceRangeComponent),
+      multi: true,
+    },
+  ],
+  template: `
+    <div class="price-range-container">
+      <label class="range-label">{{
+        metadata()?.label || 'Price range'
+      }}</label>
+      <div class="range-inputs" [formGroup]="rangeGroup">
+        <pdx-material-currency
+          formControlName="minPrice"
+          [metadata]="startCurrencyMetadata()"
+        ></pdx-material-currency>
+        <pdx-material-currency
+          formControlName="maxPrice"
+          [metadata]="endCurrencyMetadata()"
+        ></pdx-material-currency>
+      </div>
+
+      @if (
+        errorMessage() &&
+        internalControl.invalid &&
+        (internalControl.dirty || internalControl.touched)
+      ) {
+        <div class="mat-error">{{ errorMessage() }}</div>
+      }
+
+      @if (metadata()?.hint && !hasValidationError()) {
+        <div class="mat-hint">{{ metadata()!.hint }}</div>
+      }
+    </div>
+  `,
+  host: {
+    '[class]': 'componentCssClasses()',
+    '[attr.data-field-type]': '"priceRange"',
+    '[attr.data-field-name]': 'metadata()?.name',
+    '[attr.data-component-id]': 'componentId()',
+  },
+})
+export class MaterialPriceRangeComponent
+  extends SimpleBaseInputComponent
+  implements OnInit
+{
+  /** Emits whenever validation state changes. */
+  readonly validationChange = output<ValidationErrors | null>();
+
+  readonly rangeGroup = new FormGroup({
+    minPrice: new FormControl<number | null>(null),
+    maxPrice: new FormControl<number | null>(null),
+  });
+
+  readonly startCurrencyMetadata = computed(() => {
+    const md = this.metadata() as MaterialPriceRangeMetadata | null;
+    if (!md) return null;
+    const meta: MaterialCurrencyMetadata = {
+      controlType: FieldControlType.CURRENCY_INPUT,
+      name: `${md.name}_min`,
+      label: md.startLabel || 'Min',
+      inputType: 'text',
+      currency: md.currency,
+      currencyPosition: md.currencyPosition,
+      decimalPlaces: md.decimalPlaces,
+      allowNegative: md.allowNegative,
+      placeholder: md.startPlaceholder,
+      required: md.required,
+    };
+    return meta;
+  });
+
+  readonly endCurrencyMetadata = computed(() => {
+    const md = this.metadata() as MaterialPriceRangeMetadata | null;
+    if (!md) return null;
+    const meta: MaterialCurrencyMetadata = {
+      controlType: FieldControlType.CURRENCY_INPUT,
+      name: `${md.name}_max`,
+      label: md.endLabel || 'Max',
+      inputType: 'text',
+      currency: md.currency,
+      currencyPosition: md.currencyPosition,
+      decimalPlaces: md.decimalPlaces,
+      allowNegative: md.allowNegative,
+      placeholder: md.endPlaceholder,
+      required: md.required,
+    };
+    return meta;
+  });
+
+  /** Custom error messages for range-specific validations */
+  override readonly errorMessage = computed(() => {
+    const errors = this.internalControl.errors;
+    const md = this.metadata() as MaterialPriceRangeMetadata | null;
+    if (!errors) return '';
+
+    if (errors['rangeOrder']) {
+      return 'O valor inicial deve ser menor ou igual ao final';
+    }
+    if (errors['minValue'] && md?.min != null) {
+      return `Valor mínimo permitido é ${md.min}`;
+    }
+    if (errors['maxValue'] && md?.max != null) {
+      return `Valor máximo permitido é ${md.max}`;
+    }
+
+    return '';
+  });
+
+  override ngOnInit(): void {
+    const md = this.metadata() as MaterialPriceRangeMetadata | null;
+    if (md) {
+      this.rangeGroup.addValidators((group) => {
+        const val = group.value as PriceRangeValue;
+        const start = val.minPrice;
+        const end = val.maxPrice;
+        if (start != null && end != null && start > end) {
+          return { rangeOrder: true };
+        }
+        if (
+          md.min != null &&
+          ((start != null && start < md.min) || (end != null && end < md.min))
+        ) {
+          return { minValue: true };
+        }
+        if (
+          md.max != null &&
+          ((start != null && start > md.max) || (end != null && end > md.max))
+        ) {
+          return { maxValue: true };
+        }
+        return null;
+      });
+    }
+
+    this.rangeGroup.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(({ minPrice, maxPrice }) => {
+        const value: PriceRangeValue = {
+          minPrice: minPrice ?? null,
+          maxPrice: maxPrice ?? null,
+        };
+        this.setValue(value);
+      });
+
+    this.rangeGroup.statusChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        const errors = this.rangeGroup.errors;
+        this.internalControl.setErrors(errors);
+      });
+
+    this.internalControl.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((val: PriceRangeValue | null) => {
+        this.rangeGroup.patchValue(
+          {
+            minPrice: val?.minPrice ?? null,
+            maxPrice: val?.maxPrice ?? null,
+          },
+          { emitEvent: false },
+        );
+      });
+
+    super.ngOnInit();
+  }
+
+  override async validateField(): Promise<ValidationErrors | null> {
+    const errors = await super.validateField();
+    this.validationChange.emit(errors);
+    return errors;
+  }
+
+  protected override getSpecificCssClasses(): string[] {
+    return ['pdx-material-price-range'];
+  }
+
+  /** Applies component metadata with strong typing. */
+  setPriceRangeMetadata(metadata: MaterialPriceRangeMetadata): void {
+    this.setMetadata(metadata);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/services/component-registry/component-registry.service.ts
@@ -278,6 +278,12 @@ export class ComponentRegistryService implements IComponentRegistry {
         '../../components/material-currency/material-currency.component'
       ).then((m) => m.MaterialCurrencyComponent);
 
+    // Specialized price range input
+    const priceRangeFactory = () =>
+      import(
+        '../../components/material-price-range/material-price-range.component'
+      ).then((m) => m.MaterialPriceRangeComponent);
+
     // Specialized search input
     const searchInputFactory = () =>
       import('../../components/search-input/search-input.component').then(
@@ -322,6 +328,7 @@ export class ComponentRegistryService implements IComponentRegistry {
     this.register(FieldControlTypeEnum.PASSWORD, passwordInputFactory);
     this.register(FieldControlTypeEnum.NUMERIC_TEXT_BOX, numberInputFactory);
     this.register(FieldControlTypeEnum.CURRENCY_INPUT, currencyInputFactory);
+    this.register(FieldControlTypeEnum.RANGE_SLIDER, priceRangeFactory);
     this.register(FieldControlTypeEnum.SEARCH_INPUT, searchInputFactory);
     this.register(FieldControlTypeEnum.PHONE, phoneInputFactory);
     this.register(FieldControlTypeEnum.TIME_INPUT, timeInputFactory);
@@ -334,9 +341,9 @@ export class ComponentRegistryService implements IComponentRegistry {
 
     // Material color picker
     const colorPickerFactory = () =>
-      import('../../components/material-colorpicker/material-colorpicker.component').then(
-        (m) => m.MaterialColorPickerComponent,
-      );
+      import(
+        '../../components/material-colorpicker/material-colorpicker.component'
+      ).then((m) => m.MaterialColorPickerComponent);
     this.register(FieldControlTypeEnum.COLOR_PICKER, colorPickerFactory);
 
     // HTML5 date input

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/public-api.ts
@@ -23,6 +23,7 @@ export * from './lib/components/datetime-local-input/datetime-local-input.compon
 export * from './lib/components/email-input/email-input.component';
 export * from './lib/components/number-input/number-input.component';
 export * from './lib/components/material-currency/material-currency.component';
+export * from './lib/components/material-price-range/material-price-range.component';
 export * from './lib/components/month-input/month-input.component';
 export * from './lib/components/password-input/password-input.component';
 export * from './lib/components/search-input/search-input.component';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
@@ -5,14 +5,18 @@ import {
   GenericCrudService,
   CONFIG_STORAGE,
   ConfigStorage,
-
   FieldControlType,
   MaterialDatepickerMetadata,
   MaterialDateRangeMetadata,
   DateRangeValue,
+  MaterialPriceRangeMetadata,
 } from '@praxis/core';
-import { DynamicFieldLoaderDirective } from '@praxis/dynamic-fields';
-
+import {
+  DynamicFieldLoaderDirective,
+  MaterialSelectComponent,
+  MaterialCheckboxGroupComponent,
+  MaterialRadioGroupComponent,
+} from '@praxis/dynamic-fields';
 
 describe('PraxisDynamicForm', () => {
   let fixture: ComponentFixture<PraxisDynamicForm>;
@@ -145,7 +149,6 @@ describe('PraxisDynamicForm', () => {
     expect(submitSpy).toHaveBeenCalled();
   });
 
-
   it('aplica validadores de min/max em campos de data', () => {
     component.config = {
       sections: [],
@@ -222,6 +225,53 @@ describe('PraxisDynamicForm', () => {
       startDate: new Date('2024-01-01'),
       endDate: new Date('2024-01-02'),
     });
+    expect(ctrl.valid).toBeTrue();
+  });
+
+  it('valida campos de faixa de preço', () => {
+    component.config = {
+      sections: [],
+      fieldMetadata: [
+        {
+          name: 'price',
+          controlType: FieldControlType.RANGE_SLIDER,
+          min: 0,
+          max: 1000,
+        } as MaterialPriceRangeMetadata,
+      ],
+    };
+    (component as any).buildFormFromConfig();
+    const ctrl = component.form.get('price')!;
+    ctrl.setValue({ minPrice: 500, maxPrice: 400 });
+    expect(ctrl.hasError('rangeOrder')).toBeTrue();
+    ctrl.setValue({ minPrice: -10, maxPrice: 100 });
+    expect(ctrl.hasError('minValue')).toBeTrue();
+    ctrl.setValue({ minPrice: 100, maxPrice: 1500 });
+    expect(ctrl.hasError('maxValue')).toBeTrue();
+    ctrl.setValue({ minPrice: 100, maxPrice: 200 });
+    expect(ctrl.valid).toBeTrue();
+  });
+
+  it('exige mínimo e máximo quando faixa de preço é obrigatória', () => {
+    component.config = {
+      sections: [],
+      fieldMetadata: [
+        {
+          name: 'budget',
+          controlType: FieldControlType.RANGE_SLIDER,
+          required: true,
+        } as MaterialPriceRangeMetadata,
+      ],
+    };
+    (component as any).buildFormFromConfig();
+    const ctrl = component.form.get('budget')!;
+
+    expect(ctrl.hasError('required')).toBeTrue();
+
+    ctrl.setValue({ minPrice: 100, maxPrice: null });
+    expect(ctrl.hasError('required')).toBeTrue();
+
+    ctrl.setValue({ minPrice: 100, maxPrice: 200 });
     expect(ctrl.valid).toBeTrue();
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
@@ -36,6 +36,8 @@ import {
   MaterialDatepickerMetadata,
   MaterialDateRangeMetadata,
   DateRangeValue,
+  MaterialPriceRangeMetadata,
+  PriceRangeValue,
 } from '@praxis/core';
 import { DynamicFieldLoaderDirective } from '@praxis/dynamic-fields';
 import {
@@ -871,6 +873,39 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
           }
           return null;
         });
+      } else if (field.controlType === FieldControlType.RANGE_SLIDER) {
+        const md = field as MaterialPriceRangeMetadata;
+        const dv = defaultValue as PriceRangeValue | null;
+        defaultValue = {
+          minPrice: dv?.minPrice ?? null,
+          maxPrice: dv?.maxPrice ?? null,
+        } as PriceRangeValue;
+        const min = md.min ?? null;
+        const max = md.max ?? null;
+        validators.push((control) => {
+          const val = control.value as PriceRangeValue | null;
+          if (!val) {
+            return null;
+          }
+          const start = val.minPrice;
+          const end = val.maxPrice;
+          if (start != null && end != null && start > end) {
+            return { rangeOrder: true };
+          }
+          if (
+            min != null &&
+            ((start != null && start < min) || (end != null && end < min))
+          ) {
+            return { minValue: true };
+          }
+          if (
+            max != null &&
+            ((start != null && start > max) || (end != null && end > max))
+          ) {
+            return { maxValue: true };
+          }
+          return null;
+        });
       }
 
       if (field.required) {
@@ -878,6 +913,13 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
           validators.push((control) => {
             const val = control.value as DateRangeValue | null;
             return val?.startDate && val?.endDate ? null : { required: true };
+          });
+        } else if (field.controlType === FieldControlType.RANGE_SLIDER) {
+          validators.push((control) => {
+            const val = control.value as PriceRangeValue | null;
+            return val?.minPrice != null && val?.maxPrice != null
+              ? null
+              : { required: true };
           });
         } else {
           validators.push(Validators.required);


### PR DESCRIPTION
## Summary
- implement MaterialPriceRangeComponent leveraging MaterialCurrency inputs for start and end values
- add MaterialPriceRangeMetadata and PriceRangeValue models
- support range slider metadata and validation in field mapper and dynamic form
- refine MaterialPriceRangeComponent with tailored error messages

## Testing
- `npx ng test praxis-core --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npx ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npx ng test praxis-dynamic-form --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68979121379c832894f4900fe17977ca