### PR TITLE
fix: handle array date values in grid formatting

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatting.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatting.service.spec.ts
@@ -39,6 +39,25 @@ describe('DataFormattingService', () => {
     expect(result).toBe('15/05/1990');
   });
 
+  it('formats date arrays', () => {
+    const result = service.formatValue([1990, 5, 15], 'date', 'dd/MM/yyyy');
+    expect(result).toBe('15/05/1990');
+  });
+
+  it('formats date arrays with time components', () => {
+    const result = service.formatValue(
+      [1990, 5, 15, 13, 30, 0],
+      'date',
+      'dd/MM/yyyy',
+    );
+    expect(result).toBe('15/05/1990');
+  });
+
+  it('returns empty string for invalid date arrays', () => {
+    const result = service.formatValue([1990, 15, 40], 'date', 'dd/MM/yyyy');
+    expect(result).toBe('');
+  });
+
   it('returns empty string for invalid comma-separated date strings', () => {
     const result = service.formatValue('1990,15,40', 'date', 'dd/MM/yyyy');
     expect(result).toBe('');

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatting.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/data-formatter/data-formatting.service.ts
@@ -93,6 +93,27 @@ export class DataFormattingService {
           }
           return isNaN(date.getTime()) ? null : date;
         }
+        if (Array.isArray(value)) {
+          const [
+            year,
+            month = 1,
+            day = 1,
+            hour = 0,
+            minute = 0,
+            second = 0,
+            millisecond = 0,
+          ] = value;
+          const date = new Date(
+            Number(year),
+            Number(month) - 1,
+            Number(day),
+            Number(hour),
+            Number(minute),
+            Number(second),
+            Number(millisecond),
+          );
+          return isNaN(date.getTime()) ? null : date;
+        }
         return null;
 
       case 'number':


### PR DESCRIPTION
## Summary
- handle array-based date values in DataFormattingService
- test formatting of date arrays including time components and invalid input

## Testing
- `npx ng test praxis-table --watch=false --browsers=ChromeHeadless --include='**/data-formatting.service.spec.ts'` *(fails: TS2339: Property 'data' does not exist on type 'PraxisTableConfigEditor', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a7c4ab87483289c2f6e42eb9425bd