### PR TITLE
feat: use label over placeholder

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/CHANGELOG.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- placeholder só quando diferente do label; componentes sem suporte deixam de setar placeholder.

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-input.component.ts
@@ -24,6 +24,7 @@ import {
   computed,
   output,
   inject,
+  Input,
   OnInit,
   OnDestroy,
   AfterViewInit,
@@ -130,6 +131,18 @@ export abstract class SimpleBaseInputComponent
 
   /** ID único do componente */
   readonly componentId = signal<string>('');
+
+  /** Rótulo visível do campo */
+  @Input() label?: string;
+  /** Placeholder opcional */
+  @Input() placeholder?: string;
+
+  /** Indica se o placeholder deve ser exibido */
+  get shouldShowPlaceholder(): boolean {
+    const p = (this.placeholder ?? '').trim();
+    const l = (this.label ?? '').trim();
+    return !!p && p !== l;
+  }
 
   // =============================================================================
   // FORM CONTROL
@@ -469,6 +482,8 @@ export abstract class SimpleBaseInputComponent
    */
   protected setMetadata(metadata: ComponentMetadata): void {
     this.metadata.set(metadata);
+    this.label = (metadata as any).label;
+    this.placeholder = (metadata as any).placeholder;
     this.setDisabledState(!!metadata.disabled);
     // Reaplica validators quando metadata muda
     this.setupValidators();
@@ -494,8 +509,9 @@ export abstract class SimpleBaseInputComponent
 
     if (meta.name) this.nativeElement.setAttribute('name', meta.name);
     if (meta.id) this.nativeElement.id = meta.id;
-    if (meta.placeholder)
-      this.nativeElement.setAttribute('placeholder', meta.placeholder);
+    if (this.shouldShowPlaceholder && this.placeholder)
+      this.nativeElement.setAttribute('placeholder', this.placeholder);
+    else this.nativeElement.removeAttribute('placeholder');
     if (meta.readonly) this.nativeElement.setAttribute('readonly', '');
     if (meta.autocomplete)
       this.nativeElement.setAttribute('autocomplete', meta.autocomplete);

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.spec.ts
@@ -43,7 +43,6 @@ describe('SimpleBaseSelectComponent', () => {
       id: 'sel-id',
       name: 'sel',
       ariaLabel: 'Select field',
-      placeholder: 'Choose',
       required: true,
       multiple: true,
     });
@@ -61,7 +60,6 @@ describe('SimpleBaseSelectComponent', () => {
     const matSelect = (component as any).matSelect as any;
     const host: HTMLElement = fixture.nativeElement.querySelector('mat-select');
     expect(host.getAttribute('name')).toBe('sel');
-    expect(matSelect.placeholder).toBe('Choose');
     expect(matSelect.required).toBeTrue();
     expect(matSelect.multiple).toBeTrue();
   });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.ts
@@ -171,7 +171,9 @@ export abstract class SimpleBaseSelectComponent<
   }
 
   protected override setMetadata(metadata: ComponentMetadata): void {
-    super.setMetadata(metadata);
+    const { placeholder, ...rest } = metadata as any;
+    super.setMetadata(rest);
+    this.placeholder = undefined;
     this.applySelectAttributes();
   }
 
@@ -201,7 +203,6 @@ export abstract class SimpleBaseSelectComponent<
     if (meta.disableOptionCentering !== undefined)
       this.matSelect.disableOptionCentering = meta.disableOptionCentering;
     if (meta.tabIndex !== undefined) this.matSelect.tabIndex = meta.tabIndex;
-    if (meta.placeholder) this.matSelect.placeholder = meta.placeholder;
     if (meta.required !== undefined) this.matSelect.required = meta.required;
     if (meta.errorStateMatcher)
       this.matSelect.errorStateMatcher = meta.errorStateMatcher;

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/color-input/color-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/color-input/color-input.component.ts
@@ -29,7 +29,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Color' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -41,7 +41,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 
@@ -105,6 +105,7 @@ export class ColorInputComponent extends SimpleBaseInputComponent {
 
   /** Applies component metadata with strong typing. */
   setInputMetadata(metadata: MaterialColorInputMetadata): void {
-    this.setMetadata(metadata);
+    const { placeholder, ...rest } = metadata;
+    this.setMetadata(rest);
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/date-input/date-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/date-input/date-input.component.ts
@@ -30,7 +30,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Date' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -39,12 +39,13 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
         [min]="metadata()?.min || null"
         [max]="metadata()?.max || null"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/datetime-local-input/datetime-local-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/datetime-local-input/datetime-local-input.component.ts
@@ -28,7 +28,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Datetime' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -37,13 +37,14 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
         [min]="metadata()?.min || null"
         [max]="metadata()?.max || null"
         [step]="metadata()?.step || null"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/email-input/email-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/email-input/email-input.component.ts
@@ -30,7 +30,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Email' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -39,7 +39,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
@@ -47,7 +47,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
         [spellcheck]="metadata()?.spellcheck ?? false"
         [maxlength]="metadata()?.maxLength || null"
         [minlength]="metadata()?.minLength || null"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
@@ -24,12 +24,11 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Select' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
       @if (multiple()) {
         <mat-select
           multiple
           [formControl]="internalControl"
-          [placeholder]="metadata()?.placeholder || ''"
           [required]="metadata()?.required || false"
           (openedChange)="onOpened($event)"
         >
@@ -53,7 +52,6 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
       } @else {
         <mat-select
           [formControl]="internalControl"
-          [placeholder]="metadata()?.placeholder || ''"
           [required]="metadata()?.required || false"
           (openedChange)="onOpened($event)"
         >

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-checkbox-group/material-checkbox-group.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-checkbox-group/material-checkbox-group.component.ts
@@ -16,8 +16,8 @@ import {
   imports: [CommonModule, ReactiveFormsModule, MatCheckboxModule],
   template: `
     <div class="pdx-checkbox-group-wrapper">
-      @if (metadata()?.label) {
-        <label class="pdx-checkbox-label">{{ metadata()!.label }}</label>
+      @if (label) {
+        <label class="pdx-checkbox-label">{{ label }}</label>
       }
       @if (selectAll()) {
         <mat-checkbox

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-colorpicker/material-colorpicker.component.ts
@@ -25,7 +25,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Color' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       <span
         matPrefix
@@ -39,7 +39,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
         [formControl]="internalControl"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 
@@ -49,7 +49,11 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
         type="button"
         (click)="openPicker()"
         [disabled]="internalControl.disabled || metadata()?.readonly || false"
-        [attr.aria-label]="metadata()?.ariaLabel ? metadata()!.ariaLabel + ' color palette' : 'Open color palette'"
+        [attr.aria-label]="
+          metadata()?.ariaLabel
+            ? metadata()!.ariaLabel + ' color palette'
+            : 'Open color palette'
+        "
       >
         <mat-icon>palette</mat-icon>
       </button>
@@ -67,14 +71,14 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
           internalControl.invalid &&
           (internalControl.dirty || internalControl.touched)
         "
-        >
+      >
         {{ errorMessage() }}
       </mat-error>
 
       <mat-hint
         *ngIf="metadata()?.hint && !hasValidationError()"
         [align]="metadata()?.hintAlign || 'start'"
-        >
+      >
         {{ metadata()!.hint }}
       </mat-hint>
     </mat-form-field>
@@ -121,8 +125,9 @@ export class MaterialColorPickerComponent extends SimpleBaseInputComponent {
 
   /** Applies component metadata with strong typing. */
   setInputMetadata(metadata: MaterialColorPickerMetadata): void {
-    this.setMetadata(metadata);
-    if (metadata.disabled) {
+    const { placeholder, ...rest } = metadata;
+    this.setMetadata(rest);
+    if (rest.disabled) {
       this.internalControl.disable();
     } else {
       this.internalControl.enable();

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-currency/material-currency.component.ts
@@ -28,7 +28,6 @@ import { MatIconModule } from '@angular/material/icon';
 registerLocaleData(localePt);
 registerLocaleData(localePt, 'pt-BR');
 
-
 import { MaterialCurrencyMetadata } from '@praxis/core';
 import { SimpleBaseInputComponent } from '../../base/simple-base-input.component';
 
@@ -50,7 +49,7 @@ registerLocaleData(localePt, 'pt-BR');
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Amount' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -65,10 +64,10 @@ registerLocaleData(localePt, 'pt-BR');
         #currencyInput
         type="text"
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
         (input)="onInput($event)"
         (focus)="onFocus()"

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-date-range/material-date-range.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-date-range/material-date-range.component.ts
@@ -36,7 +36,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Date range' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -53,16 +53,36 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
         <input
           matStartDate
           formControlName="start"
-          [placeholder]="metadata()?.startPlaceholder || ''"
+          [placeholder]="
+            metadata()?.startPlaceholder &&
+            metadata()?.startPlaceholder.trim() !== (label ?? '').trim()
+              ? metadata()?.startPlaceholder
+              : null
+          "
           [readonly]="metadata()?.readonly || false"
-          [attr.aria-label]="metadata()?.startAriaLabel || metadata()?.label"
+          [attr.aria-label]="
+            metadata()?.startAriaLabel ||
+            (!label && metadata()?.startPlaceholder
+              ? metadata()?.startPlaceholder
+              : null)
+          "
         />
         <input
           matEndDate
           formControlName="end"
-          [placeholder]="metadata()?.endPlaceholder || ''"
+          [placeholder]="
+            metadata()?.endPlaceholder &&
+            metadata()?.endPlaceholder.trim() !== (label ?? '').trim()
+              ? metadata()?.endPlaceholder
+              : null
+          "
           [readonly]="metadata()?.readonly || false"
-          [attr.aria-label]="metadata()?.endAriaLabel || metadata()?.label"
+          [attr.aria-label]="
+            metadata()?.endAriaLabel ||
+            (!label && metadata()?.endPlaceholder
+              ? metadata()?.endPlaceholder
+              : null)
+          "
         />
       </mat-date-range-input>
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-datepicker/material-datepicker.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-datepicker/material-datepicker.component.ts
@@ -33,7 +33,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Date' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -44,12 +44,12 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
         [matDatepicker]="picker"
         [matDatepickerFilter]="metadata()?.dateFilter"
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [min]="minDate()"
         [max]="maxDate()"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
         (dateChange)="onDateChange($event)"
       />

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-file-upload/material-file-upload.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-file-upload/material-file-upload.component.ts
@@ -18,9 +18,7 @@ import { ComponentMetadata } from '@praxis/core';
   imports: [CommonModule, ReactiveFormsModule],
   template: `
     <div class="pdx-file-upload">
-      <label [attr.for]="componentId()">{{
-        metadata()?.label || 'Upload'
-      }}</label>
+      <label [attr.for]="componentId()">{{ label }}</label>
       <input
         [attr.id]="componentId()"
         type="file"
@@ -67,7 +65,8 @@ export class MaterialFileUploadComponent extends SimpleBaseInputComponent {
    * Exposes metadata setter for integration with dynamic form loader.
    */
   setFileUploadMetadata(metadata: ComponentMetadata): void {
-    this.setMetadata(metadata);
+    const { placeholder, ...rest } = metadata as any;
+    this.setMetadata(rest);
   }
 
   /**

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select-tree/material-multi-select-tree.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select-tree/material-multi-select-tree.component.ts
@@ -33,8 +33,8 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
   ],
   template: `
     <div class="pdx-multi-select-tree-wrapper">
-      @if (metadata()?.label) {
-        <label class="pdx-tree-label">{{ metadata()!.label }}</label>
+      @if (label) {
+        <label class="pdx-tree-label">{{ label }}</label>
       }
 
       @if (selectAll()) {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select/material-multi-select.component.ts
@@ -27,11 +27,10 @@ import {
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Select' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
       <mat-select
         multiple
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
         [required]="metadata()?.required || false"
       >
         @if (selectAll()) {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-price-range/material-price-range.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-price-range/material-price-range.component.ts
@@ -37,9 +37,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
   ],
   template: `
     <div class="price-range-container">
-      <label class="range-label">{{
-        metadata()?.label || 'Price range'
-      }}</label>
+      <label class="range-label">{{ label }}</label>
       <div class="range-inputs" [formGroup]="rangeGroup">
         <pdx-material-currency
           formControlName="minPrice"

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-radio-group/material-radio-group.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-radio-group/material-radio-group.component.ts
@@ -15,8 +15,8 @@ import {
   imports: [CommonModule, ReactiveFormsModule, MatRadioModule],
   template: `
     <div class="pdx-radio-group-wrapper">
-      @if (metadata()?.label) {
-        <label class="pdx-radio-label">{{ metadata()!.label }}</label>
+      @if (label) {
+        <label class="pdx-radio-label">{{ label }}</label>
       }
       <mat-radio-group
         [formControl]="internalControl"

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
@@ -24,12 +24,11 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Select' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
       @if (multiple()) {
         <mat-select
           multiple
           [formControl]="internalControl"
-          [placeholder]="metadata()?.placeholder || ''"
           [required]="metadata()?.required || false"
           (openedChange)="onOpened($event)"
         >
@@ -55,7 +54,6 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
       } @else {
         <mat-select
           [formControl]="internalControl"
-          [placeholder]="metadata()?.placeholder || ''"
           [required]="metadata()?.required || false"
           (openedChange)="onOpened($event)"
         >

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
@@ -23,12 +23,12 @@ import {
     <mat-form-field
       [appearance]="materialAppearance()"
       [color]="materialColor()"
+      floatLabel="auto"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Select' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
       <mat-select
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
         [required]="metadata()?.required || false"
       >
         <mat-option

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-textarea/material-textarea.component.html
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-textarea/material-textarea.component.html
@@ -1,33 +1,37 @@
 <!-- Container principal do textarea -->
 <div class="pdx-textarea-container">
-
   <!-- Form field principal -->
-  <mat-form-field 
+  <mat-form-field
     [appearance]="materialAppearance()"
     [color]="materialColor()"
     [floatLabel]="floatLabelBehavior()"
     [subscriptSizing]="metadata()?.materialDesign?.subscriptSizing || 'fixed'"
-    [hideRequiredMarker]="metadata()?.materialDesign?.hideRequiredMarker || false"
+    [hideRequiredMarker]="
+      metadata()?.materialDesign?.hideRequiredMarker || false
+    "
     [class]="textareaSpecificClasses()"
->
-
+  >
     <!-- Label estático -->
-    <mat-label 
+    <mat-label
       [matTooltip]="metadata()?.description || ''"
       [matTooltipDisabled]="!metadata()?.description"
-      matTooltipPosition="above">
-      {{ metadata()?.label }}
-      @if (metadata()?.required && !metadata()?.materialDesign?.hideRequiredMarker) {
+      matTooltipPosition="above"
+    >
+      {{ label }}
+      @if (
+        metadata()?.required && !metadata()?.materialDesign?.hideRequiredMarker
+      ) {
         <span class="pdx-required-marker" aria-label="required"> *</span>
       }
     </mat-label>
 
     <!-- Ícone de prefixo -->
     @if (metadata()?.prefixIcon) {
-      <mat-icon 
-        matPrefix 
+      <mat-icon
+        matPrefix
         [matTooltip]="'Icon: ' + metadata()?.prefixIcon"
-        matTooltipPosition="above">
+        matTooltipPosition="above"
+      >
         {{ metadata()?.prefixIcon }}
       </mat-icon>
     }
@@ -37,7 +41,7 @@
       #textareaElement
       matInput
       [formControl]="internalControl"
-      [placeholder]="metadata()?.placeholder || ''"
+      [placeholder]="shouldShowPlaceholder ? placeholder : null"
       [maxlength]="metadata()?.maxLength || null"
       [minlength]="metadata()?.minLength || null"
       [readonly]="metadata()?.readonly || metadata()?.readOnly || false"
@@ -49,59 +53,61 @@
       [cdkAutosizeMinRows]="metadata()?.minRows || 4"
       [cdkAutosizeMaxRows]="metadata()?.maxRows || 12"
       [style.resize]="metadata()?.resize || 'vertical'"
-      [attr.aria-describedby]="metadata()?.hint ? componentId() + '-hint' : null"
+      [attr.aria-describedby]="
+        metadata()?.hint ? componentId() + '-hint' : null
+      "
+      [attr.aria-label]="!label && placeholder ? placeholder : null"
       (input)="onTextareaInput($event)"
       (focus)="onTextareaFocus($event)"
       (blur)="onTextareaBlur($event)"
-      (keydown)="onTextareaKeyDown($event)">
+      (keydown)="onTextareaKeyDown($event)"
+    >
     </textarea>
-
 
     <!-- Ícone de sufixo customizado -->
     @if (metadata()?.suffixIcon) {
-      <mat-icon 
+      <mat-icon
         matSuffix
         [matTooltip]="'Icon: ' + metadata()?.suffixIcon"
-        matTooltipPosition="above">
+        matTooltipPosition="above"
+      >
         {{ metadata()?.suffixIcon }}
       </mat-icon>
     }
 
     <!-- Texto de ajuda -->
     @if (metadata()?.hint) {
-      <mat-hint 
-        [id]="componentId() + '-hint'"
-        align="start">
+      <mat-hint [id]="componentId() + '-hint'" align="start">
         {{ metadata()?.hint }}
       </mat-hint>
     }
 
     <!-- Contador de caracteres -->
     @if (shouldShowCharacterCount()) {
-      <mat-hint 
+      <mat-hint
         align="end"
         class="pdx-character-count"
-        [class.pdx-character-count-warning]="textareaState().characterCount > (metadata()?.maxLength! * 0.8)"
-        [class.pdx-character-count-error]="textareaState().characterCount >= metadata()?.maxLength!">
-        {{ textareaState().characterCount }}{{ metadata()?.maxLength ? '/' + metadata()?.maxLength : '' }}
+        [class.pdx-character-count-warning]="
+          textareaState().characterCount > metadata()?.maxLength! * 0.8
+        "
+        [class.pdx-character-count-error]="
+          textareaState().characterCount >= metadata()?.maxLength!
+        "
+      >
+        {{ textareaState().characterCount
+        }}{{ metadata()?.maxLength ? "/" + metadata()?.maxLength : "" }}
       </mat-hint>
     }
 
     <!-- Mensagens de erro -->
     @if (hasValidationError()) {
-      <mat-error 
-        [id]="componentId() + '-error'"
-        class="pdx-error-message">
+      <mat-error [id]="componentId() + '-error'" class="pdx-error-message">
         <mat-icon class="pdx-error-icon">error_outline</mat-icon>
         {{ errorMessage() }}
       </mat-error>
     }
-
   </mat-form-field>
-
 </div>
-
-
 
 <!-- Indicador de debug simplificado -->
 @if (metadata()?.security) {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-timepicker/material-timepicker.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-timepicker/material-timepicker.component.ts
@@ -34,7 +34,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Time' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -43,11 +43,12 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [matTimepicker]="picker"
         [step]="stepAttribute()"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 
@@ -101,7 +102,6 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
 export class MaterialTimepickerComponent extends SimpleBaseInputComponent {
   /** Emits whenever validation state changes. */
   readonly validationChange = output<ValidationErrors | null>();
-
 
   override ngOnInit(): void {
     const meta = this.metadata();
@@ -162,5 +162,4 @@ export class MaterialTimepickerComponent extends SimpleBaseInputComponent {
     }
     return null;
   }
-
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/month-input/month-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/month-input/month-input.component.ts
@@ -30,7 +30,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Month' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -39,12 +39,13 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
         [min]="metadata()?.min || null"
         [max]="metadata()?.max || null"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/number-input/number-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/number-input/number-input.component.ts
@@ -30,7 +30,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Number' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -39,14 +39,14 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
         [min]="metadata()?.min ?? null"
         [max]="metadata()?.max ?? null"
         [step]="metadata()?.step ?? null"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/password-input/password-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/password-input/password-input.component.ts
@@ -28,7 +28,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Password' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -37,12 +37,12 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
         [attr.autocomplete]="metadata()?.autocomplete || 'off'"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/phone-input/phone-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/phone-input/phone-input.component.ts
@@ -29,7 +29,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Phone' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -38,12 +38,12 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [autocomplete]="metadata()?.autocomplete || 'tel'"
         [type]="inputType()"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/search-input/search-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/search-input/search-input.component.ts
@@ -29,7 +29,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Search' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -38,13 +38,13 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [autocomplete]="metadata()?.autocomplete || 'off'"
         [spellcheck]="metadata()?.spellcheck ?? true"
         [type]="inputType()"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/text-input/text-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/text-input/text-input.component.ts
@@ -29,9 +29,10 @@ import {
     <mat-form-field
       [appearance]="materialAppearance()"
       [color]="materialColor()"
+      floatLabel="auto"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Text' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -40,7 +41,7 @@ import {
       <input
         matInput
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [type]="inputType()"
         [autocomplete]="metadata()?.autocomplete || 'off'"
@@ -48,7 +49,7 @@ import {
         [readonly]="metadata()?.readonly || false"
         [maxlength]="metadata()?.maxLength || null"
         [minlength]="metadata()?.minLength || null"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/time-input/time-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/time-input/time-input.component.ts
@@ -30,7 +30,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Time' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -39,13 +39,14 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
         [min]="metadata()?.min || null"
         [max]="metadata()?.max || null"
         [step]="metadata()?.step || null"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/url-input/url-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/url-input/url-input.component.ts
@@ -30,7 +30,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'URL' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -39,7 +39,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
-        [placeholder]="metadata()?.placeholder || ''"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
@@ -47,7 +47,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
         [spellcheck]="metadata()?.spellcheck ?? false"
         [maxlength]="metadata()?.maxLength || null"
         [minlength]="metadata()?.minLength || null"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/week-input/week-input.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/week-input/week-input.component.ts
@@ -30,7 +30,7 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       [color]="materialColor()"
       [class]="componentCssClasses()"
     >
-      <mat-label>{{ metadata()?.label || 'Week' }}</mat-label>
+      <mat-label>{{ label }}</mat-label>
 
       @if (metadata()?.prefixIcon) {
         <mat-icon matPrefix>{{ metadata()!.prefixIcon }}</mat-icon>
@@ -39,12 +39,13 @@ import { SimpleBaseInputComponent } from '../../base/simple-base-input.component
       <input
         matInput
         [formControl]="internalControl"
+        [placeholder]="shouldShowPlaceholder ? placeholder : null"
         [required]="metadata()?.required || false"
         [readonly]="metadata()?.readonly || false"
         [type]="inputType()"
         [min]="metadata()?.min || null"
         [max]="metadata()?.max || null"
-        [attr.aria-label]="metadata()?.ariaLabel || metadata()?.label"
+        [attr.aria-label]="!label && placeholder ? placeholder : null"
         [attr.aria-required]="metadata()?.required ? 'true' : 'false'"
       />
 


### PR DESCRIPTION
## Summary
- ensure selects ignore placeholder metadata
- apply conditional placeholder rendering to all dynamic field inputs
- rely on `mat-label` consistently across components
- strip placeholder metadata from non-placeholder inputs like color and file upload fields

## Testing
- `npx ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable to run)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898e7739e80832883adcebacd93bb11