### PR TITLE
feat(core): add overlay decider service

### DIFF
--- a/frontend-libs/praxis-ui-workspace/README.md
+++ b/frontend-libs/praxis-ui-workspace/README.md
@@ -9,23 +9,27 @@ O Praxis UI Workspace é um monorepo Angular que contém uma coleção de biblio
 ## 📦 Bibliotecas Incluídas
 
 ### 🎯 Praxis Core (`@praxis/core`)
+
 **Biblioteca central com interfaces e serviços fundamentais**
 
 - ✅ **TableConfig Unificado**: Interface moderna e type-safe para configuração de tabelas
 - ✅ **Modelos de Dados**: Definições robustas para paginação, filtros e configurações
 - ✅ **Serviços Base**: TableConfigService e utilitários essenciais
 - ✅ **Type Guards**: Validação e verificação de tipos em runtime
+- ✅ **OverlayDeciderService**: Seleção automática de modal, drawer ou página
 
 ### 🗃️ Praxis Table (`@praxis/table`)
+
 **Componente de tabela avançado com recursos empresariais**
 
-- ✅ **Arquitetura Unificada**: Eliminação da dualidade V1/V2 
+- ✅ **Arquitetura Unificada**: Eliminação da dualidade V1/V2
 - ✅ **PraxisTable**: Componente principal otimizado e simplificado
 - ✅ **Editores Especializados**: Configuration editors para diferentes aspectos
 - ✅ **Performance**: Virtualização e lazy loading integrados
 - ✅ **Acessibilidade**: Suporte completo a screen readers e navegação por teclado
 
 ### 🎨 Praxis Visual Builder (`@praxis/visual-builder`)
+
 **Ferramentas visuais para criação de regras e especificações**
 
 - ✅ **Rule Builder**: Interface visual para criação de regras de negócio
@@ -34,6 +38,7 @@ O Praxis UI Workspace é um monorepo Angular que contém uma coleção de biblio
 - ✅ **Export Integration**: Integração com sistemas externos
 
 ### 📋 Praxis Specification (`@praxis/specification`)
+
 **Sistema de especificações e validações**
 
 - ✅ **Field Specifications**: Definições avançadas de campos
@@ -46,7 +51,7 @@ O Praxis UI Workspace é um monorepo Angular que contém uma coleção de biblio
 ### ⚡ Principais Melhorias
 
 1. **Eliminação da Dualidade V1/V2**
-   - Interface única `TableConfig` 
+   - Interface única `TableConfig`
    - Remoção de código legacy
    - Simplificação dramática da API
 
@@ -68,12 +73,14 @@ O Praxis UI Workspace é um monorepo Angular que contém uma coleção de biblio
 ## 🛠️ Instalação e Configuração
 
 ### Pré-requisitos
+
 ```bash
 Node.js >= 18.0.0
 Angular CLI >= 18.0.0
 ```
 
 ### Instalação
+
 ```bash
 # Clone o repositório
 git clone <repository-url>
@@ -89,7 +96,22 @@ npm run build
 ng serve
 ```
 
+## 🧭 Matriz de Decisão de Overlays
+
+O `OverlayDeciderService` do `@praxis/core` seleciona automaticamente o padrão de overlay (`modal`, `drawer`, `page`, `bottom-sheet` ou `full-screen-dialog`) com base no dispositivo, número de campos e dependências do formulário.
+
+```ts
+import { OverlayDeciderService } from "@praxis/core";
+
+const decider = inject(OverlayDeciderService);
+const decision = decider.decide({ device: "desktop", fieldCount: 18, dependencyCount: 5 });
+// => { pattern: 'drawer', config: { side: 'end', width: 'min(45vw, 920px)', modal: true, footerFixed: true }, reason: 'Formulário médio...' }
+```
+
+É possível sobrescrever a matriz padrão usando `provideOverlayDecisionMatrix` na configuração da aplicação.
+
 ### Usar em seu projeto
+
 ```bash
 npm install @praxis/core @praxis/table @praxis/visual-builder @praxis/specification
 ```
@@ -97,41 +119,38 @@ npm install @praxis/core @praxis/table @praxis/visual-builder @praxis/specificat
 ## 📝 Uso Básico
 
 ### Configuração Simples de Tabela
+
 ```typescript
-import { TableConfig } from '@praxis/core';
-import { PraxisTable } from '@praxis/table';
+import { TableConfig } from "@praxis/core";
+import { PraxisTable } from "@praxis/table";
 
 @Component({
-  selector: 'app-example',
-  template: `
-    <praxis-table 
-      [config]="tableConfig"
-      [data]="tableData">
-    </praxis-table>
-  `
+  selector: "app-example",
+  template: ` <praxis-table [config]="tableConfig" [data]="tableData"> </praxis-table> `,
 })
 export class ExampleComponent {
   tableConfig: TableConfig = {
     columns: [
-      { field: 'id', header: 'ID', type: 'number' },
-      { field: 'name', header: 'Nome', type: 'string' },
-      { field: 'email', header: 'Email', type: 'string' }
+      { field: "id", header: "ID", type: "number" },
+      { field: "name", header: "Nome", type: "string" },
+      { field: "email", header: "Email", type: "string" },
     ],
     behavior: {
       pagination: { enabled: true, pageSize: 10 },
       sorting: { enabled: true, multiSort: false },
-      filtering: { enabled: true }
-    }
+      filtering: { enabled: true },
+    },
   };
 
   tableData = [
-    { id: 1, name: 'João', email: 'joao@example.com' },
-    { id: 2, name: 'Maria', email: 'maria@example.com' }
+    { id: 1, name: "João", email: "joao@example.com" },
+    { id: 2, name: "Maria", email: "maria@example.com" },
   ];
 }
 ```
 
 ### Editor Visual de Configuração
+
 ```typescript
 import { PraxisTableConfigEditor } from '@praxis/table';
 
@@ -176,13 +195,13 @@ O ecossistema Praxis é projetado para uma integração transparente entre o fro
 
     ```typescript
     // Exemplo de uso no frontend
-    import { GenericCrudService } from '@praxis/core';
+    import { GenericCrudService } from "@praxis/core";
 
-    @Injectable({ providedIn: 'root' })
+    @Injectable({ providedIn: "root" })
     export class CargoService extends GenericCrudService<Cargo> {
       constructor(http: HttpClient, schemaNormalizer: SchemaNormalizerService, apiUrl: ApiUrlConfig) {
         super(http, schemaNormalizer, apiUrl);
-        this.configure('human-resources/cargos'); // Configura o endpoint base
+        this.configure("human-resources/cargos"); // Configura o endpoint base
       }
     }
     ```
@@ -191,12 +210,11 @@ O ecossistema Praxis é projetado para uma integração transparente entre o fro
 
     ```typescript
     // Componente que usa o serviço para obter o schema
-    this.cargoService.getFilteredSchema({ path: '/api/human-resources/cargos' })
-      .subscribe(fieldDefinitions => {
-        // As fieldDefinitions são usadas para construir a configuração da tabela
-        const tableConfig = this.buildTableConfig(fieldDefinitions);
-        this.tableConfig = tableConfig;
-      });
+    this.cargoService.getFilteredSchema({ path: "/api/human-resources/cargos" }).subscribe((fieldDefinitions) => {
+      // As fieldDefinitions são usadas para construir a configuração da tabela
+      const tableConfig = this.buildTableConfig(fieldDefinitions);
+      this.tableConfig = tableConfig;
+    });
     ```
 
 ### Aplicação de Exemplo
@@ -206,11 +224,13 @@ O projeto `praxis-backend-libs-sample-app` no repositório serve como uma implem
 ## 🧪 Testes
 
 ### Executar todos os testes
+
 ```bash
 npm test
 ```
 
 ### Testes por biblioteca
+
 ```bash
 # Core
 ng test praxis-core
@@ -226,6 +246,7 @@ ng test praxis-specification
 ```
 
 ### Coverage
+
 ```bash
 npm run test:coverage
 ```
@@ -233,6 +254,7 @@ npm run test:coverage
 ## 🏗️ Build e Deploy
 
 ### Build de produção
+
 ```bash
 # Build de todas as bibliotecas
 npm run build
@@ -242,12 +264,13 @@ ng build --configuration=production
 ```
 
 ### Publicação (NPM)
+
 ```bash
 # Build e publish de uma biblioteca específica
 cd dist/praxis-core
 npm publish
 
-cd ../praxis-table  
+cd ../praxis-table
 npm publish
 
 cd ../praxis-visual-builder
@@ -260,6 +283,7 @@ npm publish
 ## 🔧 Desenvolvimento
 
 ### Adicionando uma nova funcionalidade
+
 1. Escolha a biblioteca apropriada
 2. Crie componente/serviço na pasta correspondente
 3. Adicione testes
@@ -267,6 +291,7 @@ npm publish
 5. Documente as mudanças
 
 ### Estrutura do Projeto
+
 ```
 praxis-ui-workspace/
 ├── projects/
@@ -311,7 +336,6 @@ diversas. Durante a submissão, eventos `FormSubmitEvent` são emitidos indicand
 o resultado das operações de criação ou atualização, cabendo à aplicação exibir
 as mensagens de sucesso ou erro ao usuário.
 
-
 ### Exemplo de Visualização de Registro
 
 No módulo de **Funcionários** existe uma rota de exemplo que abre um formulário
@@ -320,10 +344,7 @@ componente `FuncionariosListComponent` emite o evento `rowClick` para navegar at
 `/funcionarios/view/:id`:
 
 ```html
-<praxis-table
-  resourcePath="funcionarios"
-  [editModeEnabled]="true"
-  (rowClick)="onRowClick($event)"></praxis-table>
+<praxis-table resourcePath="funcionarios" [editModeEnabled]="true" (rowClick)="onRowClick($event)"></praxis-table>
 ```
 
 ```typescript
@@ -340,30 +361,24 @@ selecionado:
 
 ```typescript
 export const routes: Routes = [
-  { path: 'funcionarios', component: FuncionariosListComponent },
-  { path: 'funcionarios/view/:id', component: FuncionarioViewComponent },
+  { path: "funcionarios", component: FuncionariosListComponent },
+  { path: "funcionarios/view/:id", component: FuncionarioViewComponent },
   // ...demais rotas
 ];
 ```
 
 ```typescript
 @Component({
-  selector: 'app-funcionario-view',
+  selector: "app-funcionario-view",
   standalone: true,
   imports: [CommonModule, MatCardModule, MatIconModule, PraxisDynamicForm],
-  template: `
-    <praxis-dynamic-form
-      resourcePath="funcionarios"
-      [resourceId]="id"
-      mode="view">
-    </praxis-dynamic-form>
-  `,
-  styleUrl: './funcionario-view.component.scss'
+  template: ` <praxis-dynamic-form resourcePath="funcionarios" [resourceId]="id" mode="view"> </praxis-dynamic-form> `,
+  styleUrl: "./funcionario-view.component.scss",
 })
 export class FuncionarioViewComponent {
   id: string | null = null;
   constructor(private route: ActivatedRoute) {
-    this.route.paramMap.subscribe(p => (this.id = p.get('id')));
+    this.route.paramMap.subscribe((p) => (this.id = p.get("id")));
   }
 }
 ```
@@ -374,11 +389,13 @@ entidade e pode servir de base para cenários de edição ou criação.
 ## 📚 Documentação
 
 ### Guias Detalhados
+
 - [**Architecture Unification**](./ARCHITECTURE-UNIFICATION.md) - Detalhes da unificação V1/V2
 - [**Integration Plan**](./INTEGRATION-PLAN.md) - Plano de integração
 - [**Integration Example**](./INTEGRATION-EXAMPLE.md) - Exemplos práticos
 
 ### API Reference
+
 - [Praxis Core API](./projects/praxis-core/README.md)
 - [Praxis Table API](./projects/praxis-table/README.md)
 - [Visual Builder API](./projects/praxis-visual-builder/README.md)
@@ -387,6 +404,7 @@ entidade e pode servir de base para cenários de edição ou criação.
 ## 🤝 Contribuição
 
 ### Como Contribuir
+
 1. Fork o projeto
 2. Crie uma branch para sua feature (`git checkout -b feature/nova-funcionalidade`)
 3. Commit suas mudanças (`git commit -m 'Add: nova funcionalidade'`)
@@ -394,6 +412,7 @@ entidade e pode servir de base para cenários de edição ou criação.
 5. Abra um Pull Request
 
 ### Guidelines
+
 - Seguir convenções de código Angular
 - Adicionar testes para novas funcionalidades
 - Manter documentação atualizada
@@ -402,6 +421,7 @@ entidade e pode servir de base para cenários de edição ou criação.
 ## 📊 Status do Projeto
 
 ### ✅ Funcionalidades Implementadas
+
 - Arquitetura unificada TableConfig
 - Componente PraxisTable otimizado
 - Editores de configuração especializados
@@ -410,12 +430,14 @@ entidade e pode servir de base para cenários de edição ou criação.
 - Documentação abrangente
 
 ### 🔄 Em Desenvolvimento
+
 - Enhanced accessibility features
 - Performance optimizations
 - Advanced export options
 - Mobile responsiveness improvements
 
 ### 📋 Roadmap
+
 - Plugin architecture
 - Theme customization
 - Advanced filtering
@@ -424,11 +446,13 @@ entidade e pode servir de base para cenários de edição ou criação.
 ## 🛡️ Compatibilidade
 
 ### Versões Suportadas
+
 - **Angular**: 18.x+
 - **TypeScript**: 5.0+
 - **Node.js**: 18.x+
 
 ### Navegadores
+
 - Chrome 90+
 - Firefox 88+
 - Safari 14+
@@ -441,6 +465,7 @@ Este projeto está licenciado sob a [MIT License](LICENSE).
 ## 🙋‍♂️ Suporte
 
 ### Como Obter Ajuda
+
 - 📖 Consulte a [documentação](./docs/)
 - 🐛 Reporte bugs via [Issues](../../issues)
 - 💬 Discussões via [Discussions](../../discussions)

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/overlay-decision.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/overlay-decision.model.ts
@@ -1,0 +1,61 @@
+export type DeviceKind = 'mobile' | 'tablet' | 'desktop';
+export type OverlayPattern =
+  | 'modal'
+  | 'drawer'
+  | 'page'
+  | 'bottom-sheet'
+  | 'full-screen-dialog';
+
+export interface OverlayDecisionContext {
+  device: DeviceKind;
+  fieldCount: number;
+  dependencyCount: number;
+}
+
+export interface OverlayDecision {
+  pattern: OverlayPattern;
+  config?: Record<string, unknown>;
+  reason?: string;
+}
+
+export interface OverlayRange {
+  min?: number;
+  max?: number;
+}
+
+export interface OverlayRuleMatch {
+  device?: DeviceKind[];
+  fieldCount?: OverlayRange;
+  dependencyCount?: OverlayRange;
+  any?: OverlayRuleMatch[];
+}
+
+export interface OverlayRule {
+  match: OverlayRuleMatch;
+  use: OverlayDecision;
+}
+
+export interface OverlayThresholds {
+  fieldCount: {
+    small_max: number;
+    medium_max: number;
+  };
+  dependencyCount: {
+    low_max: number;
+    medium_max: number;
+  };
+}
+
+export interface OverlayDecisionMatrix {
+  version: string;
+  description?: string;
+  thresholds: OverlayThresholds;
+  rules_ordered: OverlayRule[];
+  fallback: OverlayDecision;
+  ui_hints?: Record<string, unknown>;
+}
+
+export interface OverlayDecider {
+  decide(ctx: OverlayDecisionContext): OverlayDecision;
+  explain?(ctx: OverlayDecisionContext): string;
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/overlay-decider.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/overlay-decider.service.spec.ts
@@ -1,0 +1,107 @@
+import { TestBed } from '@angular/core/testing';
+import { OverlayDeciderService } from './overlay-decider.service';
+import { OVERLAY_DECISION_MATRIX } from '../tokens/overlay-decision-matrix.token';
+import matrix from '../config/overlay-decision-matrix.json';
+import { OverlayDecisionContext } from '../models/overlay-decision.model';
+
+describe('OverlayDeciderService', () => {
+  let service: OverlayDeciderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OverlayDeciderService,
+        { provide: OVERLAY_DECISION_MATRIX, useValue: matrix },
+      ],
+    });
+    service = TestBed.inject(OverlayDeciderService);
+  });
+
+  const decide = (ctx: OverlayDecisionContext) => service.decide(ctx).pattern;
+
+  it('should respect field count boundaries', () => {
+    expect(
+      decide({ device: 'mobile', fieldCount: 12, dependencyCount: 0 }),
+    ).toBe('full-screen-dialog');
+    expect(
+      decide({ device: 'mobile', fieldCount: 13, dependencyCount: 0 }),
+    ).toBe('page');
+    expect(
+      decide({ device: 'tablet', fieldCount: 12, dependencyCount: 0 }),
+    ).toBe('modal');
+    expect(
+      decide({ device: 'tablet', fieldCount: 13, dependencyCount: 0 }),
+    ).toBe('drawer');
+    expect(
+      decide({ device: 'desktop', fieldCount: 12, dependencyCount: 0 }),
+    ).toBe('modal');
+    expect(
+      decide({ device: 'desktop', fieldCount: 13, dependencyCount: 0 }),
+    ).toBe('drawer');
+  });
+
+  it('should respect large field count boundaries', () => {
+    expect(
+      decide({ device: 'tablet', fieldCount: 24, dependencyCount: 0 }),
+    ).toBe('drawer');
+    expect(
+      decide({ device: 'tablet', fieldCount: 25, dependencyCount: 0 }),
+    ).toBe('page');
+    expect(
+      decide({ device: 'desktop', fieldCount: 24, dependencyCount: 0 }),
+    ).toBe('drawer');
+    expect(
+      decide({ device: 'desktop', fieldCount: 25, dependencyCount: 0 }),
+    ).toBe('page');
+  });
+
+  it('should respect dependency count boundaries', () => {
+    expect(
+      decide({ device: 'mobile', fieldCount: 5, dependencyCount: 3 }),
+    ).toBe('full-screen-dialog');
+    expect(
+      decide({ device: 'mobile', fieldCount: 5, dependencyCount: 4 }),
+    ).toBe('modal');
+    expect(
+      service.decide({ device: 'tablet', fieldCount: 10, dependencyCount: 3 })
+        .reason,
+    ).toContain('Tablet');
+    expect(
+      service.decide({ device: 'tablet', fieldCount: 10, dependencyCount: 4 })
+        .reason,
+    ).toContain('Padrão seguro');
+    expect(
+      service.decide({ device: 'desktop', fieldCount: 10, dependencyCount: 3 })
+        .reason,
+    ).toContain('Casos simples');
+    expect(
+      service.decide({ device: 'desktop', fieldCount: 10, dependencyCount: 4 })
+        .reason,
+    ).toContain('Padrão seguro');
+  });
+
+  it('should respect high dependency boundaries', () => {
+    expect(
+      decide({ device: 'tablet', fieldCount: 20, dependencyCount: 7 }),
+    ).toBe('drawer');
+    expect(
+      decide({ device: 'tablet', fieldCount: 20, dependencyCount: 8 }),
+    ).toBe('modal');
+    expect(
+      decide({ device: 'desktop', fieldCount: 20, dependencyCount: 7 }),
+    ).toBe('drawer');
+    expect(
+      decide({ device: 'desktop', fieldCount: 20, dependencyCount: 8 }),
+    ).toBe('page');
+  });
+
+  it('should explain decisions', () => {
+    const ctx: OverlayDecisionContext = {
+      device: 'mobile',
+      fieldCount: 2,
+      dependencyCount: 0,
+    };
+    const reason = service.explain(ctx);
+    expect(reason).toContain('Formulários curtíssimos');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/overlay-decider.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/overlay-decider.service.ts
@@ -1,0 +1,104 @@
+import { inject, Injectable, InjectionToken } from '@angular/core';
+import { OVERLAY_DECISION_MATRIX } from '../tokens/overlay-decision-matrix.token';
+import {
+  OverlayDecision,
+  OverlayDecisionContext,
+  OverlayDecisionMatrix,
+  OverlayPattern,
+  OverlayRule,
+  OverlayRuleMatch,
+} from '../models/overlay-decision.model';
+
+export const OVERLAY_DECIDER_DEBUG = new InjectionToken<boolean>(
+  'OVERLAY_DECIDER_DEBUG',
+  {
+    providedIn: 'root',
+    factory: () => false,
+  },
+);
+
+@Injectable({ providedIn: 'root' })
+export class OverlayDeciderService {
+  private readonly matrix: OverlayDecisionMatrix = inject(
+    OVERLAY_DECISION_MATRIX,
+  );
+  private readonly debug: boolean = inject(OVERLAY_DECIDER_DEBUG);
+  decide(ctx: OverlayDecisionContext): OverlayDecision {
+    const decision = this.evaluate(ctx);
+    this.log(ctx, decision);
+    return decision;
+  }
+
+  explain(ctx: OverlayDecisionContext): string {
+    return this.evaluate(ctx).reason ?? '';
+  }
+
+  private evaluate(ctx: OverlayDecisionContext): OverlayDecision {
+    for (const rule of this.matrix.rules_ordered as OverlayRule[]) {
+      if (this.matches(ctx, rule.match)) {
+        return {
+          pattern: rule.use.pattern as OverlayPattern,
+          config: rule.use.config,
+          reason: rule.use.reason,
+        };
+      }
+    }
+    return {
+      pattern: this.matrix.fallback.pattern as OverlayPattern,
+      config: this.matrix.fallback.config,
+      reason: this.matrix.fallback.reason,
+    };
+  }
+
+  private matches(
+    ctx: OverlayDecisionContext,
+    match: OverlayRuleMatch,
+  ): boolean {
+    if (match.device && !match.device.includes(ctx.device)) {
+      return false;
+    }
+    if (match.fieldCount) {
+      if (
+        match.fieldCount.min !== undefined &&
+        ctx.fieldCount < match.fieldCount.min
+      ) {
+        return false;
+      }
+      if (
+        match.fieldCount.max !== undefined &&
+        ctx.fieldCount > match.fieldCount.max
+      ) {
+        return false;
+      }
+    }
+    if (match.dependencyCount) {
+      if (
+        match.dependencyCount.min !== undefined &&
+        ctx.dependencyCount < match.dependencyCount.min
+      ) {
+        return false;
+      }
+      if (
+        match.dependencyCount.max !== undefined &&
+        ctx.dependencyCount > match.dependencyCount.max
+      ) {
+        return false;
+      }
+    }
+    if (Array.isArray(match.any)) {
+      return match.any.some((sub) => this.matches(ctx, sub));
+    }
+    return true;
+  }
+
+  private log(ctx: OverlayDecisionContext, decision: OverlayDecision): void {
+    if (this.debug) {
+      console.debug('Overlay decision', {
+        device: ctx.device,
+        fieldCount: ctx.fieldCount,
+        dependencyCount: ctx.dependencyCount,
+        pattern: decision.pattern,
+      });
+    }
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/tokens/overlay-decision-matrix.token.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/tokens/overlay-decision-matrix.token.ts
@@ -1,0 +1,21 @@
+import {
+  EnvironmentProviders,
+  InjectionToken,
+  makeEnvironmentProviders,
+} from '@angular/core';
+import { OverlayDecisionMatrix } from '../models/overlay-decision.model';
+import defaultMatrix from '../config/overlay-decision-matrix.json';
+
+export const OVERLAY_DECISION_MATRIX =
+  new InjectionToken<OverlayDecisionMatrix>('OVERLAY_DECISION_MATRIX');
+
+export function provideOverlayDecisionMatrix(
+  matrix?: OverlayDecisionMatrix,
+): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: OVERLAY_DECISION_MATRIX,
+      useValue: matrix ?? (defaultMatrix as OverlayDecisionMatrix),
+    },
+  ]);
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/public-api.ts
@@ -9,9 +9,11 @@ export * from './lib/services/generic-crud.service';
 export * from './lib/services/schema-normalizer.service';
 export * from './lib/services/table-config.service';
 export * from './lib/services/config-storage.service';
+export * from './lib/services/overlay-decider.service';
 
 // Tokens
 export * from './lib/tokens/api-url.token';
+export * from './lib/tokens/overlay-decision-matrix.token';
 
 // Models
 export * from './lib/models/table-config.model';
@@ -24,6 +26,7 @@ export * from './lib/models/material-field-metadata.interface';
 export * from './lib/models/form/form-config.model';
 export * from './lib/models/form/form-events.model';
 export * from './lib/models/form/form-layout.model';
+export * from './lib/models/overlay-decision.model';
 
 // Metadata constants
 export * from './lib/metadata/field-control-type.constants';


### PR DESCRIPTION
## Summary
- add overlay decision model and injection token
- implement OverlayDeciderService with explain support
- document overlay decision matrix in workspace README
- strengthen typing and evaluation logic for overlay decisions

## Testing
- `npm install`
- `npx ng test praxis-core --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6899040ee05c8328b213d422706a3036