### PR TITLE
refactor select components to template-driven multiple mode

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.spec.ts
@@ -9,9 +9,15 @@ import { SimpleBaseSelectComponent } from './simple-base-select.component';
 @Component({
   template: `
     <mat-form-field>
-      <mat-select [multiple]="multiple()">
-        <mat-option value="one">One</mat-option>
-      </mat-select>
+      @if (multiple()) {
+        <mat-select multiple>
+          <mat-option value="one">One</mat-option>
+        </mat-select>
+      } @else {
+        <mat-select>
+          <mat-option value="one">One</mat-option>
+        </mat-select>
+      }
     </mat-form-field>
   `,
   standalone: true,

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.ts
@@ -5,6 +5,7 @@ import {
   computed,
   inject,
   viewChild,
+  effect,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ComponentMetadata, GenericCrudService, Page } from '@praxis/core';
@@ -102,10 +103,12 @@ export abstract class SimpleBaseSelectComponent<
 
   override ngAfterViewInit(): void {
     super.ngAfterViewInit();
-    const select = this.matSelectRef();
-    if (select) {
-      this.registerMatSelect(select);
-    }
+    effect(() => {
+      const select = this.matSelectRef();
+      if (select && select !== this.matSelect) {
+        this.registerMatSelect(select);
+      }
+    });
   }
 
   /** CRUD service for remote option loading (optional) */

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
@@ -25,30 +25,56 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
       [class]="componentCssClasses()"
     >
       <mat-label>{{ metadata()?.label || 'Select' }}</mat-label>
-      <mat-select
-        [multiple]="multiple()"
-        [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
-        [required]="metadata()?.required || false"
-        (openedChange)="onOpened($event)"
-      >
-        <mat-option *ngIf="loading()" disabled>
-          <mat-progress-spinner diameter="20" mode="indeterminate" />
-        </mat-option>
-        <ng-container *ngIf="!loading()">
-          <mat-option *ngIf="error()" (click)="retry()" [value]="null">
-            {{ error() }} - Retry
+      @if (multiple()) {
+        <mat-select
+          multiple
+          [formControl]="internalControl"
+          [placeholder]="metadata()?.placeholder || ''"
+          [required]="metadata()?.required || false"
+          (openedChange)="onOpened($event)"
+        >
+          <mat-option *ngIf="loading()" disabled>
+            <mat-progress-spinner diameter="20" mode="indeterminate" />
           </mat-option>
-          <mat-option
-            *ngFor="let option of options(); trackBy: trackByOption"
-            [value]="option.value"
-            [disabled]="option.disabled"
-            (click)="selectOption(option)"
-          >
-            {{ option.label }}
+          <ng-container *ngIf="!loading()">
+            <mat-option *ngIf="error()" (click)="retry()" [value]="null">
+              {{ error() }} - Retry
+            </mat-option>
+            <mat-option
+              *ngFor="let option of options(); trackBy: trackByOption"
+              [value]="option.value"
+              [disabled]="option.disabled"
+              (click)="selectOption(option)"
+            >
+              {{ option.label }}
+            </mat-option>
+          </ng-container>
+        </mat-select>
+      } @else {
+        <mat-select
+          [formControl]="internalControl"
+          [placeholder]="metadata()?.placeholder || ''"
+          [required]="metadata()?.required || false"
+          (openedChange)="onOpened($event)"
+        >
+          <mat-option *ngIf="loading()" disabled>
+            <mat-progress-spinner diameter="20" mode="indeterminate" />
           </mat-option>
-        </ng-container>
-      </mat-select>
+          <ng-container *ngIf="!loading()">
+            <mat-option *ngIf="error()" (click)="retry()" [value]="null">
+              {{ error() }} - Retry
+            </mat-option>
+            <mat-option
+              *ngFor="let option of options(); trackBy: trackByOption"
+              [value]="option.value"
+              [disabled]="option.disabled"
+              (click)="selectOption(option)"
+            >
+              {{ option.label }}
+            </mat-option>
+          </ng-container>
+        </mat-select>
+      }
       @if (
         errorMessage() &&
         internalControl.invalid &&


### PR DESCRIPTION
## Summary
- register mat-select via effect to handle dynamic multiple state
- render async select with dedicated single and multi templates
- adjust base select spec for template-driven multiple mode

## Testing
- `npm install`
- `npx ng test praxis-dynamic-fields --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6897d8850b9c83288041118e2259cc77