### PR TITLE
feat: improve multi-select tree accessibility

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select-tree/material-multi-select-tree.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-multi-select-tree/material-multi-select-tree.component.spec.ts
@@ -65,6 +65,28 @@ describe('MaterialMultiSelectTreeComponent', () => {
     expect(labels).toEqual(['IT', 'HR']);
   });
 
+  it('should render child nodes when parent expanded', () => {
+    const parent = component.dataSource.data[0];
+    component.treeControl.expand(parent);
+    fixture.detectChanges();
+    const labels = Array.from<HTMLElement>(
+      fixture.nativeElement.querySelectorAll('.mat-tree-node .mdc-label'),
+    ).map((el) => el.textContent?.trim());
+    expect(labels).toEqual(['IT', 'Dev', 'QA', 'HR']);
+  });
+
+  it('should mark parent indeterminate when only some children selected', () => {
+    const parent = component.dataSource.data[0];
+    const child = parent.children![0];
+    component.toggleNode(child);
+    fixture.detectChanges();
+    expect(component.selection.isSelected(parent)).toBeFalse();
+    const checkbox: HTMLInputElement = fixture.nativeElement.querySelector(
+      'mat-nested-tree-node mat-checkbox input',
+    );
+    expect(checkbox.indeterminate).toBeTrue();
+  });
+
   it('should toggle select all', () => {
     component.toggleSelectAll();
     expect(component.isAllSelected()).toBeTrue();


### PR DESCRIPTION
## Summary
- make select-all label configurable and add aria labels and grouping to tree nodes
- ensure select-all logic updates parent states for consistent selection
- test parent indeterminate state when partially selecting children

## Testing
- `npm test praxis-dynamic-fields -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68991bd02e94832884f6d99ebd20da39