### PR TITLE
fix: register Portuguese locale for currency component

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.ts
@@ -13,10 +13,17 @@ import {
   ValidationErrors,
   Validators,
 } from '@angular/forms';
-import { CommonModule, CurrencyPipe } from '@angular/common';
+import {
+  CommonModule,
+  CurrencyPipe,
+  registerLocaleData,
+} from '@angular/common';
+import localePt from '@angular/common/locales/pt';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
+
+registerLocaleData(localePt, 'pt');
 
 import { MaterialCurrencyMetadata } from '@praxis/core';
 import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';

--- a/frontend-libs/praxis-ui-workspace/src/app/app.config.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/app.config.ts
@@ -6,6 +6,7 @@ import {
   provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import '@angular/common/locales/global/pt';
 
 import { routes } from './app.routes';
 import { API_URL } from '@praxis/core';


### PR DESCRIPTION
## Summary
- register Portuguese locale in MaterialCurrencyComponent
- load global Portuguese locale in app config

## Testing
- `ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: /root/.cache/puppeteer/chrome/linux-139.0.7258.66/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0)*
- `ng test --watch=false --browsers=ChromeHeadless --include=src/app/features/ui-wrappers-test/ui-wrappers-test.component.spec.ts` *(fails: /root/.cache/puppeteer/chrome/linux-139.0.7258.66/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0)*


------
https://chatgpt.com/codex/tasks/task_e_6897d5a7e0888328b5a00e24a42b9b46