### PR TITLE
fix: handle locale and select metadata

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-input.component.ts
@@ -472,6 +472,9 @@ export abstract class SimpleBaseInputComponent
     // Reaplica validators quando metadata muda
     this.setupValidators();
     this.applyNativeAttributes();
+    if (metadata.disabled !== undefined) {
+      this.setDisabledState(metadata.disabled);
+    }
     this.emitLifecycleEvent('change');
   }
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.spec.ts
@@ -9,7 +9,7 @@ import { SimpleBaseSelectComponent } from './simple-base-select.component';
 @Component({
   template: `
     <mat-form-field>
-      <mat-select>
+      <mat-select [multiple]="multiple()">
         <mat-option value="one">One</mat-option>
       </mat-select>
     </mat-form-field>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.ts
@@ -202,7 +202,6 @@ export abstract class SimpleBaseSelectComponent<
       this.matSelect.disableOptionCentering = meta.disableOptionCentering;
     if (meta.tabIndex !== undefined) this.matSelect.tabIndex = meta.tabIndex;
     if (meta.placeholder) this.matSelect.placeholder = meta.placeholder;
-    if (meta.multiple !== undefined) this.matSelect.multiple = meta.multiple;
     if (meta.required !== undefined) this.matSelect.required = meta.required;
     if (meta.errorStateMatcher)
       this.matSelect.errorStateMatcher = meta.errorStateMatcher;

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
@@ -26,10 +26,10 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
     >
       <mat-label>{{ metadata()?.label || 'Select' }}</mat-label>
       <mat-select
+        [multiple]="multiple()"
         [formControl]="internalControl"
         [placeholder]="metadata()?.placeholder || ''"
         [required]="metadata()?.required || false"
-        [disabled]="metadata()?.disabled || false"
         (openedChange)="onOpened($event)"
       >
         <mat-option *ngIf="loading()" disabled>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.ts
@@ -13,13 +13,19 @@ import {
   ValidationErrors,
   Validators,
 } from '@angular/forms';
-import { CommonModule, CurrencyPipe } from '@angular/common';
+import {
+  CommonModule,
+  CurrencyPipe,
+  registerLocaleData,
+} from '@angular/common';
+import localePt from '@angular/common/locales/pt';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 
 import { MaterialCurrencyMetadata } from '@praxis/core';
 import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
+registerLocaleData(localePt, 'pt-BR');
 
 /**
  * Input component for currency values with basic formatting support.

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-date-range/material-date-range.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-date-range/material-date-range.component.ts
@@ -78,7 +78,6 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
         [startAt]="startAt()"
         [touchUi]="metadata()?.touchUi || false"
         [color]="materialColor()"
-        [disabled]="metadata()?.disabled || false"
       ></mat-date-range-picker>
 
       @if (

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-datepicker/material-datepicker.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-datepicker/material-datepicker.component.ts
@@ -66,7 +66,6 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
         [startAt]="startAt()"
         [touchUi]="metadata()?.touchUi || false"
         [color]="materialColor()"
-        [disabled]="metadata()?.disabled || false"
       ></mat-datepicker>
 
       @if (

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
@@ -32,7 +32,6 @@ import {
         [formControl]="internalControl"
         [placeholder]="metadata()?.placeholder || ''"
         [required]="metadata()?.required || false"
-        [disabled]="metadata()?.disabled || false"
       >
         @if (selectAll()) {
           <mat-option
@@ -81,8 +80,9 @@ import {
 export class MaterialMultiSelectComponent extends SimpleBaseSelectComponent {
   override setSelectMetadata(metadata: SimpleSelectMetadata<any>): void {
     const matMetadata = metadata as MaterialSelectMetadata;
-    const source: Array<{ label?: string; text?: string; value: any; disabled?: boolean }> | undefined =
-      matMetadata.selectOptions ?? (matMetadata as any).options;
+    const source:
+      | Array<{ label?: string; text?: string; value: any; disabled?: boolean }>
+      | undefined = matMetadata.selectOptions ?? (matMetadata as any).options;
     const mappedOptions = source?.map((o) => ({
       label: o.label ?? o.text ?? '',
       value: o.value,

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
@@ -26,10 +26,10 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
     >
       <mat-label>{{ metadata()?.label || 'Select' }}</mat-label>
       <mat-select
+        [multiple]="multiple()"
         [formControl]="internalControl"
         [placeholder]="metadata()?.placeholder || ''"
         [required]="metadata()?.required || false"
-        [disabled]="metadata()?.disabled || false"
         (openedChange)="onOpened($event)"
       >
         <mat-option *ngIf="searchable()" disabled>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
@@ -30,7 +30,6 @@ import {
         [formControl]="internalControl"
         [placeholder]="metadata()?.placeholder || ''"
         [required]="metadata()?.required || false"
-        [disabled]="metadata()?.disabled || false"
       >
         <mat-option
           *ngFor="let option of options(); trackBy: trackByOption"


### PR DESCRIPTION
## Summary
- register pt-BR locale for currency formatting
- disable form controls via metadata instead of template attributes
- avoid toggling MatSelect multiple mode after init

## Testing
- `npm test -- praxis-dynamic-fields --watch=false` *(fails: Cannot start Chrome, requires chromium snap)*

------
https://chatgpt.com/codex/tasks/task_e_6897b67f42d48328b1e85ad4b520720d