### PR TITLE
fix: preserve multi-select tree hierarchy

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/utils/json-schema-mapper.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/utils/json-schema-mapper.spec.ts
@@ -24,6 +24,43 @@ describe('json-schema-mapper', () => {
     const meta = mapPropertyToFieldMetadata('departments', property);
     expect(meta?.controlType).toBe(FieldControlType.MULTI_SELECT_TREE);
     expect((meta as any).nodes?.length).toBe(2);
+    expect((meta as any).nodes[0].children?.[0].label).toBe('HR');
     expect((meta as any).options).toBeUndefined();
+  });
+
+  it('respects custom display and value fields in tree options', () => {
+    const property: JsonSchemaProperty = {
+      type: 'array',
+      'x-ui': {
+        controlType: 'multiSelectTree',
+        displayField: 'name',
+        valueField: 'id',
+        options: [
+          {
+            name: 'Operations',
+            id: 1,
+            children: [{ name: 'HR', id: 2 }],
+          },
+        ],
+      },
+    };
+
+    const meta = mapPropertyToFieldMetadata('departments', property);
+    const nodes = (meta as any).nodes;
+    expect(nodes[0].label).toBe('Operations');
+    expect(nodes[0].children[0].value).toBe(2);
+  });
+
+  it('returns empty nodes when options are invalid', () => {
+    const property: JsonSchemaProperty = {
+      type: 'array',
+      'x-ui': {
+        controlType: 'multiSelectTree',
+        options: null as any,
+      },
+    };
+
+    const meta = mapPropertyToFieldMetadata('departments', property);
+    expect((meta as any).nodes).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- tighten multi-select tree mapping by typing nodes and filtering out malformed options
- handle missing option arrays and ensure recursive children mapping
- test multi-select tree mapping with invalid options

## Testing
- `npx ng test praxis-dynamic-fields --watch=false --browsers=ChromeHeadlessNoSandbox` *(fails: NG0908: In this configuration Angular requires Zone.js)*

------
https://chatgpt.com/codex/tasks/task_e_68995a54cd788328862866e5aca24501