### PR TITLE
fix: disable select controls via form control

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
@@ -25,29 +25,56 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
       [class]="componentCssClasses()"
     >
       <mat-label>{{ metadata()?.label || 'Select' }}</mat-label>
-      <mat-select
-        [multiple]="multiple()"
-        [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
-        [required]="metadata()?.required || false"
-        (openedChange)="onOpened($event)"
-      >
-        <mat-option *ngIf="loading()" disabled>
-          <mat-progress-spinner diameter="20" mode="indeterminate" />
-        </mat-option>
-        <ng-container *ngIf="!loading()">
-          <mat-option *ngIf="error()" (click)="retry()" [value]="null">
-            {{ error() }} - Retry
+      @if (multiple()) {
+        <mat-select
+          multiple
+          [formControl]="internalControl"
+          [placeholder]="metadata()?.placeholder || ''"
+          [required]="metadata()?.required || false"
+          (openedChange)="onOpened($event)"
+        >
+          <mat-option *ngIf="loading()" disabled>
+            <mat-progress-spinner diameter="20" mode="indeterminate" />
           </mat-option>
-          <mat-option
-            *ngFor="let option of options(); trackBy: trackByOption"
-            [value]="option.value"
-            (click)="selectOption(option)"
-          >
-            {{ option.label }}
+          <ng-container *ngIf="!loading()">
+            <mat-option *ngIf="error()" (click)="retry()" [value]="null">
+              {{ error() }} - Retry
+            </mat-option>
+            <mat-option
+              *ngFor="let option of options(); trackBy: trackByOption"
+              [value]="option.value"
+              [disabled]="option.disabled"
+              (click)="selectOption(option)"
+            >
+              {{ option.label }}
+            </mat-option>
+          </ng-container>
+        </mat-select>
+      } @else {
+        <mat-select
+          [formControl]="internalControl"
+          [placeholder]="metadata()?.placeholder || ''"
+          [required]="metadata()?.required || false"
+          (openedChange)="onOpened($event)"
+        >
+          <mat-option *ngIf="loading()" disabled>
+            <mat-progress-spinner diameter="20" mode="indeterminate" />
           </mat-option>
-        </ng-container>
-      </mat-select>
+          <ng-container *ngIf="!loading()">
+            <mat-option *ngIf="error()" (click)="retry()" [value]="null">
+              {{ error() }} - Retry
+            </mat-option>
+            <mat-option
+              *ngFor="let option of options(); trackBy: trackByOption"
+              [value]="option.value"
+              [disabled]="option.disabled"
+              (click)="selectOption(option)"
+            >
+              {{ option.label }}
+            </mat-option>
+          </ng-container>
+        </mat-select>
+      }
       @if (
         errorMessage() &&
         internalControl.invalid &&
@@ -81,6 +108,7 @@ export class MaterialAsyncSelectComponent extends SimpleBaseSelectComponent {
     const mappedOptions = source?.map((o: any) => ({
       label: o.label ?? o.text,
       value: o.value,
+      disabled: o.disabled,
     }));
 
     super.setSelectMetadata({

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
@@ -42,7 +42,6 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
           <mat-option
             *ngFor="let option of options(); trackBy: trackByOption"
             [value]="option.value"
-            [disabled]="option.disabled"
             (click)="selectOption(option)"
           >
             {{ option.label }}
@@ -82,7 +81,6 @@ export class MaterialAsyncSelectComponent extends SimpleBaseSelectComponent {
     const mappedOptions = source?.map((o: any) => ({
       label: o.label ?? o.text,
       value: o.value,
-      disabled: o.disabled,
     }));
 
     super.setSelectMetadata({
@@ -95,6 +93,16 @@ export class MaterialAsyncSelectComponent extends SimpleBaseSelectComponent {
       optionLabelKey: metadata.optionLabelKey ?? metadata.displayField,
       optionValueKey: metadata.optionValueKey ?? metadata.valueField,
     });
+  }
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+    const disabled = this.metadata()?.disabled;
+    if (disabled) {
+      this.internalControl.disable({ emitEvent: false });
+    } else {
+      this.internalControl.enable({ emitEvent: false });
+    }
   }
 
   onOpened(opened: boolean): void {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
@@ -7,6 +7,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MaterialSelectMetadata, GenericCrudService } from '@praxis/core';
 import {
   SimpleBaseSelectComponent,
+  SelectOption,
   SimpleSelectMetadata,
 } from '../../base/simple-base-select.component';
 
@@ -43,6 +44,7 @@ import {
         <mat-option
           *ngFor="let option of options(); trackBy: trackByOption"
           [value]="option.value"
+          [disabled]="isOptionDisabled(option)"
           (click)="selectOption(option)"
         >
           {{ option.label }}
@@ -84,6 +86,7 @@ export class MaterialMultiSelectComponent extends SimpleBaseSelectComponent {
     const mappedOptions = source?.map((o) => ({
       label: o.label ?? o.text ?? '',
       value: o.value,
+      disabled: o.disabled,
     }));
 
     super.setSelectMetadata({
@@ -110,5 +113,16 @@ export class MaterialMultiSelectComponent extends SimpleBaseSelectComponent {
     } else {
       this.internalControl.enable({ emitEvent: false });
     }
+  }
+
+  /** Disables options when maxSelections reached */
+  isOptionDisabled(option: SelectOption<any>): boolean {
+    if (option.disabled) return true;
+    if (!this.maxSelections()) return false;
+    const current = Array.isArray(this.internalControl.value)
+      ? this.internalControl.value
+      : [];
+    const isSelected = current.includes(option.value);
+    return !isSelected && current.length >= this.maxSelections()!;
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
@@ -7,7 +7,6 @@ import { MatSelectModule } from '@angular/material/select';
 import { MaterialSelectMetadata, GenericCrudService } from '@praxis/core';
 import {
   SimpleBaseSelectComponent,
-  SelectOption,
   SimpleSelectMetadata,
 } from '../../base/simple-base-select.component';
 
@@ -44,7 +43,6 @@ import {
         <mat-option
           *ngFor="let option of options(); trackBy: trackByOption"
           [value]="option.value"
-          [disabled]="isOptionDisabled(option)"
           (click)="selectOption(option)"
         >
           {{ option.label }}
@@ -86,7 +84,6 @@ export class MaterialMultiSelectComponent extends SimpleBaseSelectComponent {
     const mappedOptions = source?.map((o) => ({
       label: o.label ?? o.text ?? '',
       value: o.value,
-      disabled: o.disabled,
     }));
 
     super.setSelectMetadata({
@@ -105,14 +102,13 @@ export class MaterialMultiSelectComponent extends SimpleBaseSelectComponent {
     });
   }
 
-  /** Disables options when maxSelections reached */
-  isOptionDisabled(option: SelectOption<any>): boolean {
-    if (option.disabled) return true;
-    if (!this.maxSelections()) return false;
-    const current = Array.isArray(this.internalControl.value)
-      ? this.internalControl.value
-      : [];
-    const isSelected = current.includes(option.value);
-    return !isSelected && current.length >= this.maxSelections()!;
+  override ngOnInit(): void {
+    super.ngOnInit();
+    const disabled = this.metadata()?.disabled;
+    if (disabled) {
+      this.internalControl.disable({ emitEvent: false });
+    } else {
+      this.internalControl.enable({ emitEvent: false });
+    }
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
@@ -46,6 +46,7 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
           <mat-option
             *ngFor="let option of filteredOptions(); trackBy: trackByOption"
             [value]="option.value"
+            [disabled]="option.disabled"
             (click)="selectOption(option)"
           >
             {{ option.label }}
@@ -71,6 +72,7 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
           <mat-option
             *ngFor="let option of filteredOptions(); trackBy: trackByOption"
             [value]="option.value"
+            [disabled]="option.disabled"
             (click)="selectOption(option)"
           >
             {{ option.label }}
@@ -112,6 +114,7 @@ export class MaterialSearchableSelectComponent extends SimpleBaseSelectComponent
     const mappedOptions = source?.map((o: any) => ({
       label: o.label ?? o.text,
       value: o.value,
+      disabled: o.disabled,
     }));
 
     super.setSelectMetadata({

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
@@ -46,7 +46,6 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
           <mat-option
             *ngFor="let option of filteredOptions(); trackBy: trackByOption"
             [value]="option.value"
-            [disabled]="option.disabled"
             (click)="selectOption(option)"
           >
             {{ option.label }}
@@ -72,7 +71,6 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
           <mat-option
             *ngFor="let option of filteredOptions(); trackBy: trackByOption"
             [value]="option.value"
-            [disabled]="option.disabled"
             (click)="selectOption(option)"
           >
             {{ option.label }}
@@ -114,7 +112,6 @@ export class MaterialSearchableSelectComponent extends SimpleBaseSelectComponent
     const mappedOptions = source?.map((o: any) => ({
       label: o.label ?? o.text,
       value: o.value,
-      disabled: o.disabled,
     }));
 
     super.setSelectMetadata({
@@ -129,6 +126,16 @@ export class MaterialSearchableSelectComponent extends SimpleBaseSelectComponent
       optionLabelKey: metadata.optionLabelKey ?? metadata.displayField,
       optionValueKey: metadata.optionValueKey ?? metadata.valueField,
     });
+  }
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+    const disabled = this.metadata()?.disabled;
+    if (disabled) {
+      this.internalControl.disable({ emitEvent: false });
+    } else {
+      this.internalControl.enable({ emitEvent: false });
+    }
   }
 
   onOpened(opened: boolean): void {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
@@ -34,6 +34,7 @@ import {
         <mat-option
           *ngFor="let option of options(); trackBy: trackByOption"
           [value]="option.value"
+          [disabled]="option.disabled"
           (click)="selectOption(option)"
         >
           {{ option.label }}
@@ -73,6 +74,7 @@ export class MaterialSelectComponent extends SimpleBaseSelectComponent {
     const mappedOptions = source?.map((o: any) => ({
       label: o.label ?? o.text,
       value: o.value,
+      disabled: o.disabled,
     }));
 
     super.setSelectMetadata({

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
@@ -34,7 +34,6 @@ import {
         <mat-option
           *ngFor="let option of options(); trackBy: trackByOption"
           [value]="option.value"
-          [disabled]="option.disabled"
           (click)="selectOption(option)"
         >
           {{ option.label }}
@@ -74,7 +73,6 @@ export class MaterialSelectComponent extends SimpleBaseSelectComponent {
     const mappedOptions = source?.map((o: any) => ({
       label: o.label ?? o.text,
       value: o.value,
-      disabled: o.disabled,
     }));
 
     super.setSelectMetadata({
@@ -89,5 +87,15 @@ export class MaterialSelectComponent extends SimpleBaseSelectComponent {
       optionValueKey:
         matMetadata.optionValueKey ?? (matMetadata as any).valueField,
     });
+  }
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+    const disabled = this.metadata()?.disabled;
+    if (disabled) {
+      this.internalControl.disable({ emitEvent: false });
+    } else {
+      this.internalControl.enable({ emitEvent: false });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- remove `[disabled]` bindings from select templates
- toggle controls using `internalControl.disable/enable` based on metadata

## Testing
- `npx ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `npx ng test praxis-ui-workspace --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_6897d88ff554832898efb7764672b829