### PR TITLE
docs: document table settings panel and extend tests

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/README.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/README.md
@@ -33,6 +33,23 @@ A biblioteca `@praxis/table` fornece um componente de tabela robusto e altamente
 - **Toolbar Editor**: Personalização de ações
 - **Messages Editor**: Textos e localização
 
+### ⚙️ Painel de Configurações
+
+Para abrir o painel de configurações, habilite o modo de edição na tabela:
+
+```html
+<praxis-table [editModeEnabled]="true"></praxis-table>
+```
+
+Um botão de engrenagem será exibido no canto superior direito. Ao clicar nele, o `SettingsPanel` é aberto permitindo ajustar:
+
+- **Comportamento**: paginação, ordenação, filtros e recursos avançados.
+- **Colunas**: visibilidade, ordem, largura e estilo.
+- **Toolbar**: ações e botões da barra de ferramentas.
+- **Mensagens**: textos e rótulos exibidos na interface.
+
+As alterações podem ser aplicadas temporariamente com **Aplicar** ou salvas de forma persistente com **Salvar & Fechar**.
+
 ## 🚀 Instalação
 
 ```bash

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.spec.ts
@@ -1,49 +1,83 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Injector } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FilterSettingsComponent } from './filter-settings.component';
+import { SettingsPanelComponent } from '@praxis/settings-panel';
+import { SettingsPanelRef } from '@praxis/settings-panel';
 import { FieldMetadata } from '@praxis/core';
 import { FilterConfig } from '../services/filter-config.service';
 
+class MockSettingsPanelRef {
+  apply = jasmine.createSpy('apply');
+  save = jasmine.createSpy('save');
+  reset = jasmine.createSpy('reset');
+  close = jasmine.createSpy('close');
+}
+
 describe('FilterSettingsComponent', () => {
-  let component: FilterSettingsComponent;
-  let fixture: ComponentFixture<FilterSettingsComponent>;
+  let fixture: ComponentFixture<SettingsPanelComponent>;
+  let panel: SettingsPanelComponent;
+  let ref: MockSettingsPanelRef;
 
   const metadata: FieldMetadata[] = [
     { name: 'name', label: 'Name', controlType: 'input' } as FieldMetadata,
     { name: 'status', label: 'Status', controlType: 'input' } as FieldMetadata,
   ];
 
-  const settings: FilterConfig = {
-    quickField: 'name',
-    alwaysVisibleFields: ['status'],
-    placeholder: 'Search',
-    showAdvanced: true,
-  };
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FilterSettingsComponent],
+      imports: [
+        SettingsPanelComponent,
+        FilterSettingsComponent,
+        NoopAnimationsModule,
+      ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(FilterSettingsComponent);
-    component = fixture.componentInstance;
-    component.metadata = metadata;
-    component.settings = settings;
+    fixture = TestBed.createComponent(SettingsPanelComponent);
+    panel = fixture.componentInstance;
+    ref = new MockSettingsPanelRef();
+
+    panel.attachContent(
+      FilterSettingsComponent,
+      TestBed.inject(Injector),
+      ref as unknown as SettingsPanelRef,
+    );
+    const instance = panel.contentRef!.instance as FilterSettingsComponent;
+    instance.metadata = metadata;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should render tabs', () => {
+    const labels = Array.from(
+      fixture.nativeElement.querySelectorAll('.mdc-tab__text-label'),
+    ).map((el: Element) => el.textContent?.trim());
+    expect(labels).toEqual(['Quick Field', 'Always Visible', 'Options']);
   });
 
-  it('should return settings from form', () => {
-    const value = component.getSettingsValue();
-    expect(value).toEqual(settings);
+  it('should emit settings value on save', () => {
+    const instance = panel.contentRef!.instance as FilterSettingsComponent;
+    instance.form.patchValue({ quickField: 'name', placeholder: 'Buscar' });
+    fixture.detectChanges();
+
+    panel.onSave();
+
+    expect(ref.save).toHaveBeenCalledWith({
+      quickField: 'name',
+      alwaysVisibleFields: [],
+      placeholder: 'Buscar',
+      showAdvanced: false,
+    } as FilterConfig);
   });
 
-  it('should reset to initial settings', () => {
-    component.form.patchValue({ quickField: 'status', placeholder: 'X' });
-    component.reset();
-    const value = component.getSettingsValue();
-    expect(value).toEqual(settings);
+  it('should enable and disable save button based on canSave$', () => {
+    const saveBtn: HTMLButtonElement = fixture.nativeElement.querySelector(
+      'button[color="primary"]',
+    );
+    expect(saveBtn.disabled).toBeTrue();
+
+    const instance = panel.contentRef!.instance as FilterSettingsComponent;
+    instance.form.patchValue({ placeholder: 'X' });
+    fixture.detectChanges();
+    expect(saveBtn.disabled).toBeFalse();
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.ts
@@ -19,6 +19,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { FieldMetadata } from '@praxis/core';
 import { FilterConfig } from '../services/filter-config.service';
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
 
 @Component({
   selector: 'filter-settings',
@@ -47,6 +49,11 @@ export class FilterSettingsComponent implements OnChanges {
     showAdvanced: FormControl<boolean>;
   }>;
 
+  /**
+   * Emits true when form has changes and is valid, enabling the save button
+   */
+  canSave$: Observable<boolean>;
+
   private initialSettings: FilterConfig = {};
 
   constructor(private fb: FormBuilder) {
@@ -56,6 +63,11 @@ export class FilterSettingsComponent implements OnChanges {
       placeholder: this.fb.control<string>(''),
       showAdvanced: this.fb.control<boolean>(false),
     });
+
+    this.canSave$ = this.form.valueChanges.pipe(
+      map(() => this.form.dirty && this.form.valid),
+      startWith(false),
+    );
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.spec.ts
@@ -5,14 +5,17 @@ import {
   tick,
 } from '@angular/core/testing';
 import { Component, SimpleChange, ViewChild } from '@angular/core';
-import { of, throwError } from 'rxjs';
+import { of, throwError, Subject } from 'rxjs';
 import {
   GenericCrudService,
   ConfigStorage,
   CONFIG_STORAGE,
 } from '@praxis/core';
 import { PraxisFilter, I18n, FilterTag } from './praxis-filter';
-import { FilterConfigService } from './services/filter-config.service';
+import {
+  FilterConfigService,
+  FilterConfig,
+} from './services/filter-config.service';
 import { SettingsPanelService } from '@praxis/settings-panel';
 
 describe('PraxisFilter', () => {
@@ -453,5 +456,29 @@ describe('PraxisFilter', () => {
     component.clear.subscribe(clearSpy);
     card.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it('should open settings panel and apply configuration', () => {
+    createComponent();
+
+    const applied$ = new Subject<FilterConfig>();
+    const ref = { applied$, close: jasmine.createSpy('close') } as any;
+    settingsPanel.open.and.returnValue(ref);
+
+    component.openSettings();
+
+    expect(settingsPanel.open).toHaveBeenCalled();
+
+    applied$.next({
+      quickField: 'name',
+      alwaysVisibleFields: ['status'],
+      placeholder: 'Buscar',
+      showAdvanced: true,
+    });
+
+    expect(component.quickField).toBe('name');
+    expect(component.alwaysVisibleFields).toEqual(['status']);
+    expect(component.advancedOpen).toBeTrue();
+    expect(ref.close).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- document how to open and use the table settings panel
- add canSave$ support and tests for FilterSettingsComponent
- test PraxisFilter settings panel integration

## Testing
- `npx ng test praxis-settings-panel --watch=false` *(fails: No binary for Chrome browser)*
- `npx ng test praxis-table --watch=false` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cefab4b788328b6849461d2d7e4c7