### PR TITLE
feat: add praxis-crud library skeleton

### DIFF
--- a/frontend-libs/praxis-ui-workspace/angular.json
+++ b/frontend-libs/praxis-ui-workspace/angular.json
@@ -31,9 +31,7 @@
                 "output": "assets/monaco"
               }
             ],
-            "styles": [
-              "src/styles.scss"
-            ]
+            "styles": ["src/styles.scss"]
           },
           "configurations": {
             "production": {
@@ -84,15 +82,13 @@
                 "glob": "**/*",
                 "input": "public"
               },
-             {
+              {
                 "glob": "**/*",
                 "input": "node_modules/monaco-editor",
                 "output": "assets/monaco"
               }
             ],
-            "styles": [
-              "src/styles.scss"
-            ]
+            "styles": ["src/styles.scss"]
           }
         }
       }
@@ -237,14 +233,46 @@
         "build": {
           "builder": "@angular/build:ng-packagr",
           "configurations": {
-            "production": { "tsConfig": "projects/praxis-dynamic-form/tsconfig.lib.prod.json" },
-            "development": { "tsConfig": "projects/praxis-dynamic-form/tsconfig.lib.json" }
+            "production": {
+              "tsConfig": "projects/praxis-dynamic-form/tsconfig.lib.prod.json"
+            },
+            "development": {
+              "tsConfig": "projects/praxis-dynamic-form/tsconfig.lib.json"
+            }
           },
           "defaultConfiguration": "production"
         },
         "test": {
           "builder": "@angular/build:karma",
-          "options": { "tsConfig": "projects/praxis-dynamic-form/tsconfig.spec.json" }
+          "options": {
+            "tsConfig": "projects/praxis-dynamic-form/tsconfig.spec.json"
+          }
+        }
+      }
+    },
+    "praxis-crud": {
+      "projectType": "library",
+      "root": "projects/praxis-crud",
+      "sourceRoot": "projects/praxis-crud/src",
+      "prefix": "lib",
+      "architect": {
+        "build": {
+          "builder": "@angular/build:ng-packagr",
+          "configurations": {
+            "production": {
+              "tsConfig": "projects/praxis-crud/tsconfig.lib.prod.json"
+            },
+            "development": {
+              "tsConfig": "projects/praxis-crud/tsconfig.lib.json"
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "test": {
+          "builder": "@angular/build:karma",
+          "options": {
+            "tsConfig": "projects/praxis-crud/tsconfig.spec.json"
+          }
         }
       }
     }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/README.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/README.md
@@ -1,0 +1,63 @@
+# PraxisCrud
+
+This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.1.0.
+
+## Code scaffolding
+
+Angular CLI includes powerful code scaffolding tools. To generate a new component, run:
+
+```bash
+ng generate component component-name
+```
+
+For a complete list of available schematics (such as `components`, `directives`, or `pipes`), run:
+
+```bash
+ng generate --help
+```
+
+## Building
+
+To build the library, run:
+
+```bash
+ng build praxis-crud
+```
+
+This command will compile your project, and the build artifacts will be placed in the `dist/` directory.
+
+### Publishing the Library
+
+Once the project is built, you can publish your library by following these steps:
+
+1. Navigate to the `dist` directory:
+   ```bash
+   cd dist/praxis-crud
+   ```
+
+2. Run the `npm publish` command to publish your library to the npm registry:
+   ```bash
+   npm publish
+   ```
+
+## Running unit tests
+
+To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
+
+```bash
+ng test
+```
+
+## Running end-to-end tests
+
+For end-to-end (e2e) testing, run:
+
+```bash
+ng e2e
+```
+
+Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
+
+## Additional Resources
+
+For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/ng-package.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/praxis-crud",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/package.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "praxis-crud",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/common": "^20.1.0",
+    "@angular/core": "^20.1.0"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "sideEffects": false
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/package.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "praxis-crud",
+  "name": "@praxis/crud",
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^20.1.0",

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.spec.ts
@@ -1,0 +1,114 @@
+import { TestBed } from '@angular/core/testing';
+import { CrudLauncherService } from './crud-launcher.service';
+import { Router } from '@angular/router';
+import { CrudMetadata } from './crud.types';
+import { DynamicFormDialogHostComponent } from './dynamic-form-dialog-host.component';
+import { DialogService, DialogRef } from './dialog.service';
+
+describe('CrudLauncherService', () => {
+  let service: CrudLauncherService;
+  let router: jasmine.SpyObj<Router>;
+  let dialog: jasmine.SpyObj<DialogService>;
+
+  beforeEach(() => {
+    router = jasmine.createSpyObj('Router', ['navigateByUrl']);
+    dialog = jasmine.createSpyObj('DialogService', ['open']);
+    TestBed.configureTestingModule({
+      providers: [
+        CrudLauncherService,
+        { provide: Router, useValue: router },
+        { provide: DialogService, useValue: dialog },
+      ],
+    });
+    service = TestBed.inject(CrudLauncherService);
+  });
+
+  it('should navigate for route open mode with params', () => {
+    const meta: CrudMetadata = {
+      component: 'praxis-crud',
+      table: {} as any,
+      actions: [
+        {
+          id: 'view',
+          label: 'View',
+          action: 'view',
+          route: '/item/:id',
+          params: [
+            { from: 'id', to: 'routeParam', name: 'id' },
+            { from: 'q', to: 'query', name: 'search' },
+          ],
+        },
+      ],
+    } as any;
+    const result = service.launch(meta.actions![0], { id: 1, q: 'abc' }, meta);
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/item/1?search=abc');
+    expect(result).toBeUndefined();
+  });
+
+  it('should open dialog for modal mode and map inputs', () => {
+    const meta: CrudMetadata = {
+      component: 'praxis-crud',
+      table: {} as any,
+      defaults: { modal: { width: '400px' } },
+      actions: [
+        {
+          id: 'edit',
+          label: 'Edit',
+          action: 'edit',
+          openMode: 'modal',
+          formId: 'f1',
+          params: [{ from: 'id', to: 'input', name: 'itemId' }],
+        },
+      ],
+    } as any;
+    const dummyRef = {} as DialogRef<any>;
+    dialog.open.and.returnValue(dummyRef);
+    const result = service.launch(meta.actions![0], { id: 10 }, meta);
+    expect(dialog.open).toHaveBeenCalledWith(
+      DynamicFormDialogHostComponent,
+      jasmine.objectContaining({
+        width: '400px',
+        data: jasmine.objectContaining({
+          inputs: { itemId: 10 },
+        }),
+      }),
+    );
+    expect(result).toBe(dummyRef);
+  });
+
+  it('should throw when route action missing route', () => {
+    const meta: CrudMetadata = {
+      component: 'praxis-crud',
+      table: {} as any,
+      actions: [
+        {
+          id: 'view',
+          label: 'View',
+          action: 'view',
+          openMode: 'route',
+        },
+      ],
+    } as any;
+    expect(() =>
+      service.launch(meta.actions![0], { id: 1 }, meta),
+    ).toThrowError('Route not provided for action view');
+  });
+
+  it('should throw when modal action missing formId', () => {
+    const meta: CrudMetadata = {
+      component: 'praxis-crud',
+      table: {} as any,
+      actions: [
+        {
+          id: 'edit',
+          label: 'Edit',
+          action: 'edit',
+          openMode: 'modal',
+        },
+      ],
+    } as any;
+    expect(() =>
+      service.launch(meta.actions![0], { id: 1 }, meta),
+    ).toThrowError('formId not provided for action edit');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.spec.ts
@@ -59,7 +59,7 @@ describe('CrudLauncherService', () => {
     const meta: CrudMetadata = {
       component: 'praxis-crud',
       table: {} as any,
-      defaults: { modal: { width: '300px' } },
+      defaults: { modal: { width: '300px', panelClass: 'custom' } },
     };
     const action: CrudAction = {
       action: 'edit',
@@ -72,6 +72,15 @@ describe('CrudLauncherService', () => {
     const result = await service.launch(action, undefined, meta);
     expect(result.mode).toBe('modal');
     expect(result.ref).toBe(dummyRef);
+    expect(dialog.openAsync).toHaveBeenCalledWith(
+      jasmine.any(Function),
+      jasmine.objectContaining({
+        panelClass: ['praxis-dialog-panel', 'custom'],
+        backdropClass: ['praxis-dialog-backdrop'],
+        autoFocus: true,
+        restoreFocus: true,
+      }),
+    );
   });
 
   it('launch navigates when mode is route', async () => {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { CrudMetadata, CrudAction, FormOpenMode } from './crud.types';
+import { DynamicFormDialogHostComponent } from './dynamic-form-dialog-host.component';
+import { DialogService, DialogRef } from './dialog.service';
+
+@Injectable({ providedIn: 'root' })
+export class CrudLauncherService {
+  private readonly router = inject(Router);
+  private readonly dialog = inject(DialogService);
+
+  launch(
+    action: CrudAction,
+    row: Record<string, unknown> | undefined,
+    metadata: CrudMetadata,
+  ): DialogRef<DynamicFormDialogHostComponent> | undefined {
+    const mode: FormOpenMode =
+      action.openMode ?? metadata.defaults?.openMode ?? 'route';
+
+    if (mode === 'route') {
+      if (!action.route) {
+        throw new Error(`Route not provided for action ${action.action}`);
+      }
+      const url = this.buildRoute(action, row);
+      this.router.navigateByUrl(url);
+      return;
+    }
+
+    if (!action.formId) {
+      throw new Error(`formId not provided for action ${action.action}`);
+    }
+    const inputs = this.mapInputs(action, row);
+    return this.dialog.open(DynamicFormDialogHostComponent, {
+      ...(metadata.defaults?.modal || {}),
+      data: { action, row, metadata, inputs },
+    });
+  }
+
+  private buildRoute(
+    action: CrudAction,
+    row: Record<string, unknown> | undefined,
+  ): string {
+    let route = action.route as string;
+    const query: Record<string, unknown> = {};
+    action.params?.forEach((p) => {
+      const value = row?.[p.from];
+      if (p.to === 'routeParam') {
+        route = route.replace(`:${p.name}`, encodeURIComponent(String(value)));
+      } else if (p.to === 'query') {
+        query[p.name] = value;
+      }
+    });
+    const queryString = new URLSearchParams(
+      query as Record<string, string>,
+    ).toString();
+    return queryString ? `${route}?${queryString}` : route;
+  }
+
+  private mapInputs(
+    action: CrudAction,
+    row: Record<string, unknown> | undefined,
+  ): Record<string, unknown> {
+    const inputs: Record<string, unknown> = {};
+    action.params?.forEach((p) => {
+      if (p.to === 'input') {
+        inputs[p.name] = row?.[p.from];
+      }
+    });
+    return inputs;
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { CrudMetadata, CrudAction, FormOpenMode } from './crud.types';
-import { DynamicFormDialogHostComponent } from './dynamic-form-dialog-host.component';
 import { DialogService, DialogRef } from './dialog.service';
 
 @Injectable({ providedIn: 'root' })
@@ -9,31 +8,44 @@ export class CrudLauncherService {
   private readonly router = inject(Router);
   private readonly dialog = inject(DialogService);
 
-  launch(
+  async launch(
     action: CrudAction,
     row: Record<string, unknown> | undefined,
     metadata: CrudMetadata,
-  ): DialogRef<DynamicFormDialogHostComponent> | undefined {
-    const mode: FormOpenMode =
-      action.openMode ?? metadata.defaults?.openMode ?? 'route';
+  ): Promise<{
+    mode: FormOpenMode;
+    ref?: DialogRef<any>;
+  }> {
+    const mode = this.resolveOpenMode(action, metadata);
 
     if (mode === 'route') {
       if (!action.route) {
         throw new Error(`Route not provided for action ${action.action}`);
       }
       const url = this.buildRoute(action, row);
-      this.router.navigateByUrl(url);
-      return;
+      await this.router.navigateByUrl(url);
+      return { mode };
     }
 
     if (!action.formId) {
       throw new Error(`formId not provided for action ${action.action}`);
     }
     const inputs = this.mapInputs(action, row);
-    return this.dialog.open(DynamicFormDialogHostComponent, {
-      ...(metadata.defaults?.modal || {}),
-      data: { action, row, metadata, inputs },
-    });
+    const ref = await this.dialog.openAsync(
+      () =>
+        import('./dynamic-form-dialog-host.component').then(
+          (m) => m.DynamicFormDialogHostComponent,
+        ),
+      {
+        ...(metadata.defaults?.modal || {}),
+        data: { action, row, metadata, inputs },
+      },
+    );
+    return { mode, ref };
+  }
+
+  resolveOpenMode(action: CrudAction, metadata: CrudMetadata): FormOpenMode {
+    return action.openMode ?? metadata.defaults?.openMode ?? 'route';
   }
 
   private buildRoute(
@@ -41,18 +53,26 @@ export class CrudLauncherService {
     row: Record<string, unknown> | undefined,
   ): string {
     let route = action.route as string;
-    const query: Record<string, unknown> = {};
+    const query: Record<string, string> = {};
     action.params?.forEach((p) => {
       const value = row?.[p.from];
       if (p.to === 'routeParam') {
-        route = route.replace(`:${p.name}`, encodeURIComponent(String(value)));
-      } else if (p.to === 'query') {
-        query[p.name] = value;
+        if (value === undefined || value === null) {
+          throw new Error(`Missing value for route param ${p.name}`);
+        }
+        const re = new RegExp(`:${p.name}\\b`, 'g');
+        route = route.replace(re, encodeURIComponent(String(value)));
+      } else if (p.to === 'query' && value !== undefined && value !== null) {
+        query[p.name] = String(value);
       }
     });
-    const queryString = new URLSearchParams(
-      query as Record<string, string>,
-    ).toString();
+    const missing = route.match(/:[a-zA-Z0-9_-]+/g);
+    if (missing) {
+      throw new Error(
+        `Missing route parameters: ${missing.map((m) => m.slice(1)).join(', ')}`,
+      );
+    }
+    const queryString = new URLSearchParams(query).toString();
     return queryString ? `${route}?${queryString}` : route;
   }
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
@@ -69,7 +69,9 @@ export class CrudLauncherService {
     const missing = route.match(/:[a-zA-Z0-9_-]+/g);
     if (missing) {
       throw new Error(
-        `Missing route parameters: ${missing.map((m) => m.slice(1)).join(', ')}`,
+        `Missing route parameters for action "${action.action}": ${missing
+          .map((m) => m.slice(1))
+          .join(', ')}`,
       );
     }
     const queryString = new URLSearchParams(query).toString();

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
@@ -31,13 +31,27 @@ export class CrudLauncherService {
       throw new Error(`formId not provided for action ${action.action}`);
     }
     const inputs = this.mapInputs(action, row);
+    const modalCfg = { ...(metadata.defaults?.modal || {}) } as any;
+    const panelClasses = ['praxis-dialog-panel'];
+    if (modalCfg.panelClass) {
+      panelClasses.push(modalCfg.panelClass);
+    }
+    const backdropClasses = ['praxis-dialog-backdrop'];
+    if (modalCfg.backdropClass) {
+      backdropClasses.push(modalCfg.backdropClass);
+    }
     const ref = await this.dialog.openAsync(
       () =>
         import('./dynamic-form-dialog-host.component').then(
           (m) => m.DynamicFormDialogHostComponent,
         ),
       {
-        ...(metadata.defaults?.modal || {}),
+        ...modalCfg,
+        panelClass: panelClasses,
+        backdropClass: backdropClasses,
+        autoFocus: true,
+        restoreFocus: true,
+        ariaLabelledBy: 'crudDialogTitle',
         data: { action, row, metadata, inputs },
       },
     );

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud-launcher.service.ts
@@ -32,11 +32,11 @@ export class CrudLauncherService {
     }
     const inputs = this.mapInputs(action, row);
     const modalCfg = { ...(metadata.defaults?.modal || {}) } as any;
-    const panelClasses = ['praxis-dialog-panel'];
+    const panelClasses = ['pfx-dialog-pane', 'pfx-dialog-frosted'];
     if (modalCfg.panelClass) {
       panelClasses.push(modalCfg.panelClass);
     }
-    const backdropClasses = ['praxis-dialog-backdrop'];
+    const backdropClasses = ['pfx-blur-backdrop'];
     if (modalCfg.backdropClass) {
       backdropClasses.push(modalCfg.backdropClass);
     }
@@ -51,6 +51,8 @@ export class CrudLauncherService {
         backdropClass: backdropClasses,
         autoFocus: true,
         restoreFocus: true,
+        minWidth: '360px',
+        maxWidth: '95vw',
         ariaLabelledBy: 'crudDialogTitle',
         data: { action, row, metadata, inputs },
       },

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud.types.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud.types.ts
@@ -4,6 +4,7 @@ import {
   FormConfig,
   RowAction,
   ToolbarAction,
+  ApiEndpoint,
 } from '@praxis/core';
 
 export type FormOpenMode = 'route' | 'modal';
@@ -29,6 +30,7 @@ export interface CrudDefaults {
 export interface CrudResource {
   path: string;
   idField?: string | number;
+  endpointKey?: ApiEndpoint;
 }
 
 export interface CrudMetadata {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud.types.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud.types.ts
@@ -40,3 +40,20 @@ export interface CrudMetadata {
   actions?: CrudAction[];
   i18n?: { crudDialog?: Record<string, string> };
 }
+
+export function assertCrudMetadata(meta: CrudMetadata): void {
+  meta.actions?.forEach((action) => {
+    const mode = action.openMode ?? meta.defaults?.openMode ?? 'route';
+    if (mode === 'route' && !action.route) {
+      throw new Error(`Route not provided for action ${action.action}`);
+    }
+    if (mode === 'modal' && !action.formId) {
+      throw new Error(`formId not provided for action ${action.action}`);
+    }
+    action.params?.forEach((p) => {
+      if (!['routeParam', 'query', 'input'].includes(p.to)) {
+        throw new Error(`Invalid param mapping target: ${p.to}`);
+      }
+    });
+  });
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud.types.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud.types.ts
@@ -1,0 +1,36 @@
+import { DialogConfig } from './dialog.service';
+import {
+  TableConfig,
+  FormConfig,
+  RowAction,
+  ToolbarAction,
+} from '@praxis/core';
+
+export type FormOpenMode = 'route' | 'modal';
+
+export interface CrudParamMapping {
+  from: string;
+  to: 'routeParam' | 'query' | 'input';
+  name: string;
+}
+
+export type CrudAction = (RowAction | ToolbarAction) & {
+  openMode?: FormOpenMode;
+  route?: string;
+  formId?: string;
+  params?: CrudParamMapping[];
+};
+
+export interface CrudDefaults {
+  openMode?: FormOpenMode;
+  modal?: DialogConfig;
+}
+
+export interface CrudMetadata {
+  component: 'praxis-crud';
+  table: TableConfig;
+  form?: FormConfig;
+  defaults?: CrudDefaults;
+  actions?: CrudAction[];
+  i18n?: { crudDialog?: Record<string, string> };
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud.types.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/crud.types.ts
@@ -26,8 +26,14 @@ export interface CrudDefaults {
   modal?: DialogConfig;
 }
 
+export interface CrudResource {
+  path: string;
+  idField?: string | number;
+}
+
 export interface CrudMetadata {
   component: 'praxis-crud';
+  resource?: CrudResource;
   table: TableConfig;
   form?: FormConfig;
   defaults?: CrudDefaults;

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { DialogService } from './dialog.service';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { Component } from '@angular/core';
+
+@Component({ selector: 'pdx-dummy', template: '' })
+class DummyComponent {}
+
+describe('DialogService', () => {
+  let service: DialogService;
+  let matDialog: jasmine.SpyObj<MatDialog>;
+
+  beforeEach(() => {
+    matDialog = jasmine.createSpyObj('MatDialog', ['open']);
+    TestBed.configureTestingModule({
+      providers: [DialogService, { provide: MatDialog, useValue: matDialog }],
+    });
+    service = TestBed.inject(DialogService);
+  });
+
+  it('delegates open to MatDialog', () => {
+    const ref = {} as MatDialogRef<any>;
+    matDialog.open.and.returnValue(ref);
+    const result = service.open(DummyComponent, { width: '100px' });
+    expect(matDialog.open).toHaveBeenCalledWith(DummyComponent, {
+      width: '100px',
+    });
+    expect(result).toBe(ref);
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { DialogService } from './dialog.service';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { Component } from '@angular/core';
+import { Component, NgZone } from '@angular/core';
 
 @Component({ selector: 'pdx-dummy', template: '' })
 class DummyComponent {}
@@ -9,11 +9,17 @@ class DummyComponent {}
 describe('DialogService', () => {
   let service: DialogService;
   let matDialog: jasmine.SpyObj<MatDialog>;
+  let ngZone: jasmine.SpyObj<NgZone>;
 
   beforeEach(() => {
     matDialog = jasmine.createSpyObj('MatDialog', ['open']);
+    ngZone = jasmine.createSpyObj('NgZone', ['run']);
     TestBed.configureTestingModule({
-      providers: [DialogService, { provide: MatDialog, useValue: matDialog }],
+      providers: [
+        DialogService,
+        { provide: MatDialog, useValue: matDialog },
+        { provide: NgZone, useValue: ngZone },
+      ],
     });
     service = TestBed.inject(DialogService);
   });
@@ -21,7 +27,9 @@ describe('DialogService', () => {
   it('delegates open to MatDialog', () => {
     const ref = {} as MatDialogRef<any>;
     matDialog.open.and.returnValue(ref);
+    ngZone.run.and.callFake((fn) => fn());
     const result = service.open(DummyComponent, { width: '100px' });
+    expect(ngZone.run).toHaveBeenCalled();
     expect(matDialog.open).toHaveBeenCalledWith(DummyComponent, {
       width: '100px',
     });
@@ -31,9 +39,9 @@ describe('DialogService', () => {
   it('supports openAsync with dynamic import', async () => {
     const ref = {} as MatDialogRef<any>;
     matDialog.open.and.returnValue(ref);
-    const result = await service.openAsync(() =>
-      Promise.resolve(DummyComponent),
-    );
+    ngZone.run.and.callFake((fn) => fn());
+    const result = await service.openAsync(() => Promise.resolve(DummyComponent));
+    expect(ngZone.run).toHaveBeenCalled();
     expect(result).toBe(ref);
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.spec.ts
@@ -27,4 +27,13 @@ describe('DialogService', () => {
     });
     expect(result).toBe(ref);
   });
+
+  it('supports openAsync with dynamic import', async () => {
+    const ref = {} as MatDialogRef<any>;
+    matDialog.open.and.returnValue(ref);
+    const result = await service.openAsync(() =>
+      Promise.resolve(DummyComponent),
+    );
+    expect(result).toBe(ref);
+  });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import {
   MatDialog,
   MatDialogRef,
@@ -26,13 +26,13 @@ export { MAT_DIALOG_DATA as DIALOG_DATA } from '@angular/material/dialog';
 
 @Injectable({ providedIn: 'root' })
 export class DialogService {
-  constructor(private matDialog: MatDialog) {}
+  constructor(private matDialog: MatDialog, private zone: NgZone) {}
 
   open<T, D = unknown, R = unknown>(
     component: ComponentType<T>,
     config?: DialogConfig<D>,
   ): DialogRef<T, R> {
-    return this.matDialog.open(component, config);
+    return this.zone.run(() => this.matDialog.open(component, config));
   }
 
   async openAsync<T, D = unknown, R = unknown>(
@@ -40,6 +40,6 @@ export class DialogService {
     config?: DialogConfig<D>,
   ): Promise<DialogRef<T, R>> {
     const component = await loader();
-    return this.matDialog.open(component, config);
+    return this.zone.run(() => this.matDialog.open(component, config));
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.ts
@@ -8,7 +8,20 @@ import {
 import { ComponentType } from '@angular/cdk/portal';
 
 export type DialogRef<T = any, R = any> = MatDialogRef<T, R>;
-export type DialogConfig<D = any> = MatDialogConfig<D>;
+
+export interface DialogConfig<D = any> extends MatDialogConfig<D> {
+  /** Disable closing when user clicks on backdrop */
+  disableCloseOnBackdrop?: boolean;
+  /** Disable closing when user presses escape */
+  disableCloseOnEsc?: boolean;
+  /** Enable maximize button */
+  canMaximize?: boolean;
+  /** Start dialog maximized */
+  startMaximized?: boolean;
+  /** Screen width in px where dialog starts fullscreen */
+  fullscreenBreakpoint?: number;
+}
+
 export { MAT_DIALOG_DATA as DIALOG_DATA } from '@angular/material/dialog';
 
 @Injectable({ providedIn: 'root' })
@@ -19,6 +32,14 @@ export class DialogService {
     component: ComponentType<T>,
     config?: DialogConfig<D>,
   ): DialogRef<T, R> {
+    return this.matDialog.open(component, config);
+  }
+
+  async openAsync<T, D = unknown, R = unknown>(
+    loader: () => Promise<ComponentType<T>>,
+    config?: DialogConfig<D>,
+  ): Promise<DialogRef<T, R>> {
+    const component = await loader();
     return this.matDialog.open(component, config);
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dialog.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import {
+  MatDialog,
+  MatDialogRef,
+  MatDialogConfig,
+  MAT_DIALOG_DATA,
+} from '@angular/material/dialog';
+import { ComponentType } from '@angular/cdk/portal';
+
+export type DialogRef<T = any, R = any> = MatDialogRef<T, R>;
+export type DialogConfig<D = any> = MatDialogConfig<D>;
+export { MAT_DIALOG_DATA as DIALOG_DATA } from '@angular/material/dialog';
+
+@Injectable({ providedIn: 'root' })
+export class DialogService {
+  constructor(private matDialog: MatDialog) {}
+
+  open<T, D = unknown, R = unknown>(
+    component: ComponentType<T>,
+    config?: DialogConfig<D>,
+  ): DialogRef<T, R> {
+    return this.matDialog.open(component, config);
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.spec.ts
@@ -1,0 +1,78 @@
+import { FormGroup } from '@angular/forms';
+import { of, EMPTY } from 'rxjs';
+import { DynamicFormDialogHostComponent } from './dynamic-form-dialog-host.component';
+import { DialogService, DialogRef } from './dialog.service';
+
+function createComponent(
+  dialogService: jasmine.SpyObj<DialogService>,
+  modal: any = {},
+  i18n: any = {},
+) {
+  const dialogRef: DialogRef<any> = {
+    close: jasmine.createSpy('close'),
+    disableClose: false,
+    keydownEvents: () => EMPTY,
+    backdropClick: () => EMPTY,
+    updateSize: jasmine.createSpy('updateSize'),
+    updatePosition: jasmine.createSpy('updatePosition'),
+  } as any;
+  const comp = new DynamicFormDialogHostComponent(
+    dialogRef,
+    {
+      action: { formId: 'f1' },
+      metadata: { defaults: { modal }, i18n: { crudDialog: i18n } },
+    },
+    dialogService,
+  );
+  comp.formComp = { form: new FormGroup({}) } as any;
+  return { comp, dialogRef };
+}
+
+describe('DynamicFormDialogHostComponent', () => {
+  let dialogService: jasmine.SpyObj<DialogService>;
+
+  beforeEach(() => {
+    dialogService = jasmine.createSpyObj('DialogService', ['open']);
+  });
+
+  it('closes immediately when form pristine', () => {
+    const { comp, dialogRef } = createComponent(dialogService);
+    comp.onCancel();
+    expect(dialogService.open).not.toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  it('asks confirmation when form dirty', () => {
+    const { comp, dialogRef } = createComponent(dialogService);
+    comp.formComp!.form.markAsDirty();
+    dialogService.open.and.returnValue({ afterClosed: () => of(true) } as any);
+    comp.onCancel();
+    expect(dialogService.open).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  it('cancels close when user rejects', () => {
+    const { comp, dialogRef } = createComponent(dialogService);
+    comp.formComp!.form.markAsDirty();
+    dialogService.open.and.returnValue({ afterClosed: () => of(false) } as any);
+    comp.onCancel();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('toggles maximization', () => {
+    const { comp, dialogRef } = createComponent(dialogService, {
+      width: '500px',
+      height: '300px',
+      canMaximize: true,
+    });
+    comp.toggleMaximize();
+    expect(dialogRef.updateSize).toHaveBeenCalledWith('100vw', '100vh');
+    comp.toggleMaximize();
+    expect(dialogRef.updateSize).toHaveBeenCalledWith('500px', '300px');
+  });
+
+  it('honors provided i18n texts', () => {
+    const { comp } = createComponent(dialogService, {}, { close: 'Fechar' });
+    expect(comp.texts.close).toBe('Fechar');
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.spec.ts
@@ -68,9 +68,17 @@ describe('DynamicFormDialogHostComponent', () => {
       canMaximize: true,
     });
     comp.toggleMaximize();
-    expect(dialogRef.updateSize).toHaveBeenCalledWith('100vw', '100vh');
+    expect(dialogRef.updateSize).toHaveBeenCalledWith(
+      'calc(100dvw - 16px)',
+      'calc(100dvh - 16px)',
+    );
+    expect(dialogRef.updatePosition).toHaveBeenCalledWith({
+      top: '8px',
+      left: '8px',
+    });
     comp.toggleMaximize();
     expect(dialogRef.updateSize).toHaveBeenCalledWith('500px', '300px');
+    expect(dialogRef.updatePosition).toHaveBeenCalledWith();
   });
 
   it('backdrop and esc respect disable flags', () => {
@@ -90,5 +98,12 @@ describe('DynamicFormDialogHostComponent', () => {
   it('honors provided i18n texts', () => {
     const { comp } = createComponent(dialogService, {}, { close: 'Fechar' });
     expect(comp.texts.close).toBe('Fechar');
+  });
+
+  it('stops loading when form ready', () => {
+    const { comp } = createComponent(dialogService);
+    expect(comp.loading).toBeTrue();
+    comp.onFormReady();
+    expect(comp.loading).toBeFalse();
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, ViewChild, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { MatDialogModule } from '@angular/material/dialog';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { PraxisDynamicForm } from '@praxis/dynamic-form';
 import { DialogService, DialogRef, DIALOG_DATA } from './dialog.service';
@@ -35,7 +35,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
             maximized ? texts.restoreLabel : texts.maximizeLabel
           "
         >
-          <mat-icon>{{ maximized ? 'close_fullscreen' : 'open_in_full' }}</mat-icon>
+          <mat-icon>{{
+            maximized ? 'close_fullscreen' : 'open_in_full'
+          }}</mat-icon>
         </button>
       }
       <button
@@ -119,6 +121,7 @@ export class DynamicFormDialogHostComponent implements OnInit {
   } as Record<string, string>;
 
   constructor(
+    @Inject(MatDialogRef)
     public dialogRef: DialogRef<DynamicFormDialogHostComponent>,
     @Inject(DIALOG_DATA) public data: any,
     private dialogService: DialogService,
@@ -152,7 +155,10 @@ export class DynamicFormDialogHostComponent implements OnInit {
     if (!this.modal.disableCloseOnEsc) {
       this.dialogRef
         .keydownEvents()
-        .pipe(filter((e) => e.key === 'Escape'), takeUntilDestroyed())
+        .pipe(
+          filter((e) => e.key === 'Escape'),
+          takeUntilDestroyed(),
+        )
         .subscribe(() => this.onCancel());
     }
 
@@ -197,7 +203,10 @@ export class DynamicFormDialogHostComponent implements OnInit {
       });
       ref
         .afterClosed()
-        .pipe(filter(Boolean), takeUntilDestroyed())
+        .pipe(
+          filter((confirmed) => !!confirmed),
+          takeUntilDestroyed(),
+        )
         .subscribe(() => this.dialogRef.close());
     } else {
       this.dialogRef.close();

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
@@ -172,6 +172,7 @@ export class DynamicFormDialogHostComponent implements OnInit {
     public dialogRef: DialogRef<DynamicFormDialogHostComponent>,
     @Inject(DIALOG_DATA) public data: any,
     private dialogService: DialogService,
+    private crud: GenericCrudService<any>,
   ) {
     this.dialogRef.disableClose = true;
 
@@ -191,6 +192,13 @@ export class DynamicFormDialogHostComponent implements OnInit {
     this.resourcePath =
       this.data.metadata?.resource?.path ??
       this.data.metadata?.table?.resourcePath;
+
+    if (this.resourcePath) {
+      this.crud.configure(
+        this.resourcePath,
+        this.data.metadata?.resource?.endpointKey,
+      );
+    }
 
     this.idField = this.data.metadata?.resource?.idField ?? 'id';
     this.resourceId = this.data.inputs?.[this.idField];

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
@@ -58,7 +58,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         [resourcePath]="resourcePath"
         [resourceId]="resourceId"
         [mode]="mode"
-        [inputs]="data.inputs"
         (formSubmit)="onSave($event)"
         (formCancel)="onCancel()"
       ></praxis-dynamic-form>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, ViewChild, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { MatDialogModule } from '@angular/material/dialog';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { PraxisDynamicForm } from '@praxis/dynamic-form';
 import { DialogService, DialogRef, DIALOG_DATA } from './dialog.service';
@@ -107,6 +107,7 @@ export class DynamicFormDialogHostComponent implements OnInit {
   } as Record<string, string>;
 
   constructor(
+    @Inject(MatDialogRef)
     public dialogRef: DialogRef<DynamicFormDialogHostComponent>,
     @Inject(DIALOG_DATA) public data: any,
     private dialogService: DialogService,

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
@@ -91,7 +91,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         --dlg-header-h: 56px;
         --dlg-footer-h: 56px;
         --dlg-pad: 16px;
-        --dlg-gap: 16px;
         display: flex;
         flex-direction: column;
         height: 100%;
@@ -101,7 +100,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         --dlg-header-h: 44px;
         --dlg-footer-h: 44px;
         --dlg-pad: 12px;
-        --dlg-gap: 12px;
       }
       .dialog-header {
         position: sticky;
@@ -129,7 +127,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         position: sticky;
         bottom: 0;
         z-index: 1;
-        background: inherit;
         padding: var(--dlg-pad);
       }
       .skeleton {
@@ -141,18 +138,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         height: 16px;
         border-radius: 4px;
         background: rgba(0, 0, 0, 0.1);
-      }
-      :host ::ng-deep .praxis-dialog-backdrop {
-        backdrop-filter: blur(4px);
-      }
-      :host ::ng-deep .praxis-dialog-panel {
-        margin: var(--dlg-gap);
-        width: clamp(360px, 88vw, var(--praxis-dialog-max-width, 960px));
-        transition:
-          width 200ms ease,
-          height 200ms ease,
-          top 200ms ease,
-          left 200ms ease;
       }
     `,
   ],
@@ -281,19 +266,22 @@ export class DynamicFormDialogHostComponent implements OnInit {
 
   toggleMaximize(initial = false): void {
     this.maximized = initial ? true : !this.maximized;
-    if (this.maximized) {
-      const gap = this.modal.fullscreenGap ?? 8;
-      this.dialogRef.updateSize(
-        `calc(100dvw - ${gap * 2}px)`,
-        `calc(100dvh - ${gap * 2}px)`,
-      );
-      this.dialogRef.updatePosition({ top: `${gap}px`, left: `${gap}px` });
-    } else {
-      this.dialogRef.updateSize(
-        this.initialSize.width,
-        this.initialSize.height,
-      );
-      this.dialogRef.updatePosition();
+
+    const gap = this.maximized ? 8 : undefined;
+    const width = this.maximized
+      ? `calc(100vw - ${2 * (gap ?? 0)}px)`
+      : this.initialSize.width;
+    const height = this.maximized
+      ? `calc(100dvh - ${2 * (gap ?? 0)}px)`
+      : this.initialSize.height;
+
+    this.dialogRef.updateSize(width, height);
+    this.dialogRef.updatePosition();
+
+    const pane: HTMLElement | undefined = (this.dialogRef as any)
+      ?._containerInstance?._elementRef?.nativeElement?.parentElement;
+    if (pane && pane.classList.contains('pfx-dialog-pane')) {
+      pane.style.margin = this.maximized ? `${gap}px` : '';
     }
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { PraxisDynamicForm } from '@praxis/dynamic-form';
+import { GenericCrudService } from '@praxis/core';
 import { DialogService, DialogRef, DIALOG_DATA } from './dialog.service';
 import { ConfirmDialogComponent } from '@praxis/dynamic-fields';
 import { filter } from 'rxjs/operators';
@@ -19,6 +20,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     MatIconModule,
     PraxisDynamicForm,
   ],
+  providers: [GenericCrudService],
   host: { class: 'praxis-dialog' },
   template: `
     <div class="dialog-header">

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/dynamic-form-dialog-host.component.ts
@@ -1,0 +1,183 @@
+import { Component, Inject, ViewChild, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { PraxisDynamicForm } from '@praxis/dynamic-form';
+import { DialogService, DialogRef, DIALOG_DATA } from './dialog.service';
+import { ConfirmDialogComponent } from '@praxis/dynamic-fields';
+import { filter } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+@Component({
+  selector: 'praxis-dynamic-form-dialog-host',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
+    PraxisDynamicForm,
+  ],
+  host: { class: 'praxis-dialog' },
+  template: `
+    <div class="dialog-header">
+      <h2 class="dialog-title">
+        {{ data.action?.label || texts.title }}
+      </h2>
+      <span class="spacer"></span>
+      @if (modal.canMaximize) {
+        <button
+          mat-icon-button
+          type="button"
+          (click)="toggleMaximize()"
+          [attr.aria-label]="
+            maximized ? texts.restoreLabel : texts.maximizeLabel
+          "
+        >
+          <mat-icon>{
+            maximized ? 'close_fullscreen' : 'open_in_full'
+          }</mat-icon>
+        </button>
+      }
+      <button
+        mat-icon-button
+        type="button"
+        (click)="onCancel()"
+        [attr.aria-label]="texts.closeLabel"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
+    <mat-dialog-content class="dialog-content">
+      <praxis-dynamic-form
+        [formId]="data.action?.formId"
+        [inputs]="data.inputs"
+        (formSubmit)="onSave($event)"
+        (formCancel)="onCancel()"
+      ></praxis-dynamic-form>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end" class="dialog-footer">
+      <button mat-button type="button" (click)="onCancel()">
+        {{ texts.close }}
+      </button>
+    </mat-dialog-actions>
+  `,
+  styles: [
+    `
+      .dialog-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .dialog-title {
+        margin: 0;
+        font: inherit;
+      }
+      .spacer {
+        flex: 1;
+      }
+      .dialog-content {
+        max-height: calc(100vh - 160px);
+        overflow: auto;
+      }
+      .dialog-footer {
+        position: sticky;
+        bottom: 0;
+        background: inherit;
+        padding-top: 8px;
+      }
+    `,
+  ],
+})
+export class DynamicFormDialogHostComponent implements OnInit {
+  @ViewChild(PraxisDynamicForm) formComp?: PraxisDynamicForm;
+  modal: any = {};
+  maximized = false;
+  texts = {
+    title: 'Form',
+    close: 'Close',
+    closeLabel: 'Close dialog',
+    maximizeLabel: 'Maximize',
+    restoreLabel: 'Restore',
+    discardTitle: 'Discard changes?',
+    discardMessage: 'You have unsaved changes. Close anyway?',
+    discardConfirm: 'Discard',
+    discardCancel: 'Cancel',
+  } as Record<string, string>;
+
+  constructor(
+    public dialogRef: DialogRef<DynamicFormDialogHostComponent>,
+    @Inject(DIALOG_DATA) public data: any,
+    private dialogService: DialogService,
+  ) {
+    this.dialogRef.disableClose = true;
+    this.texts = {
+      ...this.texts,
+      ...(this.data.metadata?.i18n?.crudDialog || {}),
+    };
+
+    this.modal = this.data.metadata?.defaults?.modal || {};
+
+    this.dialogRef
+      .keydownEvents()
+      .pipe(
+        filter((e) => e.key === 'Escape'),
+        takeUntilDestroyed(),
+      )
+      .subscribe(() => this.onCancel());
+
+    if (!this.modal.disableCloseOnBackdrop) {
+      this.dialogRef
+        .backdropClick()
+        .pipe(takeUntilDestroyed())
+        .subscribe(() => this.onCancel());
+    }
+  }
+
+  ngOnInit(): void {
+    const shouldMax =
+      this.modal.startMaximized ||
+      (this.modal.fullscreenBreakpoint &&
+        window.innerWidth <= this.modal.fullscreenBreakpoint);
+    if (shouldMax) {
+      this.toggleMaximize(true);
+    }
+  }
+
+  onSave(result: unknown): void {
+    this.dialogRef.close({ type: 'save', data: result });
+  }
+
+  onCancel(): void {
+    const dirty = this.formComp?.form.dirty;
+    if (dirty) {
+      const ref = this.dialogService.open(ConfirmDialogComponent, {
+        data: {
+          title: this.texts.discardTitle,
+          message: this.texts.discardMessage,
+          confirmText: this.texts.discardConfirm,
+          cancelText: this.texts.discardCancel,
+          type: 'warning',
+        },
+      });
+      ref
+        .afterClosed()
+        .pipe(filter(Boolean), takeUntilDestroyed())
+        .subscribe(() => this.dialogRef.close());
+    } else {
+      this.dialogRef.close();
+    }
+  }
+
+  toggleMaximize(initial = false): void {
+    this.maximized = initial ? true : !this.maximized;
+    if (this.maximized) {
+      this.dialogRef.updateSize('100vw', '100vh');
+      this.dialogRef.updatePosition({ top: '0', left: '0' });
+    } else {
+      this.dialogRef.updateSize(this.modal.width, this.modal.height);
+      this.dialogRef.updatePosition();
+    }
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PraxisCrudComponent } from './praxis-crud.component';
+import { CrudLauncherService } from './crud-launcher.service';
+import { Subject, of } from 'rxjs';
+
+describe('PraxisCrudComponent', () => {
+  let component: PraxisCrudComponent;
+  let fixture: ComponentFixture<PraxisCrudComponent>;
+  let launcher: jasmine.SpyObj<CrudLauncherService>;
+
+  beforeEach(async () => {
+    launcher = jasmine.createSpyObj('CrudLauncherService', ['launch']);
+    await TestBed.configureTestingModule({
+      imports: [PraxisCrudComponent],
+      providers: [{ provide: CrudLauncherService, useValue: launcher }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PraxisCrudComponent);
+    component = fixture.componentInstance;
+    component.metadata = {
+      component: 'praxis-crud',
+      table: {} as any,
+      actions: [],
+    } as any;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should delegate action to launcher', () => {
+    component.resolvedMetadata = {
+      component: 'praxis-crud',
+      table: {} as any,
+      actions: [{ id: 'edit', label: 'Edit', action: 'edit' }],
+    } as any;
+    component.onAction('edit', {});
+    expect(launcher.launch).toHaveBeenCalled();
+  });
+
+  it('should emit lifecycle events for modal action', () => {
+    const close$ = new Subject<any>();
+    launcher.launch.and.returnValue({
+      afterClosed: () => close$.asObservable(),
+    } as any);
+    component.resolvedMetadata = {
+      component: 'praxis-crud',
+      table: {} as any,
+      actions: [
+        {
+          id: 'edit',
+          label: 'Edit',
+          action: 'edit',
+          openMode: 'modal',
+          formId: 'f1',
+        },
+      ],
+    } as any;
+    const openSpy = jasmine.createSpy('open');
+    const closeSpy = jasmine.createSpy('close');
+    const saveSpy = jasmine.createSpy('save');
+    component.afterOpen.subscribe(openSpy);
+    component.afterClose.subscribe(closeSpy);
+    component.afterSave.subscribe(saveSpy);
+    component.onAction('edit', {});
+    expect(openSpy).toHaveBeenCalledWith({ mode: 'modal', action: 'edit' });
+    close$.next({ type: 'save', data: { id: 1 } });
+    close$.complete();
+    expect(closeSpy).toHaveBeenCalled();
+    expect(saveSpy).toHaveBeenCalledWith({ id: 1, data: { id: 1 } });
+  });
+
+  it('should emit error when launcher throws', () => {
+    const errorSpy = jasmine.createSpy('error');
+    component.resolvedMetadata = {
+      component: 'praxis-crud',
+      table: {} as any,
+      actions: [{ id: 'edit', label: 'Edit', action: 'edit' }],
+    } as any;
+    component.error.subscribe(errorSpy);
+    launcher.launch.and.throwError('boom');
+    component.onAction('edit', {});
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.spec.ts
@@ -2,11 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PraxisCrudComponent } from './praxis-crud.component';
 import { CrudLauncherService } from './crud-launcher.service';
 import { Subject } from 'rxjs';
-import { PraxisTable } from '@praxis/table';
-
-class TableStub {
-  refetch = jasmine.createSpy('refetch');
-}
+import { By } from '@angular/platform-browser';
 
 describe('PraxisCrudComponent', () => {
   let component: PraxisCrudComponent;
@@ -23,10 +19,10 @@ describe('PraxisCrudComponent', () => {
     component = fixture.componentInstance;
     component.metadata = {
       component: 'praxis-crud',
+      resource: { path: 'cargos' },
       table: {} as any,
       actions: [],
     } as any;
-    component['table'] = new TableStub() as any;
     fixture.detectChanges();
   });
 
@@ -56,6 +52,10 @@ describe('PraxisCrudComponent', () => {
       mode: 'modal',
       ref: { afterClosed: () => close$.asObservable() } as any,
     });
+    const tableEl = fixture.debugElement.query(By.css('praxis-table'));
+    const tableInstance = tableEl.componentInstance as any;
+    spyOn(tableInstance, 'refetch');
+    (component as any).table = tableInstance;
     component.resolvedMetadata = {
       component: 'praxis-crud',
       table: {} as any,
@@ -66,7 +66,7 @@ describe('PraxisCrudComponent', () => {
     await component.onAction('edit', {});
     close$.next({ type: 'save', data: { id: 1 } });
     close$.next({ type: 'delete', data: { id: 1 } });
-    expect((component as any).table.refetch).toHaveBeenCalledTimes(2);
+    expect(tableInstance.refetch).toHaveBeenCalledTimes(2);
     close$.complete();
   });
 
@@ -78,5 +78,10 @@ describe('PraxisCrudComponent', () => {
       metadata: { currentValue: component.metadata } as any,
     });
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('forwards resourcePath to table', () => {
+    const tableEl = fixture.debugElement.query(By.css('praxis-table'));
+    expect((tableEl.componentInstance as any).resourcePath).toBe('cargos');
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
@@ -1,0 +1,102 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  inject,
+  OnChanges,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+import { PraxisTable } from '@praxis/table';
+import { CrudLauncherService } from './crud-launcher.service';
+import { CrudMetadata, FormOpenMode } from './crud.types';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+@Component({
+  selector: 'praxis-crud',
+  standalone: true,
+  imports: [PraxisTable],
+  template: `
+    <praxis-table
+      [config]="resolvedMetadata?.table"
+      [resourcePath]="(resolvedMetadata?.table as any).resourcePath"
+      (rowAction)="onAction($event.action, $event.row)"
+      (toolbarAction)="onAction($event.action)"
+    ></praxis-table>
+  `,
+})
+export class PraxisCrudComponent implements OnChanges {
+  /** JSON inline ou chave/URL resolvida pelo MetadataResolver */
+  @Input({ required: true }) metadata!: CrudMetadata | string;
+  @Input() context?: Record<string, unknown>;
+  @Output() afterOpen = new EventEmitter<{
+    mode: FormOpenMode;
+    action: string;
+  }>();
+  @Output() afterClose = new EventEmitter<void>();
+  @Output() afterSave = new EventEmitter<{
+    id: string | number;
+    data: unknown;
+  }>();
+  @Output() afterDelete = new EventEmitter<{ id: string | number }>();
+  @Output() error = new EventEmitter<unknown>();
+
+  resolvedMetadata!: CrudMetadata;
+  private readonly launcher = inject(CrudLauncherService);
+  @ViewChild(PraxisTable) private table?: PraxisTable;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['metadata']) {
+      try {
+        this.resolvedMetadata =
+          typeof this.metadata === 'string'
+            ? (JSON.parse(this.metadata) as CrudMetadata)
+            : this.metadata;
+      } catch (err) {
+        this.error.emit(err);
+      }
+    }
+  }
+
+  onAction(action: string, row?: Record<string, unknown>): void {
+    try {
+      const actionMeta = this.resolvedMetadata.actions?.find(
+        (a) => a.action === action,
+      );
+      if (!actionMeta) {
+        return;
+      }
+      const mode: FormOpenMode =
+        actionMeta.openMode ??
+        this.resolvedMetadata.defaults?.openMode ??
+        'route';
+      const ref = this.launcher.launch(actionMeta, row, this.resolvedMetadata);
+      this.afterOpen.emit({ mode, action: actionMeta.action });
+      if (ref) {
+        ref
+          .afterClosed()
+          .pipe(takeUntilDestroyed())
+          .subscribe((result) => {
+            this.afterClose.emit();
+            if (result?.type === 'save') {
+              const id = (result.data as any)?.id;
+              this.afterSave.emit({ id, data: result.data });
+              this.refreshTable();
+            }
+            if (result?.type === 'delete') {
+              const id = (result.data as any)?.id;
+              this.afterDelete.emit({ id });
+              this.refreshTable();
+            }
+          });
+      }
+    } catch (err) {
+      this.error.emit(err);
+    }
+  }
+
+  private refreshTable(): void {
+    (this.table as any)?.fetchData?.();
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
@@ -21,6 +21,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     @if (resolvedMetadata; as meta) {
       <praxis-table
         [config]="meta.table"
+        [resourcePath]="meta.resource?.path"
         (rowAction)="onAction($event.action, $event.row)"
         (toolbarAction)="onAction($event.action)"
       ></praxis-table>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
@@ -21,7 +21,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     @if (resolvedMetadata; as meta) {
       <praxis-table
         [config]="meta.table"
-        [resourcePath]="meta.table?.resourcePath"
         (rowAction)="onAction($event.action, $event.row)"
         (toolbarAction)="onAction($event.action)"
       ></praxis-table>
@@ -84,12 +83,14 @@ export class PraxisCrudComponent implements OnChanges {
           .subscribe((result) => {
             this.afterClose.emit();
             if (result?.type === 'save') {
-              const id = (result.data as any)?.[idField];
+              const data = result.data as Record<string, unknown>;
+              const id = data?.[idField] as string | number;
               this.afterSave.emit({ id, data: result.data });
               this.refreshTable();
             }
             if (result?.type === 'delete') {
-              const id = (result.data as any)?.[idField];
+              const data = result.data as Record<string, unknown>;
+              const id = data?.[idField] as string | number;
               this.afterDelete.emit({ id });
               this.refreshTable();
             }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
@@ -18,9 +18,10 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   standalone: true,
   imports: [PraxisTable],
   template: `
-    @if (resolvedMetadata as meta) {
+    @if (resolvedMetadata; as meta) {
       <praxis-table
         [config]="meta.table"
+        [resourcePath]="meta.table?.resourcePath"
         (rowAction)="onAction($event.action, $event.row)"
         (toolbarAction)="onAction($event.action)"
       ></praxis-table>
@@ -76,18 +77,19 @@ export class PraxisCrudComponent implements OnChanges {
       );
       this.afterOpen.emit({ mode, action: actionMeta.action });
       if (ref) {
+        const idField = this.getIdField();
         ref
           .afterClosed()
           .pipe(takeUntilDestroyed())
           .subscribe((result) => {
             this.afterClose.emit();
             if (result?.type === 'save') {
-              const id = (result.data as any)?.id;
+              const id = (result.data as any)?.[idField];
               this.afterSave.emit({ id, data: result.data });
               this.refreshTable();
             }
             if (result?.type === 'delete') {
-              const id = (result.data as any)?.id;
+              const id = (result.data as any)?.[idField];
               this.afterDelete.emit({ id });
               this.refreshTable();
             }
@@ -100,5 +102,9 @@ export class PraxisCrudComponent implements OnChanges {
 
   private refreshTable(): void {
     this.table.refetch();
+  }
+
+  private getIdField(): string {
+    return (this.resolvedMetadata?.resource?.idField as string) || 'id';
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
@@ -18,12 +18,14 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   standalone: true,
   imports: [PraxisTable],
   template: `
-    <praxis-table
-      [config]="resolvedMetadata?.table"
-      [resourcePath]="(resolvedMetadata?.table as any).resourcePath"
-      (rowAction)="onAction($event.action, $event.row)"
-      (toolbarAction)="onAction($event.action)"
-    ></praxis-table>
+    @if (resolvedMetadata as meta) {
+      <praxis-table
+        [config]="meta.table"
+        [resourcePath]="meta.resource?.path"
+        (rowAction)="onAction($event.action, $event.row)"
+        (toolbarAction)="onAction($event.action)"
+      ></praxis-table>
+    }
   `,
 })
 export class PraxisCrudComponent implements OnChanges {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/lib/praxis-crud.component.ts
@@ -64,6 +64,7 @@ export class PraxisCrudComponent implements OnChanges {
 
   async onAction(action: string, row?: Record<string, unknown>): Promise<void> {
     try {
+      (document.activeElement as HTMLElement | null)?.blur();
       const actionMeta = this.resolvedMetadata.actions?.find(
         (a) => a.action === action,
       );

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/src/public-api.ts
@@ -1,0 +1,9 @@
+/*
+ * Public API Surface of praxis-crud
+ */
+
+export * from './lib/praxis-crud.component';
+export * from './lib/crud-launcher.service';
+export * from './lib/dynamic-form-dialog-host.component';
+export * from './lib/crud.types';
+export * from './lib/dialog.service';

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/tsconfig.lib.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/tsconfig.lib.json
@@ -1,0 +1,18 @@
+/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts"
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/tsconfig.lib.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/tsconfig.lib.json
@@ -7,12 +7,9 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
+    "sourceMap": true,
     "types": []
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.spec.ts"]
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/tsconfig.lib.prod.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/tsconfig.lib.prod.json
@@ -1,0 +1,11 @@
+/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-crud/tsconfig.spec.json
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-crud/tsconfig.spec.json
@@ -1,0 +1,14 @@
+/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-toolbar.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-toolbar.ts
@@ -18,24 +18,29 @@ import { TableConfig } from '@praxis/core';
     MatIconModule,
     MatMenuModule,
     MatFormFieldModule,
-    MatInputModule
+    MatInputModule,
   ],
   template: `
     <mat-toolbar class="praxis-toolbar">
       <!-- Add button via actions array -->
       <ng-container *ngFor="let action of getStartActions()">
-        <button mat-button [color]="action.color || 'primary'"
-                (click)="toolbarAction.emit({action: action.action})">
-          <mat-icon *ngIf="action.icon">{{action.icon}}</mat-icon>
+        <button
+          mat-button
+          [color]="action.color || 'primary'"
+          (click)="emitToolbarAction($event, action.action)"
+        >
+          <mat-icon *ngIf="action.icon">{{ action.icon }}</mat-icon>
           {{ action.label }}
         </button>
       </ng-container>
       <ng-container *ngFor="let action of config?.toolbar?.actions">
-        <button mat-button
-                [color]="action.color"
-                [disabled]="action.disabled"
-                (click)="toolbarAction.emit({action: action.action})">
-          <mat-icon *ngIf="action.icon">{{action.icon}}</mat-icon>
+        <button
+          mat-button
+          [color]="action.color"
+          [disabled]="action.disabled"
+          (click)="emitToolbarAction($event, action.action)"
+        >
+          <mat-icon *ngIf="action.icon">{{ action.icon }}</mat-icon>
           {{ action.label }}
         </button>
       </ng-container>
@@ -43,7 +48,7 @@ import { TableConfig } from '@praxis/core';
         <span class="spacer"></span>
         <mat-form-field appearance="outline" style="margin-right:8px;">
           <mat-label>Filtro</mat-label>
-          <input matInput  [value]="filterValue" />
+          <input matInput [value]="filterValue" />
         </mat-form-field>
       </ng-container>
       <ng-content select="[advancedFilter]"></ng-content>
@@ -55,24 +60,41 @@ import { TableConfig } from '@praxis/core';
         </button>
         <mat-menu #exportMenu="matMenu">
           <button mat-menu-item *ngFor="let format of config?.export?.formats">
-            <mat-icon>{{getExportIcon(format)}}</mat-icon>
-            {{format.toUpperCase()}}
+            <mat-icon>{{ getExportIcon(format) }}</mat-icon>
+            {{ format.toUpperCase() }}
           </button>
         </mat-menu>
       </ng-container>
     </mat-toolbar>
   `,
-  styles: [`:host{display:block;} .spacer{flex:1 1 auto;}`]
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .spacer {
+        flex: 1 1 auto;
+      }
+    `,
+  ],
 })
 export class PraxisTableToolbar {
-
   @Input() config?: TableConfig;
   @Input() showFilter = false;
   @Input() filterValue = '';
-  @Output() toolbarAction = new EventEmitter<{action: string}>();
+  @Output() toolbarAction = new EventEmitter<{ action: string }>();
+
+  emitToolbarAction(event: Event, action: string): void {
+    (event.target as HTMLElement).blur();
+    this.toolbarAction.emit({ action });
+  }
 
   getStartActions() {
-    return this.config?.toolbar?.actions?.filter(action => action.position === 'start') || [];
+    return (
+      this.config?.toolbar?.actions?.filter(
+        (action) => action.position === 'start',
+      ) || []
+    );
   }
 
   getExportIcon(format: string): string {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -493,6 +493,10 @@ export class PraxisTable
       });
   }
 
+  refetch(): void {
+    this.fetchData();
+  }
+
   /**
    * Get the cell value for a given row and column
    * Handles the complete transformation pipeline:

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -250,6 +250,7 @@ export class PraxisTable
 
   onRowAction(action: string, row: any, event: Event): void {
     event.stopPropagation();
+    (event.target as HTMLElement).blur();
     this.rowAction.emit({ action, row });
   }
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -58,6 +58,7 @@ import { ColumnDataType } from './data-formatter/data-formatter-types';
       [config]="config"
       [showFilter]="showFilter"
       [filterValue]="filterValue"
+      (toolbarAction)="onToolbarAction($event)"
     >
       <ng-content select="[advancedFilter]" />
       <ng-content select="[toolbar]" />
@@ -166,6 +167,7 @@ export class PraxisTable
 
   @Output() rowClick = new EventEmitter<{ row: any; index: number }>();
   @Output() rowAction = new EventEmitter<{ action: string; row: any }>();
+  @Output() toolbarAction = new EventEmitter<{ action: string }>();
 
   @ViewChild(MatPaginator) paginator?: MatPaginator;
   @ViewChild(MatSort) sort?: MatSort;
@@ -249,6 +251,10 @@ export class PraxisTable
   onRowAction(action: string, row: any, event: Event): void {
     event.stopPropagation();
     this.rowAction.emit({ action, row });
+  }
+
+  onToolbarAction(event: { action: string }): void {
+    this.toolbarAction.emit(event);
   }
 
   openConfigEditor(): void {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/praxis-table-v2-integration.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/praxis-table-v2-integration.spec.ts
@@ -267,4 +267,27 @@ describe('PraxisTable Unified Architecture', () => {
       expect(component.config.columns.length).toBe(1);
     });
   });
+
+  describe('Action Handling', () => {
+    it('should emit toolbar actions', () => {
+      const config: TableConfig = {
+        columns: [],
+        toolbar: {
+          visible: true,
+          actions: [{ id: 'add', label: 'Add', action: 'add' }],
+        },
+      };
+
+      component.config = config;
+      fixture.detectChanges();
+
+      const spy = jasmine.createSpy('toolbar');
+      component.toolbarAction.subscribe(spy);
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector(
+        'praxis-table-toolbar button',
+      );
+      button.click();
+      expect(spy).toHaveBeenCalledWith({ action: 'add' });
+    });
+  });
 });

--- a/frontend-libs/praxis-ui-workspace/src/app/app.routes.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/app.routes.ts
@@ -1,7 +1,7 @@
 import { Routes } from '@angular/router';
 import { FuncionariosListComponent } from './features/funcionarios/list/funcionarios-list.component';
 import { FuncionarioViewComponent } from './features/funcionarios/view/funcionario-view.component';
-import { CargosListComponent } from './features/cargos/list/cargos-list.component';
+import { CargosCrudComponent } from './features/cargos/crud/cargos-crud.component';
 import { CargoViewComponent } from './features/cargos/view/cargo-view.component';
 import { DepartamentosListComponent } from './features/departamentos/list/departamentos-list.component';
 import { DepartamentoViewComponent } from './features/departamentos/view/departamento-view.component';
@@ -21,7 +21,7 @@ import { UiWrappersTestComponent } from './features/ui-wrappers-test/ui-wrappers
 export const routes: Routes = [
   { path: 'funcionarios', component: FuncionariosListComponent },
   { path: 'funcionarios/view/:id', component: FuncionarioViewComponent },
-  { path: 'cargos', component: CargosListComponent },
+  { path: 'cargos', component: CargosCrudComponent },
   { path: 'cargos/view/:id', component: CargoViewComponent },
   { path: 'departamentos', component: DepartamentosListComponent },
   { path: 'departamentos/view/:id', component: DepartamentoViewComponent },

--- a/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.html
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.html
@@ -1,0 +1,11 @@
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>
+      <mat-icon aria-hidden="true">work</mat-icon>
+      <span>Cargos</span>
+    </mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <praxis-crud [metadata]="metadata"></praxis-crud>
+  </mat-card-content>
+</mat-card>

--- a/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.scss
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.scss
@@ -1,0 +1,1 @@
+/* styles for cargos crud */

--- a/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CargosCrudComponent } from './cargos-crud.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { GenericCrudService } from '@praxis/core';
+import { DialogService } from 'praxis-crud';
+
+describe('CargosCrudComponent', () => {
+  let component: CargosCrudComponent;
+  let fixture: ComponentFixture<CargosCrudComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CargosCrudComponent, RouterTestingModule],
+      providers: [
+        { provide: GenericCrudService, useValue: { configure: () => {} } },
+        { provide: DialogService, useValue: { open: () => ({}) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CargosCrudComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+

--- a/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CargosCrudComponent } from './cargos-crud.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { GenericCrudService } from '@praxis/core';
-import { DialogService } from 'praxis-crud';
+import { DialogService } from '@praxis/crud';
 
 describe('CargosCrudComponent', () => {
   let component: CargosCrudComponent;

--- a/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { PraxisCrudComponent, CrudMetadata } from 'praxis-crud';
+import { PraxisCrudComponent, CrudMetadata } from '@praxis/crud';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { GenericCrudService, ApiEndpoint } from '@praxis/core';

--- a/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.ts
@@ -6,7 +6,7 @@ import { GenericCrudService, ApiEndpoint } from '@praxis/core';
 
 const metadata: CrudMetadata = {
   component: 'praxis-crud',
-  resource: { path: 'cargos', idField: 'id' },
+  resource: { path: 'cargos', idField: 'id', endpointKey: ApiEndpoint.HumanResources },
   table: {
     columns: [],
     actions: {

--- a/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.ts
@@ -6,11 +6,9 @@ import { GenericCrudService, ApiEndpoint } from '@praxis/core';
 
 const metadata: CrudMetadata = {
   component: 'praxis-crud',
+  resource: { path: 'cargos', idField: 'id' },
   table: {
-    columns: [
-      { field: 'id', header: 'ID' } as any,
-      { field: 'descricao', header: 'Descrição' } as any,
-    ],
+    columns: [],
     actions: {
       row: {
         enabled: true,
@@ -55,10 +53,7 @@ const metadata: CrudMetadata = {
   ],
   defaults: {
     openMode: 'modal',
-    modal: {
-      width: '880px',
-      maxWidth: '95vw',
-    },
+    modal: { width: '880px', maxWidth: '95vw' },
   },
 };
 
@@ -68,7 +63,7 @@ const metadata: CrudMetadata = {
   imports: [MatCardModule, MatIconModule, PraxisCrudComponent],
   providers: [GenericCrudService],
   templateUrl: './cargos-crud.component.html',
-  styleUrl: './cargos-crud.component.scss',
+  styleUrls: ['./cargos-crud.component.scss'],
 })
 export class CargosCrudComponent {
   metadata = metadata;

--- a/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.ts
+++ b/frontend-libs/praxis-ui-workspace/src/app/features/cargos/crud/cargos-crud.component.ts
@@ -1,0 +1,80 @@
+import { Component } from '@angular/core';
+import { PraxisCrudComponent, CrudMetadata } from 'praxis-crud';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { GenericCrudService, ApiEndpoint } from '@praxis/core';
+
+const metadata: CrudMetadata = {
+  component: 'praxis-crud',
+  table: {
+    columns: [
+      { field: 'id', header: 'ID' } as any,
+      { field: 'descricao', header: 'Descrição' } as any,
+    ],
+    actions: {
+      row: {
+        enabled: true,
+        actions: [
+          { id: 'view', label: 'Visualizar', action: 'view', icon: 'visibility' },
+          { id: 'edit', label: 'Editar', action: 'edit', icon: 'edit' },
+        ],
+      },
+      toolbar: {
+        enabled: true,
+        actions: [
+          { id: 'create', label: 'Adicionar', action: 'create', icon: 'add' },
+        ],
+      },
+    },
+    resourcePath: 'cargos',
+  } as any,
+  actions: [
+    {
+      id: 'view',
+      label: 'Visualizar',
+      action: 'view',
+      openMode: 'route',
+      route: '/cargos/view/:id',
+      params: [{ from: 'id', to: 'routeParam', name: 'id' }],
+    },
+    {
+      id: 'edit',
+      label: 'Editar',
+      action: 'edit',
+      openMode: 'modal',
+      formId: 'cargos-edit',
+      params: [{ from: 'id', to: 'input', name: 'id' }],
+    },
+    {
+      id: 'create',
+      label: 'Adicionar',
+      action: 'create',
+      openMode: 'modal',
+      formId: 'cargos-create',
+    },
+  ],
+  defaults: {
+    openMode: 'modal',
+    modal: {
+      width: '880px',
+      maxWidth: '95vw',
+    },
+  },
+};
+
+@Component({
+  selector: 'app-cargos-crud',
+  standalone: true,
+  imports: [MatCardModule, MatIconModule, PraxisCrudComponent],
+  providers: [GenericCrudService],
+  templateUrl: './cargos-crud.component.html',
+  styleUrl: './cargos-crud.component.scss',
+})
+export class CargosCrudComponent {
+  metadata = metadata;
+
+  constructor(private crudService: GenericCrudService<any>) {
+    this.crudService.configure('cargos', ApiEndpoint.HumanResources);
+  }
+}
+

--- a/frontend-libs/praxis-ui-workspace/src/styles.scss
+++ b/frontend-libs/praxis-ui-workspace/src/styles.scss
@@ -3,6 +3,69 @@
  * ============================= */
 @use "theme-dark" as *;
 
+:root {
+  --pfx-gap: 16px;
+  --pfx-gap-max: 24px;
+  --pfx-radius: 14px;
+  --pfx-surface: rgba(28, 28, 36, 0.85);
+  --pfx-surface-border: rgba(255, 255, 255, 0.08);
+  --pfx-backdrop: rgba(14, 14, 23, 0.35);
+  --pfx-backdrop-blur: 6px;
+}
+
+@media (min-width: 1280px) {
+  :root {
+    --pfx-gap: var(--pfx-gap-max);
+  }
+}
+
+/* Backdrop with menu-like blur */
+.pfx-blur-backdrop {
+  background-color: var(--pfx-backdrop) !important;
+  backdrop-filter: blur(var(--pfx-backdrop-blur)) saturate(110%);
+  -webkit-backdrop-filter: blur(var(--pfx-backdrop-blur)) saturate(110%);
+}
+
+/* Dialog pane halo */
+.cdk-overlay-pane.pfx-dialog-pane {
+  margin: var(--pfx-gap) !important;
+  border-radius: var(--pfx-radius) !important;
+  overflow: hidden;
+  transition:
+    width 0.2s ease,
+    height 0.2s ease,
+    margin 0.2s ease;
+  box-shadow:
+    0 20px 60px rgba(0, 0, 0, 0.45),
+    0 2px 10px rgba(0, 0, 0, 0.25);
+}
+
+/* Frosted surface */
+.pfx-dialog-frosted .mat-mdc-dialog-surface {
+  background: var(--pfx-surface) !important;
+  border: 1px solid var(--pfx-surface-border);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+}
+
+/* Subtle ring */
+.cdk-overlay-pane.pfx-dialog-pane::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.05) inset,
+    0 0 0 2px rgba(255, 255, 255, 0.02);
+}
+
+/* Header/Footer highlight */
+.praxis-dialog .dialog-header,
+.praxis-dialog .dialog-footer {
+  background: color-mix(in srgb, var(--md-sys-color-surface), transparent 85%);
+}
+
 html,
 body {
   height: 100%;

--- a/frontend-libs/praxis-ui-workspace/tsconfig.json
+++ b/frontend-libs/praxis-ui-workspace/tsconfig.json
@@ -27,7 +27,7 @@
       "@praxis/dynamic-form": [
         "projects/praxis-dynamic-form/src/public-api.ts"
       ],
-      "praxis-crud": ["./dist/praxis-crud"]
+      "@praxis/crud": ["projects/praxis-crud/src/public-api.ts"]
     },
     "importHelpers": true,
     "target": "ES2022",

--- a/frontend-libs/praxis-ui-workspace/tsconfig.json
+++ b/frontend-libs/praxis-ui-workspace/tsconfig.json
@@ -24,7 +24,10 @@
       "@praxis/visual-builder": [
         "projects/praxis-visual-builder/src/public-api.ts"
       ],
-      "@praxis/dynamic-form": ["projects/praxis-dynamic-form/src/public-api.ts"]
+      "@praxis/dynamic-form": [
+        "projects/praxis-dynamic-form/src/public-api.ts"
+      ],
+      "praxis-crud": ["./dist/praxis-crud"]
     },
     "importHelpers": true,
     "target": "ES2022",
@@ -75,6 +78,12 @@
     },
     {
       "path": "./projects/praxis-dynamic-fields/tsconfig.spec.json"
+    },
+    {
+      "path": "./projects/praxis-crud/tsconfig.lib.json"
+    },
+    {
+      "path": "./projects/praxis-crud/tsconfig.spec.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace string-based lookup with direct `CrudAction` usage in launcher to avoid redundant searches and enforce action typing
- pass resolved action metadata from `PraxisCrudComponent` and emit `afterOpen` with explicit action id
- adjust unit tests to call the launcher with action objects, keeping route and modal error coverage intact

## Testing
- `npm test -- --project=praxis-crud --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689a61c629ac8328a0a72deff886e75f