### PR TITLE
feat: support dynamic select endpoint metadata

### DIFF
--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/extension/CustomOpenApiResolver.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/extension/CustomOpenApiResolver.java
@@ -895,6 +895,18 @@ public class CustomOpenApiResolver extends ModelResolver {
         if (!annotation.helpText().isEmpty()) {
             uiExtension.put(FieldConfigProperties.HELP_TEXT.getValue(), annotation.helpText());
         }
+        if (!annotation.valueField().isEmpty()) {
+            uiExtension.put(FieldConfigProperties.VALUE_FIELD.getValue(), annotation.valueField());
+        }
+        if (!annotation.displayField().isEmpty()) {
+            uiExtension.put(FieldConfigProperties.DISPLAY_FIELD.getValue(), annotation.displayField());
+        }
+        if (!annotation.endpoint().isEmpty()) {
+            uiExtension.put(FieldConfigProperties.ENDPOINT.getValue(), annotation.endpoint());
+        }
+        if (!annotation.emptyOptionText().isEmpty()) {
+            uiExtension.put(FieldConfigProperties.EMPTY_OPTION_TEXT.getValue(), annotation.emptyOptionText());
+        }
         if (!annotation.options().isEmpty()) {
             OpenApiUiUtils.populateUiOptionsFromString(uiExtension, annotation.options(), this._mapper);
         }
@@ -925,6 +937,9 @@ public class CustomOpenApiResolver extends ModelResolver {
         }
         if (!annotation.sortable()) { // padrão é true
             uiExtension.put(FieldConfigProperties.SORTABLE.getValue(), false);
+        }
+        if (annotation.multiple()) {
+            uiExtension.put(FieldConfigProperties.MULTIPLE.getValue(), true);
         }
         if (annotation.filterable()) { // padrão é false
             uiExtension.put(FieldConfigProperties.FILTERABLE.getValue(), true);

--- a/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/extension/EndpointPropertiesTest.java
+++ b/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/extension/EndpointPropertiesTest.java
@@ -1,0 +1,58 @@
+package org.praxisplatform.uischema.extension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.praxisplatform.uischema.FieldConfigProperties;
+import org.praxisplatform.uischema.FieldControlType;
+import org.praxisplatform.uischema.extension.annotation.UISchema;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EndpointPropertiesTest {
+
+    private CustomOpenApiResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new CustomOpenApiResolver(new ObjectMapper());
+    }
+
+    static class DummyDTO {
+        @UISchema(
+                controlType = FieldControlType.SELECT,
+                valueField = "id",
+                displayField = "nome",
+                endpoint = "/api/items",
+                emptyOptionText = "Select...",
+                multiple = true
+        )
+        private String item;
+    }
+
+    @Test
+    void includesEndpointAndMappingProperties() throws NoSuchFieldException {
+        Schema<?> schema = new Schema<>();
+        schema.setName("item");
+
+        Field field = DummyDTO.class.getDeclaredField("item");
+        resolver.applyBeanValidatorAnnotations(schema, field.getAnnotations(), null, true);
+
+        assertNotNull(schema.getExtensions());
+        assertTrue(schema.getExtensions().containsKey("x-ui"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> xUi = (Map<String, Object>) schema.getExtensions().get("x-ui");
+
+        assertEquals("/api/items", xUi.get(FieldConfigProperties.ENDPOINT.getValue()));
+        assertEquals("id", xUi.get(FieldConfigProperties.VALUE_FIELD.getValue()));
+        assertEquals("nome", xUi.get(FieldConfigProperties.DISPLAY_FIELD.getValue()));
+        assertEquals("Select...", xUi.get(FieldConfigProperties.EMPTY_OPTION_TEXT.getValue()));
+        assertEquals(true, xUi.get(FieldConfigProperties.MULTIPLE.getValue()));
+    }
+}
+

--- a/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/uischema/dto/UiSchemaTestDTO.java
+++ b/examples/praxis-backend-libs-sample-app/src/main/java/com/example/praxis/uischema/dto/UiSchemaTestDTO.java
@@ -1,6 +1,7 @@
 package com.example.praxis.uischema.dto;
 
 import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import com.example.praxis.common.config.ApiRouteDefinitions;
 import org.praxisplatform.uischema.FieldControlType;
 import org.praxisplatform.uischema.FieldDataType;
 import org.praxisplatform.uischema.NumericFormat;
@@ -219,15 +220,15 @@ public class UiSchemaTestDTO {
     private List<String> departments;
 
     @UISchema(
-            label = "Country",
+            label = "Department",
             controlType = FieldControlType.AUTO_COMPLETE,
-            endpoint = "/api/countries",
+            endpoint = ApiRouteDefinitions.HR_DEPARTAMENTOS_PATH,
             order = 16,
             group = "selection",
-            displayField = "name",
-            valueField = "code"
+            displayField = "nome",
+            valueField = "id"
     )
-    private String country;
+    private Long departmentId;
 
     @UISchema(
             label = "Favorite Color",
@@ -288,16 +289,18 @@ public class UiSchemaTestDTO {
     private String internalNotes;
 
     @UISchema(
-            label = "City",
+            label = "Job Position",
             controlType = FieldControlType.SELECT,
-            endpoint = "/api/cities",
+            endpoint = ApiRouteDefinitions.HR_CARGOS_PATH,
             order = 22,
             group = "selection",
             filter = "contains",
             filterOptions = "[{\"label\":\"Starts With\",\"value\":\"startsWith\"}]",
-            filterControlType = "input"
+            filterControlType = "input",
+            displayField = "nome",
+            valueField = "id"
     )
-    private String city;
+    private Long jobPositionId;
 
     @UISchema(
             label = "Tags",
@@ -430,12 +433,12 @@ public class UiSchemaTestDTO {
         this.departments = departments;
     }
 
-    public String getCountry() {
-        return country;
+    public Long getDepartmentId() {
+        return departmentId;
     }
 
-    public void setCountry(String country) {
-        this.country = country;
+    public void setDepartmentId(Long departmentId) {
+        this.departmentId = departmentId;
     }
 
     public String getFavoriteColor() {
@@ -478,12 +481,12 @@ public class UiSchemaTestDTO {
         this.internalNotes = internalNotes;
     }
 
-    public String getCity() {
-        return city;
+    public Long getJobPositionId() {
+        return jobPositionId;
     }
 
-    public void setCity(String city) {
-        this.city = city;
+    public void setJobPositionId(Long jobPositionId) {
+        this.jobPositionId = jobPositionId;
     }
 
     public List<String> getTags() {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
@@ -94,6 +94,7 @@ describe('FieldDefinition to FieldMetadata mapper', () => {
       selectAll: true,
       maxSelections: 5,
       filter: { active: true },
+      emptyOptionText: 'Select...',
       options: [{ key: '1', value: 'Open' }],
     } as any;
 
@@ -107,6 +108,7 @@ describe('FieldDefinition to FieldMetadata mapper', () => {
     expect(meta.optionLabelKey).toBe('name');
     expect(meta.optionValueKey).toBe('id');
     expect(meta.filterCriteria).toEqual({ active: true });
+    expect((meta as any).emptyOptionText).toBe('Select...');
     expect(meta.selectOptions?.[0]).toEqual({ value: '1', text: 'Open' });
   });
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/helpers/field-definition-mapper.ts
@@ -42,6 +42,7 @@ export function mapFieldDefinitionToMetadata(
     'searchable',
     'selectAll',
     'maxSelections',
+    'emptyOptionText',
   ];
 
   for (const prop of simpleProps) {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/material-field-metadata.interface.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/material-field-metadata.interface.ts
@@ -748,6 +748,9 @@ export interface MaterialSelectMetadata extends FieldMetadata {
     group?: string;
   }>;
 
+  /** Placeholder option text for empty selection */
+  emptyOptionText?: string;
+
   /** Enable multiple selection */
   multiple?: boolean;
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/schema-normalizer.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/schema-normalizer.service.spec.ts
@@ -1,0 +1,33 @@
+import { SchemaNormalizerService } from './schema-normalizer.service';
+
+describe('SchemaNormalizerService', () => {
+  let service: SchemaNormalizerService;
+
+  beforeEach(() => {
+    service = new SchemaNormalizerService();
+  });
+
+  it('should map UI select properties from schema', () => {
+    const schema = {
+      properties: {
+        dept: {
+          type: 'string',
+          'x-ui': {
+            endpoint: '/api/dept',
+            valueField: 'id',
+            displayField: 'name',
+            multiple: true,
+            emptyOptionText: 'None',
+          },
+        },
+      },
+    };
+
+    const [field] = service.normalizeSchema(schema);
+    expect(field.endpoint).toBe('/api/dept');
+    expect(field.valueField).toBe('id');
+    expect(field.displayField).toBe('name');
+    expect(field.multiple).toBeTrue();
+    expect(field.emptyOptionText).toBe('None');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/schema-normalizer.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/schema-normalizer.service.ts
@@ -3,7 +3,6 @@ import { FieldDefinition } from '../models/field-definition.model';
 
 @Injectable({ providedIn: 'root' })
 export class SchemaNormalizerService {
-
   /** Convert value to boolean. Accepts boolean, string or number. */
   private parseBoolean(value: any): boolean {
     if (typeof value === 'boolean') {
@@ -83,7 +82,7 @@ export class SchemaNormalizerService {
       'maxFileSize',
       'customValidator',
       'asyncValidator',
-      'minWords'
+      'minWords',
     ];
 
     for (const p of props) {
@@ -127,7 +126,10 @@ export class SchemaNormalizerService {
     for (const [name, prop] of Object.entries(properties)) {
       const field: FieldDefinition = { name };
 
-      const ui = prop && typeof prop === 'object' && typeof prop['x-ui'] === 'object' ? prop['x-ui'] : {};
+      const ui =
+        prop && typeof prop === 'object' && typeof prop['x-ui'] === 'object'
+          ? prop['x-ui']
+          : {};
 
       // -------------------------------------------------------------------
       // Basic information
@@ -166,15 +168,21 @@ export class SchemaNormalizerService {
       Object.assign(field, this.parseValidators(ui));
 
       // Inline conditional functions
-      const condDisplay = this.parseFunction(ui.conditionalDisplay) as (() => boolean) | undefined;
+      const condDisplay = this.parseFunction(ui.conditionalDisplay) as
+        | (() => boolean)
+        | undefined;
       if (condDisplay) {
         field.conditionalDisplay = condDisplay;
       }
-      const condRequired = this.parseFunction(ui.conditionalRequired) as (() => boolean) | undefined;
+      const condRequired = this.parseFunction(ui.conditionalRequired) as
+        | (() => boolean)
+        | undefined;
       if (condRequired) {
         field.conditionalRequired = condRequired;
       }
-      const transformFn = this.parseFunction(ui.transformValueFunction) as ((val: any) => any) | undefined;
+      const transformFn = this.parseFunction(ui.transformValueFunction) as
+        | ((val: any) => any)
+        | undefined;
       if (transformFn) {
         field.transformValueFunction = transformFn;
       }
@@ -216,11 +224,25 @@ export class SchemaNormalizerService {
       if (ui.endpoint !== undefined) {
         field.endpoint = ui.endpoint;
       }
+      if (ui.valueField !== undefined) {
+        field.valueField = ui.valueField;
+      }
+      if (ui.displayField !== undefined) {
+        field.displayField = ui.displayField;
+      }
+      if (ui.multiple !== undefined) {
+        field.multiple = this.parseBoolean(ui.multiple);
+      }
+      if (ui.emptyOptionText !== undefined) {
+        field.emptyOptionText = ui.emptyOptionText;
+      }
       if (ui.dependentField !== undefined) {
         field.dependentField = ui.dependentField;
       }
       if (ui.resetOnDependentChange !== undefined) {
-        field.resetOnDependentChange = this.parseBoolean(ui.resetOnDependentChange);
+        field.resetOnDependentChange = this.parseBoolean(
+          ui.resetOnDependentChange,
+        );
       }
 
       if (ui.buttons !== undefined) {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.spec.ts
@@ -72,4 +72,16 @@ describe('SimpleBaseSelectComponent', () => {
     (component as any).matSelect.openedChange.emit(true);
     expect(spy).toHaveBeenCalledWith(true);
   });
+
+  it('should expose empty option text from metadata', () => {
+    component.apply({ name: 'test', emptyOptionText: 'None' });
+    fixture.detectChanges();
+    expect(component.emptyOptionText()).toBe('None');
+  });
+
+  it('should ignore empty option text when multiple is true', () => {
+    component.apply({ name: 'multi', emptyOptionText: 'None', multiple: true });
+    fixture.detectChanges();
+    expect(component.emptyOptionText()).toBeNull();
+  });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/simple-base-select.component.ts
@@ -49,6 +49,8 @@ export interface SimpleSelectMetadata<T = any> extends ComponentMetadata {
   optionLabelKey?: string;
   /** Key for option value when loading from backend */
   optionValueKey?: string;
+  /** Placeholder option text when no value is selected */
+  emptyOptionText?: string;
 }
 
 /**
@@ -91,6 +93,8 @@ export abstract class SimpleBaseSelectComponent<
   readonly optionLabelKey = signal<string>('label');
   /** Field used for option values when loading from backend */
   readonly optionValueKey = signal<string>('value');
+  /** Text displayed for an empty option */
+  readonly emptyOptionText = signal<string | null>(null);
   /** Current page index when fetching remote options */
   readonly pageIndex = signal(0);
   /** Number of options retrieved per request */
@@ -144,10 +148,14 @@ export abstract class SimpleBaseSelectComponent<
     if (metadata.options) {
       this.options.set(metadata.options);
     }
-    this.multiple.set(!!metadata.multiple);
+    const isMultiple = !!metadata.multiple;
+    this.multiple.set(isMultiple);
     this.searchable.set(!!metadata.searchable);
     this.selectAll.set(!!metadata.selectAll);
     this.maxSelections.set(metadata.maxSelections ?? null);
+    this.emptyOptionText.set(
+      isMultiple ? null : (metadata.emptyOptionText ?? null),
+    );
 
     const path = metadata.resourcePath || metadata.endpoint;
     if (path) {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { MaterialAsyncSelectComponent } from './material-async-select.component';
 import { GenericCrudService, API_URL, Page } from '@praxis/core';
 import { of, throwError } from 'rxjs';
@@ -76,5 +77,27 @@ describe('MaterialAsyncSelectComponent', () => {
     component.retry();
     expect(crudService.filter).toHaveBeenCalledTimes(2);
     expect(component.options()).toEqual([{ label: 'One', value: '1' }]);
+  });
+
+  it('should render empty option text when provided', () => {
+    component.setSelectMetadata({
+      selectOptions: [{ label: 'One', value: '1' }],
+      emptyOptionText: 'None',
+    } as any);
+    fixture.detectChanges();
+    const option = fixture.debugElement.query(By.css('mat-option'));
+    expect(option.nativeElement.textContent.trim()).toBe('None');
+  });
+
+  it('should not render empty option when multiple is true', () => {
+    component.setSelectMetadata({
+      selectOptions: [{ label: 'One', value: '1' }],
+      emptyOptionText: 'None',
+      multiple: true,
+    } as any);
+    fixture.detectChanges();
+    const options = fixture.debugElement.queryAll(By.css('mat-option'));
+    expect(options.length).toBe(1);
+    expect(options[0].nativeElement.textContent.trim()).toBe('One');
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-async-select/material-async-select.component.ts
@@ -65,6 +65,13 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
               {{ error() }} - Retry
             </mat-option>
             <mat-option
+              *ngIf="emptyOptionText()"
+              [value]="null"
+              (click)="selectOption({ label: emptyOptionText()!, value: null })"
+            >
+              {{ emptyOptionText() }}
+            </mat-option>
+            <mat-option
               *ngFor="let option of options(); trackBy: trackByOption"
               [value]="option.value"
               [disabled]="option.disabled"

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { MaterialSearchableSelectComponent } from './material-searchable-select.component';
 import { GenericCrudService, API_URL, Page } from '@praxis/core';
 import { of } from 'rxjs';
@@ -75,5 +76,15 @@ describe('MaterialSearchableSelectComponent', () => {
       { name: 'On' },
       { pageNumber: 0, pageSize: 50 },
     );
+  });
+
+  it('renders empty option when emptyOptionText is provided', () => {
+    component.setSelectMetadata({
+      selectOptions: [{ label: 'Apple', value: 'a' }],
+      emptyOptionText: 'None',
+    } as any);
+    fixture.detectChanges();
+    const option = fixture.debugElement.query(By.css('mat-option'));
+    expect(option.nativeElement.textContent.trim()).toBe('None');
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-searchable-select/material-searchable-select.component.ts
@@ -70,6 +70,13 @@ import { SimpleBaseSelectComponent } from '../../base/simple-base-select.compone
             />
           </mat-option>
           <mat-option
+            *ngIf="emptyOptionText()"
+            [value]="null"
+            (click)="selectOption({ label: emptyOptionText()!, value: null })"
+          >
+            {{ emptyOptionText() }}
+          </mat-option>
+          <mat-option
             *ngFor="let option of filteredOptions(); trackBy: trackByOption"
             [value]="option.value"
             [disabled]="option.disabled"

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.spec.ts
@@ -79,4 +79,20 @@ describe('MaterialSelectComponent', () => {
     expect(matSelect.required).toBeTrue();
     expect(matSelect.disabled).toBeTrue();
   });
+
+  it('should render an empty option when emptyOptionText is provided', () => {
+    const meta: MaterialSelectMetadata = {
+      controlType: FieldControlType.SELECT,
+      name: 'status',
+      label: 'Status',
+      emptyOptionText: 'None',
+      selectOptions: [{ label: 'A', text: 'A', value: 'a' }],
+    } as any;
+    component.setSelectMetadata(meta as any);
+    fixture.detectChanges();
+    const options = fixture.debugElement.queryAll(By.css('mat-option'));
+    expect(options[0].nativeElement.textContent.trim()).toBe('None');
+    options[0].triggerEventHandler('click', {});
+    expect(component.internalControl.value).toBeNull();
+  });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-select/material-select.component.ts
@@ -32,6 +32,13 @@ import {
         [required]="metadata()?.required || false"
       >
         <mat-option
+          *ngIf="emptyOptionText()"
+          [value]="null"
+          (click)="selectOption({ label: emptyOptionText()!, value: null })"
+        >
+          {{ emptyOptionText() }}
+        </mat-option>
+        <mat-option
           *ngFor="let option of options(); trackBy: trackByOption"
           [value]="option.value"
           [disabled]="option.disabled"


### PR DESCRIPTION
## Summary
- parse endpoint mapping properties in SchemaNormalizerService and FieldDefinitionMapper
- render configurable empty option in Material select components
- ignore empty option when multi-select is enabled and cover with unit tests

## Testing
- `npm run test -- praxis-core --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform. Please set CHROME_BIN env variable.)*
- `npm run test -- praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform. Please set CHROME_BIN env variable.)*

------
https://chatgpt.com/codex/tasks/task_e_6898f7b8f074832881fca38da2ff3f9d