### PR TITLE
fix(table): handle locale for numeric, currency and percent formats

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/columns-config-editor/columns-config-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/columns-config-editor/columns-config-editor.component.ts
@@ -1198,6 +1198,9 @@ export class ColumnsConfigEditorComponent implements OnInit, OnDestroy {
     }
 
     this.selectedColumn.format = format;
+    if (!this.selectedColumn.type) {
+      this.selectedColumn.type = this.selectedColumnDataType;
+    }
     this.onColumnPropertyChange();
   }
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatter.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatter.component.ts
@@ -7,7 +7,7 @@ import {
   OnChanges,
   SimpleChanges,
   ChangeDetectorRef,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -30,7 +30,7 @@ import {
   PERCENTAGE_PRESETS,
   STRING_PRESETS,
   BOOLEAN_PRESETS,
-  FormatPreset
+  FormatPreset,
 } from './data-formatter-types';
 import { DataFormattingService } from './data-formatting.service';
 
@@ -50,7 +50,7 @@ import { DataFormattingService } from './data-formatting.service';
     MatCardModule,
     MatDividerModule,
     MatTooltipModule,
-    MatChipsModule
+    MatChipsModule,
   ],
   template: `
     <div class="data-formatter">
@@ -67,12 +67,20 @@ import { DataFormattingService } from './data-formatting.service';
       <div *ngIf="columnType === 'date'" class="format-section">
         <mat-form-field appearance="outline" class="full-width">
           <mat-label>Formato de Data</mat-label>
-          <mat-select [(ngModel)]="selectedPreset" (ngModelChange)="onPresetChange()">
-            <mat-option *ngFor="let preset of datePresets" [value]="preset.value">
+          <mat-select
+            [(ngModel)]="selectedPreset"
+            (ngModelChange)="onPresetChange()"
+          >
+            <mat-option
+              *ngFor="let preset of datePresets"
+              [value]="preset.value"
+            >
               <div class="preset-option">
                 <div class="preset-content">
                   <span class="preset-label">{{ preset.label }}</span>
-                  <span class="preset-description">{{ preset.description }}</span>
+                  <span class="preset-description">{{
+                    preset.description
+                  }}</span>
                 </div>
                 <span class="preset-example">{{ preset.example }}</span>
               </div>
@@ -81,13 +89,19 @@ import { DataFormattingService } from './data-formatting.service';
           <mat-hint>Escolha um formato predefinido ou personalize</mat-hint>
         </mat-form-field>
 
-        <mat-form-field *ngIf="selectedPreset === 'custom'" appearance="outline" class="full-width">
+        <mat-form-field
+          *ngIf="selectedPreset === 'custom'"
+          appearance="outline"
+          class="full-width"
+        >
           <mat-label>Formato Personalizado</mat-label>
-          <input matInput 
-                 [(ngModel)]="customFormat"
-                 (ngModelChange)="onCustomFormatChange()"
-                 placeholder="dd/MM/yyyy HH:mm:ss"
-                 matTooltip="Use padrões do Angular DatePipe: dd, MM, yyyy, HH, mm, ss">
+          <input
+            matInput
+            [(ngModel)]="customFormat"
+            (ngModelChange)="onCustomFormatChange()"
+            placeholder="dd/MM/yyyy HH:mm:ss"
+            matTooltip="Use padrões do Angular DatePipe: dd, MM, yyyy, HH, mm, ss"
+          />
           <mat-hint>Ex: dd/MM/yyyy, HH:mm:ss, EEE dd/MM</mat-hint>
         </mat-form-field>
       </div>
@@ -97,7 +111,10 @@ import { DataFormattingService } from './data-formatting.service';
         <div class="format-row">
           <mat-form-field appearance="outline" class="decimal-select">
             <mat-label>Casas Decimais</mat-label>
-            <mat-select [(ngModel)]="decimalMode" (ngModelChange)="onDecimalModeChange()">
+            <mat-select
+              [(ngModel)]="decimalMode"
+              (ngModelChange)="onDecimalModeChange()"
+            >
               <mat-option value="0">Nenhuma (1.234)</mat-option>
               <mat-option value="1">1 fixa (1.234,5)</mat-option>
               <mat-option value="2">2 fixas (1.234,56)</mat-option>
@@ -106,16 +123,25 @@ import { DataFormattingService } from './data-formatting.service';
             </mat-select>
           </mat-form-field>
 
-          <mat-checkbox [(ngModel)]="thousandsSeparator" 
-                        (ngModelChange)="onFormatOptionChange()"
-                        class="format-checkbox">
+          <mat-checkbox
+            [(ngModel)]="thousandsSeparator"
+            (ngModelChange)="onFormatOptionChange()"
+            class="format-checkbox"
+          >
             Separador de milhares
           </mat-checkbox>
         </div>
 
-        <mat-form-field *ngIf="decimalMode === 'variable'" appearance="outline" class="full-width">
+        <mat-form-field
+          *ngIf="decimalMode === 'variable'"
+          appearance="outline"
+          class="full-width"
+        >
           <mat-label>Faixa de Decimais</mat-label>
-          <mat-select [(ngModel)]="variableRange" (ngModelChange)="onFormatOptionChange()">
+          <mat-select
+            [(ngModel)]="variableRange"
+            (ngModelChange)="onFormatOptionChange()"
+          >
             <mat-option value="0-1">0 a 1 casa</mat-option>
             <mat-option value="0-2">0 a 2 casas</mat-option>
             <mat-option value="0-3">0 a 3 casas</mat-option>
@@ -129,7 +155,10 @@ import { DataFormattingService } from './data-formatting.service';
         <div class="format-row">
           <mat-form-field appearance="outline" class="currency-select">
             <mat-label>Moeda</mat-label>
-            <mat-select [(ngModel)]="currencyCode" (ngModelChange)="onFormatOptionChange()">
+            <mat-select
+              [(ngModel)]="currencyCode"
+              (ngModelChange)="onFormatOptionChange()"
+            >
               <mat-option value="BRL">Real Brasileiro (R$)</mat-option>
               <mat-option value="USD">Dólar Americano (US$)</mat-option>
               <mat-option value="EUR">Euro (€)</mat-option>
@@ -139,7 +168,10 @@ import { DataFormattingService } from './data-formatting.service';
 
           <mat-form-field appearance="outline" class="decimal-select">
             <mat-label>Casas Decimais</mat-label>
-            <mat-select [(ngModel)]="currencyDecimals" (ngModelChange)="onFormatOptionChange()">
+            <mat-select
+              [(ngModel)]="currencyDecimals"
+              (ngModelChange)="onFormatOptionChange()"
+            >
               <mat-option value="0">Nenhuma</mat-option>
               <mat-option value="2">2 casas</mat-option>
               <mat-option value="3">3 casas</mat-option>
@@ -148,15 +180,19 @@ import { DataFormattingService } from './data-formatting.service';
         </div>
 
         <div class="format-row">
-          <mat-checkbox [(ngModel)]="currencySymbol" 
-                        (ngModelChange)="onFormatOptionChange()"
-                        class="format-checkbox">
+          <mat-checkbox
+            [(ngModel)]="currencySymbol"
+            (ngModelChange)="onFormatOptionChange()"
+            class="format-checkbox"
+          >
             Exibir símbolo da moeda
           </mat-checkbox>
 
-          <mat-checkbox [(ngModel)]="currencyThousands" 
-                        (ngModelChange)="onFormatOptionChange()"
-                        class="format-checkbox">
+          <mat-checkbox
+            [(ngModel)]="currencyThousands"
+            (ngModelChange)="onFormatOptionChange()"
+            class="format-checkbox"
+          >
             Separador de milhares
           </mat-checkbox>
         </div>
@@ -167,19 +203,23 @@ import { DataFormattingService } from './data-formatting.service';
         <div class="format-row">
           <mat-form-field appearance="outline" class="decimal-select">
             <mat-label>Casas Decimais</mat-label>
-            <mat-select [(ngModel)]="percentageDecimals" (ngModelChange)="onFormatOptionChange()">
+            <mat-select
+              [(ngModel)]="percentageDecimals"
+              (ngModelChange)="onFormatOptionChange()"
+            >
               <mat-option value="0">Nenhuma (12%)</mat-option>
               <mat-option value="1">1 casa (12,3%)</mat-option>
               <mat-option value="2">2 casas (12,34%)</mat-option>
               <mat-option value="3">3 casas (12,345%)</mat-option>
             </mat-select>
           </mat-form-field>
-
         </div>
 
-        <mat-checkbox [(ngModel)]="percentageMultiplier" 
-                      (ngModelChange)="onFormatOptionChange()"
-                      class="format-checkbox">
+        <mat-checkbox
+          [(ngModel)]="percentageMultiplier"
+          (ngModelChange)="onFormatOptionChange()"
+          class="format-checkbox"
+        >
           Multiplicar por 100 (0.15 → 15%)
         </mat-checkbox>
       </div>
@@ -188,8 +228,14 @@ import { DataFormattingService } from './data-formatting.service';
       <div *ngIf="columnType === 'string'" class="format-section">
         <mat-form-field appearance="outline" class="full-width">
           <mat-label>Transformação de Texto</mat-label>
-          <mat-select [(ngModel)]="stringTransform" (ngModelChange)="onFormatOptionChange()">
-            <mat-option *ngFor="let preset of stringPresets" [value]="preset.value">
+          <mat-select
+            [(ngModel)]="stringTransform"
+            (ngModelChange)="onFormatOptionChange()"
+          >
+            <mat-option
+              *ngFor="let preset of stringPresets"
+              [value]="preset.value"
+            >
               <div class="preset-option">
                 <span class="preset-label">{{ preset.label }}</span>
                 <span class="preset-example">{{ preset.example }}</span>
@@ -199,9 +245,11 @@ import { DataFormattingService } from './data-formatting.service';
         </mat-form-field>
 
         <div class="format-row">
-          <mat-checkbox [(ngModel)]="enableTruncate" 
-                        (ngModelChange)="onTruncateToggle()"
-                        class="format-checkbox">
+          <mat-checkbox
+            [(ngModel)]="enableTruncate"
+            (ngModelChange)="onTruncateToggle()"
+            class="format-checkbox"
+          >
             Truncar texto longo
           </mat-checkbox>
         </div>
@@ -210,20 +258,24 @@ import { DataFormattingService } from './data-formatting.service';
           <div class="format-row">
             <mat-form-field appearance="outline" class="truncate-length">
               <mat-label>Tamanho Máximo</mat-label>
-              <input matInput 
-                     type="number"
-                     [(ngModel)]="truncateLength"
-                     (ngModelChange)="onFormatOptionChange()"
-                     [min]="1"
-                     [max]="500">
+              <input
+                matInput
+                type="number"
+                [(ngModel)]="truncateLength"
+                (ngModelChange)="onFormatOptionChange()"
+                [min]="1"
+                [max]="500"
+              />
             </mat-form-field>
 
             <mat-form-field appearance="outline" class="truncate-suffix">
               <mat-label>Sufixo</mat-label>
-              <input matInput 
-                     [(ngModel)]="truncateSuffix"
-                     (ngModelChange)="onFormatOptionChange()"
-                     placeholder="...">
+              <input
+                matInput
+                [(ngModel)]="truncateSuffix"
+                (ngModelChange)="onFormatOptionChange()"
+                placeholder="..."
+              />
             </mat-form-field>
           </div>
         </div>
@@ -233,8 +285,14 @@ import { DataFormattingService } from './data-formatting.service';
       <div *ngIf="columnType === 'boolean'" class="format-section">
         <mat-form-field appearance="outline" class="full-width">
           <mat-label>Exibição de Valores</mat-label>
-          <mat-select [(ngModel)]="booleanDisplay" (ngModelChange)="onBooleanDisplayChange()">
-            <mat-option *ngFor="let preset of booleanPresets" [value]="preset.value">
+          <mat-select
+            [(ngModel)]="booleanDisplay"
+            (ngModelChange)="onBooleanDisplayChange()"
+          >
+            <mat-option
+              *ngFor="let preset of booleanPresets"
+              [value]="preset.value"
+            >
               <div class="preset-option">
                 <span class="preset-label">{{ preset.label }}</span>
                 <span class="preset-example">{{ preset.example }}</span>
@@ -248,18 +306,22 @@ import { DataFormattingService } from './data-formatting.service';
           <div class="format-row">
             <mat-form-field appearance="outline" class="boolean-value">
               <mat-label>Texto para Verdadeiro</mat-label>
-              <input matInput 
-                     [(ngModel)]="customTrueValue"
-                     (ngModelChange)="onFormatOptionChange()"
-                     placeholder="Verdadeiro">
+              <input
+                matInput
+                [(ngModel)]="customTrueValue"
+                (ngModelChange)="onFormatOptionChange()"
+                placeholder="Verdadeiro"
+              />
             </mat-form-field>
 
             <mat-form-field appearance="outline" class="boolean-value">
               <mat-label>Texto para Falso</mat-label>
-              <input matInput 
-                     [(ngModel)]="customFalseValue"
-                     (ngModelChange)="onFormatOptionChange()"
-                     placeholder="Falso">
+              <input
+                matInput
+                [(ngModel)]="customFalseValue"
+                (ngModelChange)="onFormatOptionChange()"
+                placeholder="Falso"
+              />
             </mat-form-field>
           </div>
         </div>
@@ -278,195 +340,196 @@ import { DataFormattingService } from './data-formatting.service';
       </div>
     </div>
   `,
-  styles: [`
-    .data-formatter {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
-
-    .formatter-header {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 16px 0;
-      border-bottom: 1px solid var(--mat-sys-outline-variant);
-    }
-
-    .header-icon {
-      font-size: 24px;
-      width: 24px;
-      height: 24px;
-      color: var(--mat-sys-primary);
-    }
-
-    .header-content h4 {
-      margin: 0 0 4px 0;
-      font-size: 1.1rem;
-      font-weight: 500;
-      color: var(--mat-sys-on-surface);
-    }
-
-    .header-description {
-      margin: 0;
-      font-size: 0.875rem;
-      color: var(--mat-sys-on-surface-variant);
-    }
-
-    .format-section {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
-
-    .format-row {
-      display: flex;
-      gap: 16px;
-      align-items: center;
-      flex-wrap: wrap;
-    }
-
-    .full-width {
-      width: 100%;
-    }
-
-    .decimal-select,
-    .currency-select {
-      min-width: 200px;
-      flex: 1;
-    }
-
-    .truncate-length {
-      flex: 1;
-      min-width: 120px;
-    }
-
-    .truncate-suffix {
-      flex: 1;
-      min-width: 100px;
-    }
-
-    .boolean-value {
-      flex: 1;
-      min-width: 150px;
-    }
-
-    .format-checkbox {
-      margin-right: 16px;
-    }
-
-    .preset-option {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      width: 100%;
-      padding: 4px 0;
-    }
-
-    .preset-content {
-      display: flex;
-      flex-direction: column;
-      flex: 1;
-    }
-
-    .preset-label {
-      font-weight: 500;
-      font-size: 0.9rem;
-    }
-
-    .preset-description {
-      font-size: 0.8rem;
-      color: var(--mat-sys-on-surface-variant);
-    }
-
-    .preset-example {
-      font-family: monospace;
-      font-size: 0.8rem;
-      color: var(--mat-sys-primary);
-      background-color: var(--mat-sys-primary-container);
-      padding: 2px 6px;
-      border-radius: 4px;
-      margin-left: 8px;
-    }
-
-    .truncate-options {
-      margin-left: 24px;
-      padding-left: 16px;
-      border-left: 2px solid var(--mat-sys-outline-variant);
-    }
-
-    .custom-boolean {
-      margin-top: 8px;
-    }
-
-    .preview-section {
-      margin-top: 16px;
-    }
-
-    .preview-content {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 16px;
-      background-color: var(--mat-sys-surface-container);
-      border-radius: 8px;
-      margin-top: 16px;
-    }
-
-    .preview-icon {
-      color: var(--mat-sys-secondary);
-    }
-
-    .preview-text {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-
-    .preview-label {
-      font-size: 0.875rem;
-      color: var(--mat-sys-on-surface-variant);
-    }
-
-    .preview-value {
-      font-family: monospace;
-      font-size: 1rem;
-      font-weight: 500;
-      color: var(--mat-sys-on-surface);
-      background-color: var(--mat-sys-surface-container-high);
-      padding: 8px 12px;
-      border-radius: 4px;
-      border: 1px solid var(--mat-sys-outline-variant);
-    }
-
-    /* Responsive Design */
-    @media (max-width: 768px) {
-      .format-row {
+  styles: [
+    `
+      .data-formatter {
+        display: flex;
         flex-direction: column;
-        align-items: stretch;
+        gap: 16px;
       }
 
-      .decimal-select,
-      .currency-select,
-      .truncate-length,
-      .truncate-suffix,
-      .boolean-value {
-        min-width: unset;
+      .formatter-header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 16px 0;
+        border-bottom: 1px solid var(--mat-sys-outline-variant);
+      }
+
+      .header-icon {
+        font-size: 24px;
+        width: 24px;
+        height: 24px;
+        color: var(--mat-sys-primary);
+      }
+
+      .header-content h4 {
+        margin: 0 0 4px 0;
+        font-size: 1.1rem;
+        font-weight: 500;
+        color: var(--mat-sys-on-surface);
+      }
+
+      .header-description {
+        margin: 0;
+        font-size: 0.875rem;
+        color: var(--mat-sys-on-surface-variant);
+      }
+
+      .format-section {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .format-row {
+        display: flex;
+        gap: 16px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .full-width {
         width: 100%;
       }
 
-      .format-checkbox {
-        margin-right: 0;
-        margin-bottom: 8px;
+      .decimal-select,
+      .currency-select {
+        min-width: 200px;
+        flex: 1;
       }
-    }
-  `]
+
+      .truncate-length {
+        flex: 1;
+        min-width: 120px;
+      }
+
+      .truncate-suffix {
+        flex: 1;
+        min-width: 100px;
+      }
+
+      .boolean-value {
+        flex: 1;
+        min-width: 150px;
+      }
+
+      .format-checkbox {
+        margin-right: 16px;
+      }
+
+      .preset-option {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+        padding: 4px 0;
+      }
+
+      .preset-content {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+      }
+
+      .preset-label {
+        font-weight: 500;
+        font-size: 0.9rem;
+      }
+
+      .preset-description {
+        font-size: 0.8rem;
+        color: var(--mat-sys-on-surface-variant);
+      }
+
+      .preset-example {
+        font-family: monospace;
+        font-size: 0.8rem;
+        color: var(--mat-sys-primary);
+        background-color: var(--mat-sys-primary-container);
+        padding: 2px 6px;
+        border-radius: 4px;
+        margin-left: 8px;
+      }
+
+      .truncate-options {
+        margin-left: 24px;
+        padding-left: 16px;
+        border-left: 2px solid var(--mat-sys-outline-variant);
+      }
+
+      .custom-boolean {
+        margin-top: 8px;
+      }
+
+      .preview-section {
+        margin-top: 16px;
+      }
+
+      .preview-content {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 16px;
+        background-color: var(--mat-sys-surface-container);
+        border-radius: 8px;
+        margin-top: 16px;
+      }
+
+      .preview-icon {
+        color: var(--mat-sys-secondary);
+      }
+
+      .preview-text {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .preview-label {
+        font-size: 0.875rem;
+        color: var(--mat-sys-on-surface-variant);
+      }
+
+      .preview-value {
+        font-family: monospace;
+        font-size: 1rem;
+        font-weight: 500;
+        color: var(--mat-sys-on-surface);
+        background-color: var(--mat-sys-surface-container-high);
+        padding: 8px 12px;
+        border-radius: 4px;
+        border: 1px solid var(--mat-sys-outline-variant);
+      }
+
+      /* Responsive Design */
+      @media (max-width: 768px) {
+        .format-row {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .decimal-select,
+        .currency-select,
+        .truncate-length,
+        .truncate-suffix,
+        .boolean-value {
+          min-width: unset;
+          width: 100%;
+        }
+
+        .format-checkbox {
+          margin-right: 0;
+          margin-bottom: 8px;
+        }
+      }
+    `,
+  ],
 })
 export class DataFormatterComponent implements OnInit, OnChanges {
-  
   @Input() columnType: ColumnDataType = 'string';
   @Input() currentFormat: string = '';
-  
+
   @Output() formatChange = new EventEmitter<string>();
 
   // Preset data
@@ -512,7 +575,7 @@ export class DataFormatterComponent implements OnInit, OnChanges {
 
   constructor(
     private cdr: ChangeDetectorRef,
-    private formattingService: DataFormattingService
+    private formattingService: DataFormattingService,
   ) {}
 
   ngOnInit(): void {
@@ -531,37 +594,58 @@ export class DataFormatterComponent implements OnInit, OnChanges {
 
   getTypeIcon(): string {
     switch (this.columnType) {
-      case 'date': return 'calendar_today';
-      case 'number': return 'numbers';
-      case 'currency': return 'attach_money';
-      case 'percentage': return 'percent';
-      case 'string': return 'text_fields';
-      case 'boolean': return 'toggle_on';
-      default: return 'format_shapes';
+      case 'date':
+        return 'calendar_today';
+      case 'number':
+        return 'numbers';
+      case 'currency':
+        return 'attach_money';
+      case 'percentage':
+        return 'percent';
+      case 'string':
+        return 'text_fields';
+      case 'boolean':
+        return 'toggle_on';
+      default:
+        return 'format_shapes';
     }
   }
 
   getTypeLabel(): string {
     switch (this.columnType) {
-      case 'date': return 'Data';
-      case 'number': return 'Número';
-      case 'currency': return 'Moeda';
-      case 'percentage': return 'Percentual';
-      case 'string': return 'Texto';
-      case 'boolean': return 'Booleano';
-      default: return 'Dados';
+      case 'date':
+        return 'Data';
+      case 'number':
+        return 'Número';
+      case 'currency':
+        return 'Moeda';
+      case 'percentage':
+        return 'Percentual';
+      case 'string':
+        return 'Texto';
+      case 'boolean':
+        return 'Booleano';
+      default:
+        return 'Dados';
     }
   }
 
   getTypeDescription(): string {
     switch (this.columnType) {
-      case 'date': return 'Configure como as datas serão exibidas';
-      case 'number': return 'Defina a formatação de números';
-      case 'currency': return 'Configure a exibição de valores monetários';
-      case 'percentage': return 'Formate a exibição de percentuais';
-      case 'string': return 'Transforme a apresentação de texto';
-      case 'boolean': return 'Escolha como exibir valores verdadeiro/falso';
-      default: return 'Configure a formatação dos dados';
+      case 'date':
+        return 'Configure como as datas serão exibidas';
+      case 'number':
+        return 'Defina a formatação de números';
+      case 'currency':
+        return 'Configure a exibição de valores monetários';
+      case 'percentage':
+        return 'Formate a exibição de percentuais';
+      case 'string':
+        return 'Transforme a apresentação de texto';
+      case 'boolean':
+        return 'Escolha como exibir valores verdadeiro/falso';
+      default:
+        return 'Configure a formatação dos dados';
     }
   }
 
@@ -592,7 +676,7 @@ export class DataFormatterComponent implements OnInit, OnChanges {
         this.parseBooleanFormat();
         break;
     }
-    
+
     this.generatePreview();
     this.cdr.markForCheck();
   }
@@ -623,7 +707,9 @@ export class DataFormatterComponent implements OnInit, OnChanges {
   }
 
   private parseDateFormat(): void {
-    const presetMatch = this.datePresets.find(p => p.value === this.currentFormat);
+    const presetMatch = this.datePresets.find(
+      (p) => p.value === this.currentFormat,
+    );
     if (presetMatch) {
       this.selectedPreset = presetMatch.value;
     } else {
@@ -655,11 +741,14 @@ export class DataFormatterComponent implements OnInit, OnChanges {
       this.currencyCode = parts[0];
       this.currencySymbol = parts[1] === 'symbol';
       this.currencyDecimals = parts[2];
+      this.currencyThousands = !parts.includes('nosep');
     }
   }
 
   private parsePercentageFormat(): void {
-    const match = this.currentFormat.match(/1\.(\d+)-(\d+)/);
+    this.percentageMultiplier = this.currentFormat.includes('|x100');
+    const format = this.currentFormat.replace('|x100', '');
+    const match = format.match(/1\.(\d+)-(\d+)/);
     if (match) {
       this.percentageDecimals = match[2];
     }
@@ -718,9 +807,12 @@ export class DataFormatterComponent implements OnInit, OnChanges {
 
     switch (this.columnType) {
       case 'date':
-        formatString = this.selectedPreset === 'custom' ? this.customFormat : this.selectedPreset;
+        formatString =
+          this.selectedPreset === 'custom'
+            ? this.customFormat
+            : this.selectedPreset;
         break;
-        
+
       case 'number':
         if (this.decimalMode === 'variable') {
           const [min, max] = this.variableRange.split('-');
@@ -732,23 +824,29 @@ export class DataFormatterComponent implements OnInit, OnChanges {
           formatString += '|nosep';
         }
         break;
-        
+
       case 'currency':
         const symbolType = this.currencySymbol ? 'symbol' : 'code';
         formatString = `${this.currencyCode}|${symbolType}|${this.currencyDecimals}`;
+        if (!this.currencyThousands) {
+          formatString += '|nosep';
+        }
         break;
-        
+
       case 'percentage':
         formatString = `1.${this.percentageDecimals}-${this.percentageDecimals}`;
+        if (this.percentageMultiplier) {
+          formatString += '|x100';
+        }
         break;
-        
+
       case 'string':
         formatString = this.stringTransform;
         if (this.enableTruncate) {
           formatString += `|truncate|${this.truncateLength}|${this.truncateSuffix}`;
         }
         break;
-        
+
       case 'boolean':
         if (this.booleanDisplay === 'custom') {
           formatString = `custom|${this.customTrueValue}|${this.customFalseValue}`;
@@ -773,7 +871,11 @@ export class DataFormatterComponent implements OnInit, OnChanges {
 
     const sampleValue = this.getSampleValue();
     try {
-      this.previewValue = this.formattingService.formatValue(sampleValue, this.columnType, formatString);
+      this.previewValue = this.formattingService.formatValue(
+        sampleValue,
+        this.columnType,
+        formatString,
+      );
     } catch (error) {
       this.previewValue = 'Erro na formatação';
       console.warn('Preview generation error:', error);
@@ -808,7 +910,9 @@ export class DataFormatterComponent implements OnInit, OnChanges {
   private getCurrentFormatString(): string {
     switch (this.columnType) {
       case 'date':
-        return this.selectedPreset === 'custom' ? this.customFormat : this.selectedPreset;
+        return this.selectedPreset === 'custom'
+          ? this.customFormat
+          : this.selectedPreset;
       case 'number':
         if (this.decimalMode === 'variable') {
           const [min, max] = this.variableRange.split('-');
@@ -818,9 +922,9 @@ export class DataFormatterComponent implements OnInit, OnChanges {
         }
       case 'currency':
         const symbolType = this.currencySymbol ? 'symbol' : 'code';
-        return `${this.currencyCode}|${symbolType}|${this.currencyDecimals}`;
+        return `${this.currencyCode}|${symbolType}|${this.currencyDecimals}${!this.currencyThousands ? '|nosep' : ''}`;
       case 'percentage':
-        return `1.${this.percentageDecimals}-${this.percentageDecimals}`;
+        return `1.${this.percentageDecimals}-${this.percentageDecimals}${this.percentageMultiplier ? '|x100' : ''}`;
       case 'string':
         let format = this.stringTransform;
         if (this.enableTruncate) {
@@ -837,5 +941,4 @@ export class DataFormatterComponent implements OnInit, OnChanges {
         return '';
     }
   }
-
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatting.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatting.service.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+import { LOCALE_ID } from '@angular/core';
+import {
+  DatePipe,
+  DecimalPipe,
+  CurrencyPipe,
+  PercentPipe,
+  UpperCasePipe,
+  LowerCasePipe,
+  TitleCasePipe,
+  registerLocaleData,
+} from '@angular/common';
+import localePt from '@angular/common/locales/pt';
+import { DataFormattingService } from './data-formatting.service';
+
+describe('DataFormattingService', () => {
+  let service: DataFormattingService;
+
+  beforeEach(() => {
+    registerLocaleData(localePt);
+    TestBed.configureTestingModule({
+      providers: [
+        DatePipe,
+        DecimalPipe,
+        CurrencyPipe,
+        PercentPipe,
+        UpperCasePipe,
+        LowerCasePipe,
+        TitleCasePipe,
+        DataFormattingService,
+        { provide: LOCALE_ID, useValue: 'pt-BR' },
+      ],
+    });
+    service = TestBed.inject(DataFormattingService);
+  });
+
+  it('formats comma-separated date strings', () => {
+    const result = service.formatValue('1990,5,15', 'date', 'dd/MM/yyyy');
+    expect(result).toBe('15/05/1990');
+  });
+
+  it('returns empty string for invalid comma-separated date strings', () => {
+    const result = service.formatValue('1990,15,40', 'date', 'dd/MM/yyyy');
+    expect(result).toBe('');
+  });
+
+  it('keeps decimal comma when suppressing thousand separator', () => {
+    const result = service.formatValue(1234.56, 'number', '1.2-2|nosep');
+    expect(result).toBe('1234,56');
+  });
+
+  it('removes thousand separator for currency when requested', () => {
+    const result = service.formatValue(
+      1234.56,
+      'currency',
+      'BRL|symbol|2|nosep',
+    );
+    expect(result).toBe('R$ 1234,56');
+  });
+
+  it('multiplies percentage values when x100 flag is present', () => {
+    const result = service.formatValue(0.15, 'percentage', '1.0-0|x100');
+    expect(result).toBe('15%');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatting.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatting.service.ts
@@ -1,11 +1,21 @@
-import { Injectable } from '@angular/core';
-import { DatePipe, DecimalPipe, CurrencyPipe, PercentPipe, UpperCasePipe, LowerCasePipe, TitleCasePipe } from '@angular/common';
+import { Inject, Injectable, LOCALE_ID } from '@angular/core';
+import {
+  DatePipe,
+  DecimalPipe,
+  CurrencyPipe,
+  PercentPipe,
+  UpperCasePipe,
+  LowerCasePipe,
+  TitleCasePipe,
+} from '@angular/common';
 import { ColumnDataType } from './data-formatter-types';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class DataFormattingService {
+  private groupSeparator: string;
+  private decimalSeparator: string;
 
   constructor(
     private datePipe: DatePipe,
@@ -14,13 +24,23 @@ export class DataFormattingService {
     private percentPipe: PercentPipe,
     private upperCasePipe: UpperCasePipe,
     private lowerCasePipe: LowerCasePipe,
-    private titleCasePipe: TitleCasePipe
-  ) {}
+    private titleCasePipe: TitleCasePipe,
+    @Inject(LOCALE_ID) private locale: string,
+  ) {
+    const parts = new Intl.NumberFormat(this.locale).formatToParts(12345.6);
+    this.groupSeparator = parts.find((p) => p.type === 'group')?.value || ',';
+    this.decimalSeparator =
+      parts.find((p) => p.type === 'decimal')?.value || '.';
+  }
 
   /**
    * Apply formatting to a value based on column type and format string
    */
-  formatValue(value: any, columnType: ColumnDataType, formatString: string): any {
+  formatValue(
+    value: any,
+    columnType: ColumnDataType,
+    formatString: string,
+  ): any {
     if (value === null || value === undefined) {
       return value;
     }
@@ -47,7 +67,10 @@ export class DataFormattingService {
           return value;
       }
     } catch (error) {
-      console.warn(`Error formatting value ${value} with type ${columnType} and format ${formatString}:`, error);
+      console.warn(
+        `Error formatting value ${value} with type ${columnType} and format ${formatString}:`,
+        error,
+      );
       return value; // Return original value on error
     }
   }
@@ -60,7 +83,14 @@ export class DataFormattingService {
       case 'date':
         if (value instanceof Date) return value;
         if (typeof value === 'string' || typeof value === 'number') {
-          const date = new Date(value);
+          let date = new Date(value);
+          if (typeof value === 'string' && isNaN(date.getTime())) {
+            const parts = value.split(',');
+            if (parts.length === 3) {
+              const [year, month, day] = parts.map(Number);
+              date = new Date(year, month - 1, day);
+            }
+          }
           return isNaN(date.getTime()) ? null : date;
         }
         return null;
@@ -70,7 +100,10 @@ export class DataFormattingService {
       case 'percentage':
         if (typeof value === 'number') return value;
         if (typeof value === 'string') {
-          const num = parseFloat(value);
+          const normalized = value
+            .replace(new RegExp(`\\${this.groupSeparator}`, 'g'), '')
+            .replace(this.decimalSeparator, '.');
+          const num = parseFloat(normalized);
           return isNaN(num) ? 0 : num;
         }
         return 0;
@@ -114,11 +147,16 @@ export class DataFormattingService {
     if (formatString.includes('|nosep')) {
       // No thousands separator
       const format = formatString.replace('|nosep', '');
-      const formatted = this.decimalPipe.transform(value, format, 'pt-BR') || value.toString();
-      return formatted.replace(/\./g, '').replace(/,/g, '.');
+      const formatted =
+        this.decimalPipe.transform(value, format, this.locale) ||
+        value.toString();
+      return this.removeGrouping(formatted);
     }
 
-    return this.decimalPipe.transform(value, formatString, 'pt-BR') || value.toString();
+    return (
+      this.decimalPipe.transform(value, formatString, this.locale) ||
+      value.toString()
+    );
   }
 
   /**
@@ -128,22 +166,55 @@ export class DataFormattingService {
     // Parse format: "BRL|symbol|2" or "USD|code|2"
     const parts = formatString.split('|');
     if (parts.length < 3) {
-      return this.currencyPipe.transform(value, 'BRL', 'symbol', '1.2-2', 'pt-BR') || value.toString();
+      return (
+        this.currencyPipe.transform(
+          value,
+          'BRL',
+          'symbol',
+          '1.2-2',
+          this.locale,
+        ) || value.toString()
+      );
     }
 
     const currencyCode = parts[0];
     const display = parts[1]; // 'symbol' or 'code'
     const decimals = parts[2];
+    const noSep = parts.includes('nosep');
     const digitsInfo = `1.${decimals}-${decimals}`;
 
-    return this.currencyPipe.transform(value, currencyCode, display, digitsInfo, 'pt-BR') || value.toString();
+    const formatted =
+      this.currencyPipe.transform(
+        value,
+        currencyCode,
+        display,
+        digitsInfo,
+        this.locale,
+      ) || value.toString();
+
+    return noSep ? this.removeGrouping(formatted) : formatted;
   }
 
   /**
    * Format percentage values
    */
   private formatPercentage(value: number, formatString: string): string {
-    return this.percentPipe.transform(value, formatString, 'pt-BR') || value.toString();
+    if (formatString.includes('|x100')) {
+      const format = formatString.replace('|x100', '');
+      const formatted =
+        this.decimalPipe.transform(value * 100, format, this.locale) ||
+        (value * 100).toString();
+      return `${formatted}%`;
+    }
+
+    return (
+      this.percentPipe.transform(value, formatString, this.locale) ||
+      value.toString()
+    );
+  }
+
+  private removeGrouping(value: string): string {
+    return value.replace(new RegExp(`\\${this.groupSeparator}`, 'g'), '');
   }
 
   /**
@@ -212,7 +283,7 @@ export class DataFormattingService {
       'yes-no': { true: 'Sim', false: 'Não' },
       'active-inactive': { true: 'Ativo', false: 'Inativo' },
       'on-off': { true: 'Ligado', false: 'Desligado' },
-      'enabled-disabled': { true: 'Habilitado', false: 'Desabilitado' }
+      'enabled-disabled': { true: 'Habilitado', false: 'Desabilitado' },
     };
 
     const display = displays[formatString] || displays['true-false'];


### PR DESCRIPTION
## Summary
- respect locale-specific separators when parsing and formatting numbers, currencies and percentages
- normalize numeric strings according to `LOCALE_ID`
- register `pt-BR` locale in formatter service tests

## Testing
- `npx ng test praxis-table --watch=false --browsers=ChromeHeadless --include=src/lib/data-formatter/data-formatting.service.spec.ts` *(fails: Property 'dateTimeFormat' is missing in type...)*

------
https://chatgpt.com/codex/tasks/task_e_689a650b9b008328a310d5e55cd92d3d