### PR TITLE
fix: normalize api endpoints

### DIFF
--- a/frontend-libs/praxis-ui-workspace/angular.json
+++ b/frontend-libs/praxis-ui-workspace/angular.json
@@ -118,7 +118,8 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "tsConfig": "projects/praxis-core/tsconfig.spec.json"
+            "tsConfig": "projects/praxis-core/tsconfig.spec.json",
+            "main": "projects/praxis-core/src/test.ts"
           }
         }
       }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/examples/material-metadata-usage.example.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/examples/material-metadata-usage.example.ts
@@ -27,7 +27,7 @@ import {
   MaterialButtonMetadata,
   MaterialNumericMetadata,
   MaterialTextareaMetadata,
-  MaterialTimepickerMetadata
+  MaterialTimepickerMetadata,
 } from '../models/material-field-metadata.interface';
 
 // =============================================================================
@@ -165,7 +165,7 @@ export const countrySelect: MaterialSelectMetadata = {
   required: true,
   searchable: true,
   searchPlaceholder: 'Search countries...',
-  endpoint: '/api/countries',
+  endpoint: 'countries',
   valueField: 'code',
   displayField: 'name',
   validators: {
@@ -289,8 +289,8 @@ export const meetingTimePicker: MaterialTimepickerMetadata = {
   openOnClick: true,
   materialDesign: {
     appearance: 'outline',
-    color: 'primary'
-  }
+    color: 'primary',
+  },
 };
 
 // =============================================================================
@@ -434,7 +434,7 @@ export const productForm: FieldMetadata[] = [
     controlType: 'select',
     required: true,
     order: 3,
-    endpoint: '/api/categories',
+    endpoint: 'categories',
     valueField: 'id',
     displayField: 'name',
     materialDesign: {
@@ -677,7 +677,7 @@ export const contactFormConfig: FormConfiguration = {
     scrollToFirstError: true,
   },
   submission: {
-    endpoint: '/api/contact',
+    endpoint: 'contact',
     method: 'POST',
     successMessage: 'Thank you! Your message has been sent.',
     errorMessage:

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/field-definition-mapper.spec.ts
@@ -100,7 +100,8 @@ describe('FieldDefinition to FieldMetadata mapper', () => {
 
     const meta = mapFieldDefinitionToMetadata(def);
 
-    expect(meta.endpoint).toBe('/api/status');
+    expect(meta.resourcePath).toBe('status');
+    expect(meta.endpoint).toBe('status');
     expect(meta.multiple).toBeTrue();
     expect(meta.searchable).toBeTrue();
     expect(meta.selectAll).toBeTrue();
@@ -121,5 +122,30 @@ describe('FieldDefinition to FieldMetadata mapper', () => {
     const meta = mapFieldDefinitionToMetadata(def);
 
     expect(meta.searchable).toBeTrue();
+  });
+
+  it('should normalize endpoints removing duplicate api segments', () => {
+    const def: FieldDefinition = {
+      name: 'department',
+      controlType: 'select',
+      endpoint: '/api/api/human-resources/departamentos',
+    } as any;
+
+    const meta = mapFieldDefinitionToMetadata(def);
+
+    expect(meta.resourcePath).toBe('human-resources/departamentos');
+    expect(meta.endpoint).toBe('human-resources/departamentos');
+  });
+
+  it('should normalize absolute endpoints to relative paths', () => {
+    const def: FieldDefinition = {
+      name: 'job',
+      controlType: 'select',
+      endpoint: 'http://localhost:8087/api/human-resources/cargos',
+    } as any;
+
+    const meta = mapFieldDefinitionToMetadata(def);
+
+    expect(meta.resourcePath).toBe('human-resources/cargos');
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/generic-crud.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/generic-crud.service.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { GenericCrudService } from './generic-crud.service';
+import { API_URL, ApiUrlConfig } from '../tokens/api-url.token';
+import { SchemaNormalizerService } from './schema-normalizer.service';
+
+describe('GenericCrudService', () => {
+  let service: GenericCrudService<any>;
+  let httpMock: HttpTestingController;
+  const apiConfig: ApiUrlConfig = {
+    default: { baseUrl: 'http://localhost:8087', path: 'api' },
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        GenericCrudService,
+        SchemaNormalizerService,
+        { provide: API_URL, useValue: apiConfig },
+      ],
+    });
+    service = TestBed.inject(GenericCrudService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should strip leading /api from resourcePath', () => {
+    service.configure('/api/test');
+    service.getAll().subscribe();
+    const req = httpMock.expectOne('http://localhost:8087/api/test/all');
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: [] });
+  });
+
+  it('should strip api prefix without leading slash', () => {
+    service.configure('api/other');
+    service.getAll().subscribe();
+    const req = httpMock.expectOne('http://localhost:8087/api/other/all');
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: [] });
+  });
+
+  it('should handle resourcePath with multiple api segments', () => {
+    service.configure('/api/api/multi');
+    service.getAll().subscribe();
+    const req = httpMock.expectOne('http://localhost:8087/api/multi/all');
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: [] });
+  });
+
+  it('should ignore domain from absolute resourcePath', () => {
+    service.configure('http://example.com/api/external');
+    service.getAll().subscribe();
+    const req = httpMock.expectOne('http://localhost:8087/api/external/all');
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: [] });
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/generic-crud.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/services/generic-crud.service.ts
@@ -146,10 +146,32 @@ export class GenericCrudService<T> {
     this.baseApiUrl = buildApiUrl(entry);
 
     const base = this.baseApiUrl.replace(/\/+$/, '');
-    const resource = resourcePath.replace(/^\/+/, '');
+    let resource = resourcePath.trim();
+
+    // Convert absolute URLs to their path component
+    if (/^https?:\/\//i.test(resource)) {
+      try {
+        const url = new URL(resource);
+        resource = url.pathname;
+      } catch {
+        // ignore parse errors and treat as relative string
+      }
+    }
+
+    resource = resource.replace(/^\/+/, '');
+
+    // Remove duplicated `api` segments only if base URL already contains `/api`
+    try {
+      const basePath = new URL(base).pathname;
+      if (/\/api(\/|$)/.test(basePath)) {
+        resource = resource.replace(/^(?:api\/)+/, '');
+      }
+    } catch {
+      // ignore invalid base URLs
+    }
 
     this.resourcePath = resource;
-    this.apiUrl = `${base}/${resource}`;
+    this.apiUrl = `${base}/${resource}`.replace(/\/+$/, '');
     this.configured = true;
   }
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/test.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/test.ts
@@ -1,0 +1,11 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+);


### PR DESCRIPTION
## Summary
- refine field endpoint mapping to drop origins and repeated `api` segments
- clean GenericCrudService.configure and add tests for duplicated or absolute paths
- wire up zone-based test bootstrap

## Testing
- `CHROME_BIN=/tmp/chrome.sh npx ng test praxis-core --watch=false --browsers=ChromeHeadless` *(fails: module 'puppeteer' not found when launching Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6899190926d48328a6ce94df231c0ad5