### PR TITLE
feat: parse UI annotation options

### DIFF
--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/extension/CustomOpenApiResolver.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/extension/CustomOpenApiResolver.java
@@ -895,6 +895,9 @@ public class CustomOpenApiResolver extends ModelResolver {
         if (!annotation.helpText().isEmpty()) {
             uiExtension.put(FieldConfigProperties.HELP_TEXT.getValue(), annotation.helpText());
         }
+        if (!annotation.options().isEmpty()) {
+            OpenApiUiUtils.populateUiOptionsFromString(uiExtension, annotation.options(), this._mapper);
+        }
         
         // Inteiros não zero
         if (annotation.order() != 0) {

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/uischema/dto/UiSchemaTestDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/uischema/dto/UiSchemaTestDTO.java
@@ -299,6 +299,15 @@ public class UiSchemaTestDTO {
     )
     private String city;
 
+    @UISchema(
+            label = "Tags",
+            controlType = FieldControlType.MULTI_SELECT,
+            options = "[\"alpha\",\"beta\"]",
+            order = 23,
+            group = "selection"
+    )
+    private List<String> tags;
+
     // Getters and setters
 
     public String getTextField() {
@@ -475,6 +484,14 @@ public class UiSchemaTestDTO {
 
     public void setCity(String city) {
         this.city = city;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
     }
 }
 

--- a/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/uischema/UiSchemaTestControllerTest.java
+++ b/examples/praxis-backend-libs-sample-app/src/test/java/com/example/praxis/uischema/UiSchemaTestControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -29,6 +30,22 @@ public class UiSchemaTestControllerTest {
                                 "Location",
                                 containsString(
                                         "document=" + ApiRouteDefinitions.UI_WRAPPERS_TEST_GROUP)));
+    }
+
+    @Test
+    public void optionsFromAnnotationAreExposed() throws Exception {
+        mockMvc
+                .perform(get("/schemas/filtered")
+                        .param("path", ApiRouteDefinitions.UI_WRAPPERS_TEST_PATH)
+                        .param("operation", "get")
+                        .param("schemaType", "response")
+                        .param("document", ApiRouteDefinitions.UI_WRAPPERS_TEST_GROUP))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties.status['x-ui'].options[0].label").value("Active"))
+                .andExpect(jsonPath("$.properties.roles['x-ui'].options[0].label").value("Admin"))
+                .andExpect(jsonPath("$.properties.agreement['x-ui'].options[0].label").value("Yes"))
+                .andExpect(jsonPath("$.properties.departments['x-ui'].options[0].label").value("Operations"))
+                .andExpect(jsonPath("$.properties.tags['x-ui'].options[0].label").value("alpha"));
     }
 }
 


### PR DESCRIPTION
## Summary
- parse `@UISchema.options` JSON strings and expose as `x-ui.options`
- support primitive arrays by converting them to label/value pairs
- expand sample DTO and tests to cover options parsing

## Testing
- `mvn -q test` *(backend-libs/praxis-metadata-core; fails: Non-resolvable parent POM)*
- `mvn -q test` *(examples/praxis-backend-libs-sample-app; fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68980b9e931c83289b6ef863a4441808