### PR TITLE
fix(praxis-dynamic-fields): prevent multi-select option toggle

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.spec.ts
@@ -7,6 +7,8 @@ import {
   API_URL,
 } from '@praxis/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatSelectHarness } from '@angular/material/select/testing';
 
 import { MaterialMultiSelectComponent } from './material-multi-select.component';
 
@@ -67,5 +69,14 @@ describe('MaterialMultiSelectComponent', () => {
     expect(component.internalControl.value).toEqual(['one', 'two']); // limited by maxSelections
     component.toggleSelectAll();
     expect(component.internalControl.value).toEqual([]);
+  });
+
+  it('should select option on click', async () => {
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    const select = await loader.getHarness(MatSelectHarness);
+    await select.open();
+    const options = await select.getOptions();
+    await options[0].click();
+    expect(component.internalControl.value).toEqual(['one']);
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
@@ -3,6 +3,7 @@ import { NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
+import { MatOptionSelectionChange } from '@angular/material/core';
 
 import { MaterialSelectMetadata, GenericCrudService } from '@praxis/core';
 import {
@@ -45,7 +46,7 @@ import {
           *ngFor="let option of options(); trackBy: trackByOption"
           [value]="option.value"
           [disabled]="isOptionDisabled(option)"
-          (click)="selectOption(option)"
+          (onSelectionChange)="onOptionSelectionChange(option, $event)"
         >
           {{ option.label }}
         </mat-option>
@@ -124,5 +125,15 @@ export class MaterialMultiSelectComponent extends SimpleBaseSelectComponent {
       : [];
     const isSelected = current.includes(option.value);
     return !isSelected && current.length >= this.maxSelections()!;
+  }
+
+  /** Emits optionSelected when a user picks an option */
+  onOptionSelectionChange(
+    option: SelectOption<any>,
+    event: MatOptionSelectionChange,
+  ): void {
+    if (event.isUserInput && event.source.selected) {
+      this.optionSelected.emit(option);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- stop double toggling by removing manual click handler from MaterialMultiSelectComponent
- emit optionSelected via onSelectionChange
- cover multi-select user interaction with a harness-based test

## Testing
- `ng test praxis-dynamic-fields` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6898a324e81c832883ee48fed707dddb