### PR TITLE
feat: refine settings panel layout and closing API

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-settings-panel/src/lib/settings-panel.component.html
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-settings-panel/src/lib/settings-panel.component.html
@@ -24,12 +24,14 @@
   <footer class="settings-panel-footer">
     <button mat-button type="button" (click)="onReset()">Redefinir</button>
     <span class="spacer"></span>
+    <button mat-stroked-button type="button" (click)="onCancel()">
+      Cancelar
+    </button>
     <button mat-stroked-button type="button" (click)="onApply()">
       Aplicar
     </button>
-    <button mat-raised-button color="primary" type="button" (click)="onSave()">
+    <button mat-flat-button color="primary" type="button" (click)="onSave()">
       Salvar &amp; Fechar
     </button>
-    <button mat-button type="button" (click)="onCancel()">Cancelar</button>
   </footer>
 </div>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-settings-panel/src/lib/settings-panel.component.scss
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-settings-panel/src/lib/settings-panel.component.scss
@@ -1,7 +1,7 @@
 .settings-panel {
-  height: 100vh;
   display: flex;
   flex-direction: column;
+  height: 100%;
   background: var(--surface);
   border-left: 1px solid var(--border-color);
 }
@@ -22,13 +22,13 @@
 }
 
 .settings-panel-footer {
-  display: flex;
-  align-items: center;
-  padding: 16px;
-  border-top: 1px solid var(--border-color);
   position: sticky;
   bottom: 0;
+  border-top: 1px solid var(--border-color);
   background: var(--surface);
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
 }
 
 .spacer {
@@ -36,5 +36,5 @@
 }
 
 :host ::ng-deep .praxis-settings-panel-backdrop {
-  background: var(--overlay-backdrop, rgba(0, 0, 0, 0.4));
+  background: rgba(0, 0, 0, 0.4);
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-settings-panel/src/lib/settings-panel.ref.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-settings-panel/src/lib/settings-panel.ref.ts
@@ -29,9 +29,10 @@ export class SettingsPanelRef {
   }
 
   close(reason: SettingsPanelCloseReason = 'cancel'): void {
-    if (this.overlayRef.hasAttached()) {
-      this.overlayRef.dispose();
+    if (!this.overlayRef?.hasAttached()) {
+      return;
     }
+    this.overlayRef.dispose();
     this.closedSubject.next(reason);
     this.complete();
   }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-settings-panel/src/lib/settings-panel.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-settings-panel/src/lib/settings-panel.service.spec.ts
@@ -37,4 +37,22 @@ describe('SettingsPanelService', () => {
     expect(await savedPromise).toBe('b');
     expect(await closedPromise).toBe('save');
   });
+
+  it('closes an existing panel when opening a new one', async () => {
+    const firstRef = service.open({
+      id: 'a',
+      title: 'First',
+      content: { component: DummyComponent },
+    });
+
+    const closedPromise = firstValueFrom(firstRef.closed$);
+
+    service.open({
+      id: 'b',
+      title: 'Second',
+      content: { component: DummyComponent },
+    });
+
+    expect(await closedPromise).toBe('cancel');
+  });
 });


### PR DESCRIPTION
## Summary
- reorder footer actions and apply sticky layout
- style overlay backdrop
- unify close reasons and document single-panel rule

## Testing
- `npm test -- praxis-settings-panel --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless requires chromium snap)*

------
https://chatgpt.com/codex/tasks/task_e_689a98669b0883289245fc9d0474e5da