### PR TITLE
feat(table): add filter settings panel

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '@praxis/core';
 import { PraxisFilter, I18n, FilterTag } from './praxis-filter';
 import { FilterConfigService } from './services/filter-config.service';
+import { SettingsPanelService } from '@praxis/settings-panel';
 
 describe('PraxisFilter', () => {
   let component: PraxisFilter;
@@ -20,6 +21,7 @@ describe('PraxisFilter', () => {
   let crud: jasmine.SpyObj<GenericCrudService<any>>;
   let storage: jasmine.SpyObj<ConfigStorage>;
   let configService: FilterConfigService;
+  let settingsPanel: jasmine.SpyObj<SettingsPanelService>;
 
   beforeEach(async () => {
     crud = jasmine.createSpyObj('GenericCrudService', [
@@ -36,12 +38,15 @@ describe('PraxisFilter', () => {
       'clearConfig',
     ]);
 
+    settingsPanel = jasmine.createSpyObj('SettingsPanelService', ['open']);
+
     await TestBed.configureTestingModule({
       imports: [PraxisFilter],
       providers: [
         { provide: GenericCrudService, useValue: crud },
         { provide: CONFIG_STORAGE, useValue: storage },
         FilterConfigService,
+        { provide: SettingsPanelService, useValue: settingsPanel },
       ],
     }).compileComponents();
     configService = TestBed.inject(FilterConfigService);

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/open-filter-settings.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/open-filter-settings.spec.ts
@@ -1,0 +1,60 @@
+import { Subject } from 'rxjs';
+import { PraxisFilter } from '../praxis-filter';
+import { SettingsPanelService } from '@praxis/settings-panel';
+import { FilterConfigService, FilterConfig } from '../services/filter-config.service';
+import { GenericCrudService, ConfigStorage } from '@praxis/core';
+
+describe('PraxisFilter openSettings', () => {
+  it('should apply changes and persist on save', () => {
+    const applied$ = new Subject<FilterConfig>();
+    const saved$ = new Subject<FilterConfig>();
+    const ref = { applied$, saved$, close: jasmine.createSpy('close') } as any;
+    const settingsPanel: SettingsPanelService = {
+      open: () => ref,
+    } as any;
+    const filterConfig: FilterConfigService = {
+      save: jasmine.createSpy('save'),
+      load: () => undefined,
+    } as any;
+    const crud = { configure: () => {} } as unknown as GenericCrudService<any>;
+    const storage = {
+      loadConfig: () => undefined,
+      saveConfig: () => undefined,
+      clearConfig: () => {},
+    } as ConfigStorage;
+    const destroyRef = { onDestroy: () => {} } as any;
+
+    const filter = new PraxisFilter(
+      crud,
+      storage,
+      destroyRef,
+      filterConfig,
+      settingsPanel,
+    );
+    (filter as any).configKey = 'f1';
+    (filter as any).schemaMetas = [];
+    filter.quickField = 'cpf';
+    filter.alwaysVisibleFields = ['age'];
+
+    filter.openSettings();
+
+    const newConfig: FilterConfig = {
+      quickField: 'name',
+      alwaysVisibleFields: ['age', 'cpf'],
+      placeholder: 'Buscar',
+      showAdvanced: true,
+    };
+    applied$.next(newConfig);
+    expect(filter.quickField).toBe('name');
+    expect(filter.alwaysVisibleFields).toEqual(['age', 'cpf']);
+    expect(ref.close).toHaveBeenCalled();
+
+    saved$.next({ quickField: 'id' });
+    expect(filterConfig.save).toHaveBeenCalledWith('f1', {
+      quickField: 'id',
+      alwaysVisibleFields: [],
+      placeholder: undefined,
+      showAdvanced: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow filter to open settings panel for configuration
- add settings button and accessibility
- test filter settings integration

## Testing
- `npm run format` *(fails: Missing script "format")*
- `npx ng test praxis-table --watch=false --browsers=ChromeHeadless` *(fails: TS errors during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_689ceaa04fe8832880f5ff7d68bd55fc