### PR TITLE
fix(praxis-table): persist filter config on apply and save

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.ts
@@ -528,14 +528,30 @@ export class PraxisFilter implements OnInit, OnChanges {
         this.applySchemaMetas();
       };
 
+      const persistConfig = (): void => {
+        this.filterConfig.save(this.configKey, {
+          quickField: this.quickField,
+          alwaysVisibleFields: this.alwaysVisibleFields,
+          placeholder: this.placeholder,
+          showAdvanced: this.advancedOpen,
+        });
+        console.log('PFILTER:config:save', {
+          quickField: this.quickField,
+          alwaysVisibleFields: this.alwaysVisibleFields,
+          placeholder: this.placeholder,
+          showAdvanced: this.advancedOpen,
+        });
+      };
+
       ref.applied$.subscribe((cfg: FilterConfig) => {
         applyChanges(cfg);
+        persistConfig();
         ref.close('apply');
       });
 
       ref.saved$.subscribe((cfg: FilterConfig) => {
         applyChanges(cfg);
-        this.saveConfig();
+        persistConfig();
       });
     } catch {
       // Intentionally ignore errors

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/open-filter-settings.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/open-filter-settings.spec.ts
@@ -1,11 +1,14 @@
-import { Subject } from 'rxjs';
+import { Subject, of } from 'rxjs';
 import { PraxisFilter } from '../praxis-filter';
 import { SettingsPanelService } from '@praxis/settings-panel';
-import { FilterConfigService, FilterConfig } from '../services/filter-config.service';
+import {
+  FilterConfigService,
+  FilterConfig,
+} from '../services/filter-config.service';
 import { GenericCrudService, ConfigStorage } from '@praxis/core';
 
 describe('PraxisFilter openSettings', () => {
-  it('should apply changes and persist on save', () => {
+  it('should apply changes and persist on apply and save', () => {
     const applied$ = new Subject<FilterConfig>();
     const saved$ = new Subject<FilterConfig>();
     const ref = { applied$, saved$, close: jasmine.createSpy('close') } as any;
@@ -32,7 +35,11 @@ describe('PraxisFilter openSettings', () => {
       settingsPanel,
     );
     (filter as any).configKey = 'f1';
-    (filter as any).schemaMetas = [];
+    (filter as any).schemaMetas = [
+      { name: 'cpf' } as any,
+      { name: 'age' } as any,
+      { name: 'name' } as any,
+    ];
     filter.quickField = 'cpf';
     filter.alwaysVisibleFields = ['age'];
 
@@ -47,8 +54,22 @@ describe('PraxisFilter openSettings', () => {
     applied$.next(newConfig);
     expect(filter.quickField).toBe('name');
     expect(filter.alwaysVisibleFields).toEqual(['age', 'cpf']);
+    expect(filter.quickFieldMeta?.name).toBe('name');
+    expect(filter.alwaysVisibleMetas.map((m) => m.name)).toEqual([
+      'age',
+      'cpf',
+    ]);
+    expect(filter.i18n!.searchPlaceholder).toBe('Buscar');
+    expect(filter.advancedOpen).toBeTrue();
     expect(ref.close).toHaveBeenCalled();
+    expect(filterConfig.save).toHaveBeenCalledWith('f1', {
+      quickField: 'name',
+      alwaysVisibleFields: ['age', 'cpf'],
+      placeholder: 'Buscar',
+      showAdvanced: true,
+    });
 
+    (filterConfig.save as jasmine.Spy).calls.reset();
     saved$.next({ quickField: 'id' });
     expect(filterConfig.save).toHaveBeenCalledWith('f1', {
       quickField: 'id',
@@ -56,5 +77,52 @@ describe('PraxisFilter openSettings', () => {
       placeholder: undefined,
       showAdvanced: false,
     });
+  });
+
+  it('should reapply saved config when reopened', () => {
+    const settingsPanel: SettingsPanelService = {
+      open: () => ({}) as any,
+    } as any;
+    const metas = [{ name: 'name' } as any, { name: 'age' } as any];
+    const filterConfig: FilterConfigService = {
+      save: () => {},
+      load: () => ({
+        quickField: 'name',
+        alwaysVisibleFields: ['age'],
+        placeholder: 'Buscar',
+        showAdvanced: true,
+      }),
+    } as any;
+    const crud = {
+      configure: () => {},
+      getFilteredSchema: () => of([]),
+      getSchema: () => of([]),
+    } as any;
+    const storage = {
+      loadConfig: () => undefined,
+      saveConfig: () => undefined,
+      clearConfig: () => {},
+    } as ConfigStorage;
+    const destroyRef = { onDestroy: () => {} } as any;
+
+    const filter = new PraxisFilter(
+      crud,
+      storage,
+      destroyRef,
+      filterConfig,
+      settingsPanel,
+    );
+    filter.resourcePath = '/test';
+    filter.formId = 'f1';
+    filter.ngOnInit();
+    (filter as any).schemaMetas = metas;
+    (filter as any).applySchemaMetas();
+
+    expect(filter.quickField).toBe('name');
+    expect(filter.alwaysVisibleFields).toEqual(['age']);
+    expect(filter.i18n!.searchPlaceholder).toBe('Buscar');
+    expect(filter.advancedOpen).toBeTrue();
+    expect(filter.quickFieldMeta?.name).toBe('name');
+    expect(filter.alwaysVisibleMetas.map((m) => m.name)).toEqual(['age']);
   });
 });


### PR DESCRIPTION
## Summary
- persist filter configuration when applying or saving filter settings
- immediately update filter placeholder, advanced state, and metadata
- add tests for config persistence and reload on reopen

## Testing
- `npx ng test praxis-table --watch=false` *(fails: TS errors in existing specs)*

------
https://chatgpt.com/codex/tasks/task_e_689ceccd87788328a32d07ebd1726bbb