### PR TITLE
fix: ensure metadata labels propagate to all fields

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/base-dynamic-field-component.interface.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/base/base-dynamic-field-component.interface.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Interface base para todos os componentes de campos dinâmicos
- * 
+ *
  * Define o contrato comum que todos os componentes dinâmicos devem implementar
  * para garantir compatibilidade com o DynamicFieldLoaderDirective e outros
  * serviços do sistema.
@@ -40,33 +40,32 @@ export interface ValueChangeOptions {
 
 /**
  * Interface base que todos os componentes de campos dinâmicos devem implementar.
- * 
+ *
  * Esta interface define o contrato mínimo necessário para que um componente
  * seja compatível com o sistema de renderização dinâmica do Praxis.
- * 
+ *
  * ## Responsabilidades Principais
- * 
+ *
  * - Gerenciar metadata do componente através de signals
  * - Integrar com Angular Reactive Forms
  * - Fornecer controles de foco e blur
  * - Implementar lifecycle hooks customizados
  * - Manter identificação única do componente
- * 
+ *
  * ## Implementação
- * 
+ *
  * Componentes podem implementar esta interface diretamente ou herdar de:
  * - SimpleBaseInputComponent (para campos de entrada)
  * - SimpleBaseButtonComponent (para ações/botões)
  */
 export interface BaseDynamicFieldComponent {
-
   // =============================================================================
   // PROPRIEDADES OBRIGATÓRIAS
   // =============================================================================
 
   /**
    * Metadata do componente que define sua configuração e comportamento.
-   * 
+   *
    * Contém informações como label, tipo de controle, validações,
    * propriedades visuais e outras configurações específicas.
    */
@@ -74,7 +73,7 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * ID único do componente para identificação e debugging.
-   * 
+   *
    * Gerado automaticamente durante a inicialização e usado
    * para logging, testes e identificação em runtime.
    */
@@ -86,15 +85,23 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * FormControl associado ao componente para integração com Angular Reactive Forms.
-   * 
+   *
    * Opcional porque nem todos os componentes precisam de FormControl
    * (ex: botões, labels, componentes de exibição).
    */
   readonly formControl?: WritableSignal<AbstractControl | null>;
 
   /**
+   * Label textual exibido para o usuário, quando aplicável.
+   *
+   * Útil para componentes que apresentam uma descrição direta do campo
+   * como inputs e seletores. Implementação opcional.
+   */
+  label?: string;
+
+  /**
    * Observable de eventos de lifecycle do componente.
-   * 
+   *
    * Permite monitorar o ciclo de vida do componente externamente
    * para debugging, analytics ou integração com outros sistemas.
    */
@@ -106,7 +113,7 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * Foca no elemento principal do componente.
-   * 
+   *
    * Deve focar no input, botão ou elemento interativo principal.
    * Implementação deve ser robusta e não falhar se elemento não existir.
    */
@@ -114,10 +121,24 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * Remove o foco do elemento principal do componente.
-   * 
+   *
    * Útil para controle programático de foco e navegação por teclado.
    */
   blur(): void;
+
+  // =============================================================================
+  // MÉTODOS OPCIONAIS - METADATA
+  // =============================================================================
+
+  /**
+   * Define os metadados de entrada do componente.
+   *
+   * Permite que o componente ajuste propriedades derivadas (como label
+   * e placeholders) antes da configuração padrão.
+   *
+   * @param metadata Metadados do campo
+   */
+  setInputMetadata?(metadata: ComponentMetadata): void;
 
   // =============================================================================
   // MÉTODOS OPCIONAIS - LIFECYCLE
@@ -125,7 +146,7 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * Hook chamado após a inicialização completa do componente.
-   * 
+   *
    * Executado depois que metadata e formControl foram configurados.
    * Ideal para configurações específicas do componente.
    */
@@ -133,7 +154,7 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * Hook chamado antes da destruição do componente.
-   * 
+   *
    * Usado para limpeza de recursos, cancelamento de subscriptions,
    * ou salvamento de estado.
    */
@@ -145,7 +166,7 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * Define o valor do campo programaticamente.
-   * 
+   *
    * Implementação opcional para componentes que gerenciam valores.
    * Deve atualizar tanto o FormControl quanto o estado interno.
    */
@@ -153,21 +174,21 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * Obtém o valor atual do campo.
-   * 
+   *
    * @returns Valor atual ou null se não aplicável
    */
   getValue?(): any;
 
   /**
    * Marca o componente como tocado (touched).
-   * 
+   *
    * Usado para controle de validação e exibição de mensagens de erro.
    */
   markAsTouched?(): void;
 
   /**
    * Marca o componente como modificado (dirty).
-   * 
+   *
    * Indica que o valor foi alterado pelo usuário.
    */
   markAsDirty?(): void;
@@ -178,7 +199,7 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * Define o estado de loading do componente.
-   * 
+   *
    * Útil para botões e componentes que executam ações assíncronas.
    */
   setLoading?(loading: boolean): void;
@@ -190,7 +211,7 @@ export interface BaseDynamicFieldComponent {
 
   /**
    * Força a validação do componente.
-   * 
+   *
    * @returns Promise com erros de validação ou null se válido
    */
   validateField?(): Promise<any>;
@@ -208,27 +229,39 @@ export interface BaseDynamicFieldComponent {
 /**
  * Type guard para verificar se um objeto implementa BaseDynamicFieldComponent
  */
-export function isBaseDynamicFieldComponent(obj: any): obj is BaseDynamicFieldComponent {
-  return obj &&
+export function isBaseDynamicFieldComponent(
+  obj: any,
+): obj is BaseDynamicFieldComponent {
+  return (
+    obj &&
     typeof obj === 'object' &&
     'metadata' in obj &&
     'componentId' in obj &&
     typeof obj.focus === 'function' &&
     typeof obj.blur === 'function' &&
     typeof obj.metadata === 'function' &&
-    typeof obj.componentId === 'function';
+    typeof obj.componentId === 'function'
+  );
 }
 
 /**
  * Type guard para verificar se componente suporta valores (tem FormControl)
  */
-export function isValueBasedComponent(component: BaseDynamicFieldComponent): component is BaseDynamicFieldComponent & { formControl: WritableSignal<AbstractControl | null> } {
+export function isValueBasedComponent(
+  component: BaseDynamicFieldComponent,
+): component is BaseDynamicFieldComponent & {
+  formControl: WritableSignal<AbstractControl | null>;
+} {
   return 'formControl' in component && component.formControl !== undefined;
 }
 
 /**
  * Type guard para verificar se componente suporta loading
  */
-export function isLoadingCapableComponent(component: BaseDynamicFieldComponent): component is BaseDynamicFieldComponent & { setLoading: (loading: boolean) => void } {
+export function isLoadingCapableComponent(
+  component: BaseDynamicFieldComponent,
+): component is BaseDynamicFieldComponent & {
+  setLoading: (loading: boolean) => void;
+} {
   return typeof (component as any).setLoading === 'function';
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-textarea/material-textarea.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-textarea/material-textarea.component.spec.ts
@@ -25,7 +25,7 @@ describe('MaterialTextareaComponent', () => {
       name: 'description',
       label: 'Description',
     } as any;
-    component.setTextareaMetadata(metadata);
+    component.setInputMetadata(metadata);
     fixture.detectChanges();
   });
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-textarea/material-textarea.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/components/material-textarea/material-textarea.component.ts
@@ -171,7 +171,7 @@ export class MaterialTextareaComponent
   /**
    * Define metadata e aplica configurações
    */
-  setTextareaMetadata(metadata: MaterialTextareaMetadata): void {
+  setInputMetadata(metadata: MaterialTextareaMetadata): void {
     this.setMetadata(metadata);
   }
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/directives/dynamic-field-loader.directive.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/directives/dynamic-field-loader.directive.spec.ts
@@ -6,12 +6,13 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, DebugElement } from '@angular/core';
+import { Component, DebugElement, signal } from '@angular/core';
 import {
   FormBuilder,
   FormGroup,
   ReactiveFormsModule,
   Validators,
+  AbstractControl,
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -20,7 +21,9 @@ import { DynamicFieldLoaderDirective } from './dynamic-field-loader.directive';
 import { ComponentRegistryService } from '../services/component-registry/component-registry.service';
 import { TextInputComponent } from '../components/text-input/text-input.component';
 import { MaterialButtonComponent } from '../components/material-button/material-button.component';
-import { FieldMetadata } from '@praxis/core';
+import { FieldMetadata, ComponentMetadata } from '@praxis/core';
+import { BaseDynamicFieldComponent } from '../base/base-dynamic-field-component.interface';
+import { logger } from '../utils/logger';
 
 // =============================================================================
 // TEST COMPONENTS
@@ -105,6 +108,40 @@ class ItemTemplateHostComponent {
 // MOCK SERVICES
 // =============================================================================
 
+@Component({
+  selector: 'pdx-faulty',
+  standalone: true,
+  template: '',
+})
+class FaultyComponent implements BaseDynamicFieldComponent {
+  metadata = signal<ComponentMetadata | null>(null);
+  componentId = signal('faulty');
+  formControl = signal<AbstractControl | null>(null);
+  label?: string;
+
+  setInputMetadata(): void {
+    throw new Error('fail');
+  }
+
+  focus(): void {}
+  blur(): void {}
+}
+
+@Component({
+  selector: 'pdx-no-meta',
+  standalone: true,
+  template: '',
+})
+class NoMetadataComponent implements BaseDynamicFieldComponent {
+  metadata = signal<ComponentMetadata | null>(null);
+  componentId = signal('no-meta');
+  formControl = signal<AbstractControl | null>(null);
+  label?: string;
+
+  focus(): void {}
+  blur(): void {}
+}
+
 class MockComponentRegistryService {
   async getComponent(controlType: string): Promise<any> {
     switch (controlType) {
@@ -112,13 +149,17 @@ class MockComponentRegistryService {
         return TextInputComponent;
       case 'button':
         return MaterialButtonComponent;
+      case 'faulty':
+        return FaultyComponent;
+      case 'noMeta':
+        return NoMetadataComponent;
       default:
         return null;
     }
   }
 
   isRegistered(controlType: string): boolean {
-    return ['input', 'button'].includes(controlType);
+    return ['input', 'button', 'faulty', 'noMeta'].includes(controlType);
   }
 }
 
@@ -134,7 +175,12 @@ describe('DynamicFieldLoaderDirective', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestHostComponent, NoopAnimationsModule, ReactiveFormsModule],
+      imports: [
+        TestHostComponent,
+        NoopAnimationsModule,
+        ReactiveFormsModule,
+        FaultyComponent,
+      ],
       providers: [
         {
           provide: ComponentRegistryService,
@@ -290,6 +336,55 @@ describe('DynamicFieldLoaderDirective', () => {
       expect(emailMetadata.label).toBe('Email');
       expect(emailMetadata.controlType).toBe('input');
       expect(emailMetadata.required).toBe(true);
+    });
+
+    it('should apply label from metadata to component instance', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const emailComponent = component.createdComponents.get('email');
+      expect(emailComponent.instance.label).toBe('Email');
+    });
+
+    it('should fallback to metadata signal when setInputMetadata throws', async () => {
+      const fb = new FormBuilder();
+      component.fields = [
+        {
+          name: 'bad',
+          label: 'Bad',
+          controlType: 'faulty',
+        } as any,
+      ];
+      component.testForm = fb.group({ bad: [''] });
+
+      const errorSpy = spyOn(logger, 'error');
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const badComponent = component.createdComponents.get('bad');
+      expect(badComponent.instance.metadata()?.label).toBe('Bad');
+      expect(badComponent.instance.label).toBe('Bad');
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('should apply label when component lacks setInputMetadata', async () => {
+      const fb = new FormBuilder();
+      component.fields = [
+        {
+          name: 'plain',
+          label: 'Plain',
+          controlType: 'noMeta',
+        } as any,
+      ];
+      component.testForm = fb.group({ plain: [''] });
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const plainComponent = component.createdComponents.get('plain');
+      expect(plainComponent.instance.metadata()?.label).toBe('Plain');
+      expect(plainComponent.instance.label).toBe('Plain');
     });
 
     it('should associate FormControls with components', async () => {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/directives/dynamic-field-loader.directive.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-fields/src/lib/directives/dynamic-field-loader.directive.ts
@@ -403,7 +403,7 @@ export class DynamicFieldLoaderDirective
 
     // Validações não-críticas (warnings)
     if (this.fields.length === 0) {
-      console.warn(
+      logger.warn(
         '[DynamicFieldLoader] Fields array is empty - no components will be rendered',
       );
       return;
@@ -412,7 +412,7 @@ export class DynamicFieldLoaderDirective
     // Validar e normalizar estrutura básica dos fields
     this.fields = this.fields.map((field, index) => {
       if (!field.name) {
-        console.error(
+        logger.error(
           `[DynamicFieldLoader] Field at index ${index} is missing required 'name' property:`,
           field,
         );
@@ -433,7 +433,7 @@ export class DynamicFieldLoaderDirective
           );
           return inferredField;
         } else {
-          console.error(
+          logger.error(
             `[DynamicFieldLoader] Field '${field.name}' is missing required 'controlType' property and couldn't be inferred:`,
             field,
           );
@@ -445,7 +445,7 @@ export class DynamicFieldLoaderDirective
 
       // Verificar se FormControl existe
       if (!this.formGroup!.get(field.name)) {
-        console.warn(
+        logger.warn(
           `[DynamicFieldLoader] FormControl for field '${field.name}' not found in FormGroup`,
         );
       }
@@ -459,7 +459,7 @@ export class DynamicFieldLoaderDirective
       (name, index) => fieldNames.indexOf(name) !== index,
     );
     if (duplicates.length > 0) {
-      console.error(
+      logger.error(
         `[DynamicFieldLoader] Duplicate field names found:`,
         duplicates,
       );
@@ -616,7 +616,7 @@ export class DynamicFieldLoaderDirective
       // 2) cria componente do campo dentro do shell
       const componentType = await this.resolveComponentType(field.controlType);
       if (!componentType) {
-        console.warn(
+        logger.warn(
           `[DynamicFieldLoader] No component found for controlType '${field.controlType}', skipping field '${field.name}'`,
         );
         shellRef.destroy();
@@ -641,7 +641,7 @@ export class DynamicFieldLoaderDirective
 
       return componentRef as any;
     } catch (error) {
-      console.error(
+      logger.error(
         `[DynamicFieldLoader] Failed to create component for field '${field.name}':`,
         error,
       );
@@ -666,7 +666,7 @@ export class DynamicFieldLoaderDirective
         await this.componentRegistry.getComponent(controlType);
       return componentType;
     } catch (error) {
-      console.error(
+      logger.error(
         `[DynamicFieldLoader] Error resolving component type '${controlType}':`,
         error,
       );
@@ -690,22 +690,51 @@ export class DynamicFieldLoaderDirective
     const instance = componentRef.instance;
 
     try {
-      // Associar metadata com verificação robusta
-      if (instance && 'metadata' in instance) {
+      // Associar metadata utilizando método público quando disponível
+      let metadataAssigned = false;
+      if (instance && 'setInputMetadata' in instance) {
+        try {
+          (instance as any).setInputMetadata(field);
+          metadataAssigned = true;
+        } catch (error) {
+          logger.error(
+            `[DynamicFieldLoader] Error calling setInputMetadata for field '${field.name}':`,
+            error,
+          );
+        }
+      }
+
+      if (!metadataAssigned && instance && 'metadata' in instance) {
+        // Fallback para componentes que expõem o signal diretamente
         const instanceWithMetadata = instance as any;
         if (
           typeof instanceWithMetadata.metadata === 'function' &&
           'set' in instanceWithMetadata.metadata
         ) {
           instanceWithMetadata.metadata.set(field);
+          metadataAssigned = true;
         } else {
-          console.error(
+          logger.error(
             `[DynamicFieldLoader] Component '${field.name}' metadata property is not a WritableSignal`,
           );
         }
-      } else {
-        console.warn(
-          `[DynamicFieldLoader] Component for field '${field.name}' does not have metadata property`,
+      }
+
+      // Atribui label diretamente quando o componente expõe essa propriedade
+      if ('label' in instance && field.label !== undefined) {
+        try {
+          (instance as any).label = field.label;
+        } catch (error) {
+          logger.error(
+            `[DynamicFieldLoader] Error assigning label for field '${field.name}':`,
+            error,
+          );
+        }
+      }
+
+      if (!metadataAssigned) {
+        logger.warn(
+          `[DynamicFieldLoader] Component for field '${field.name}' does not support metadata assignment`,
         );
       }
 
@@ -720,17 +749,17 @@ export class DynamicFieldLoaderDirective
           ) {
             instanceWithFormControl.formControl.set(formControl);
           } else {
-            console.error(
+            logger.error(
               `[DynamicFieldLoader] Component '${field.name}' formControl property is not a WritableSignal`,
             );
           }
         } else {
-          console.warn(
+          logger.warn(
             `[DynamicFieldLoader] Component for field '${field.name}' does not have formControl property`,
           );
         }
       } else {
-        console.warn(
+        logger.warn(
           `[DynamicFieldLoader] No FormControl found for field '${field.name}' in FormGroup`,
         );
       }
@@ -746,7 +775,7 @@ export class DynamicFieldLoaderDirective
       // Detectar mudanças após configuração
       componentRef.changeDetectorRef.detectChanges();
     } catch (error) {
-      console.error(
+      logger.error(
         `[DynamicFieldLoader] Error configuring component for field '${field.name}':`,
         error,
       );


### PR DESCRIPTION
## Summary
- assign metadata labels directly in `DynamicFieldLoaderDirective` so all dynamic field components render their labels
- standardize `MaterialTextareaComponent` on the `setInputMetadata` hook for consistent metadata initialization
- extend directive tests to cover components without metadata hooks and verify label propagation

## Testing
- `npm run ng -- test praxis-dynamic-fields --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68995b08ff9483289ef27909959be0c9