### PR TITLE
test: add filter settings tests and docs

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/README.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/README.md
@@ -668,6 +668,25 @@ onFilter(dto: any) {
 }
 ```
 
+### ⚙️ Painel de Configurações do Filtro
+
+O `PraxisFilter` possui um painel de configurações acessível pelo ícone de
+engrenagem na barra do filtro ou programaticamente através do método
+`openSettings()`. Nesse painel é possível ajustar:
+
+- **quickField** – campo utilizado para a busca rápida
+- **alwaysVisibleFields** – campos que permanecem sempre visíveis
+- **placeholder** – texto exibido no campo de busca
+- **showAdvanced** – define se a seção avançada inicia aberta
+
+```ts
+@ViewChild(PraxisFilter) filter!: PraxisFilter;
+
+abrirConfiguracoes() {
+  this.filter.openSettings();
+}
+```
+
 ## 📊 Roadmap
 
 ### Próximas Versões

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.spec.ts
@@ -2,11 +2,58 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FilterSettingsComponent } from './filter-settings.component';
 import { FieldMetadata } from '@praxis/core';
 import { FilterConfig } from '../services/filter-config.service';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { BehaviorSubject } from 'rxjs';
+import {
+  SettingsPanelComponent,
+  SettingsPanelRef,
+} from '@praxis/settings-panel';
+import {
+  Injector,
+  Component,
+  ChangeDetectionStrategy,
+  SimpleChange,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+
+class MockSettingsPanelRef {
+  apply = jasmine.createSpy('apply');
+  save = jasmine.createSpy('save');
+  reset = jasmine.createSpy('reset');
+  close = jasmine.createSpy('close');
+}
+
+@Component({
+  selector: 'test-filter-settings',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './filter-settings.component.html',
+  styleUrls: ['./filter-settings.component.scss'],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatTabsModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatInputModule,
+    MatCheckboxModule,
+  ],
+})
+class TestFilterSettingsComponent extends FilterSettingsComponent {
+  canSave$ = new BehaviorSubject<boolean>(false);
+
+  constructor(fb: FormBuilder) {
+    super(fb);
+  }
+}
 
 describe('FilterSettingsComponent', () => {
-  let component: FilterSettingsComponent;
-  let fixture: ComponentFixture<FilterSettingsComponent>;
-
   const metadata: FieldMetadata[] = [
     { name: 'name', label: 'Name', controlType: 'input' } as FieldMetadata,
     { name: 'status', label: 'Status', controlType: 'input' } as FieldMetadata,
@@ -16,34 +63,77 @@ describe('FilterSettingsComponent', () => {
     quickField: 'name',
     alwaysVisibleFields: ['status'],
     placeholder: 'Search',
-    showAdvanced: true,
+    showAdvanced: false,
   };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FilterSettingsComponent],
+      imports: [
+        FilterSettingsComponent,
+        TestFilterSettingsComponent,
+        SettingsPanelComponent,
+        NoopAnimationsModule,
+      ],
     }).compileComponents();
+  });
 
-    fixture = TestBed.createComponent(FilterSettingsComponent);
-    component = fixture.componentInstance;
+  it('should render all tabs', () => {
+    const fixture = TestBed.createComponent(FilterSettingsComponent);
+    const component = fixture.componentInstance;
     component.metadata = metadata;
     component.settings = settings;
+    component.ngOnChanges({
+      settings: new SimpleChange(null, settings, true),
+    });
     fixture.detectChanges();
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Quick Field');
+    expect(text).toContain('Always Visible');
+    expect(text).toContain('Options');
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should emit settings value on apply', () => {
+    const fixture = TestBed.createComponent(SettingsPanelComponent);
+    const panel = fixture.componentInstance;
+    const ref = new MockSettingsPanelRef();
+    panel.attachContent(
+      TestFilterSettingsComponent,
+      TestBed.inject(Injector),
+      ref as unknown as SettingsPanelRef,
+    );
+    const content = panel.contentRef!.instance as TestFilterSettingsComponent;
+    content.metadata = metadata;
+    content.settings = settings;
+    content.ngOnChanges({
+      settings: new SimpleChange(null, settings, true),
+    });
+    content.form.patchValue({ placeholder: 'Buscar' });
+    panel.onApply();
+    expect(ref.apply).toHaveBeenCalledWith({
+      quickField: 'name',
+      alwaysVisibleFields: ['status'],
+      placeholder: 'Buscar',
+      showAdvanced: false,
+    });
   });
 
-  it('should return settings from form', () => {
-    const value = component.getSettingsValue();
-    expect(value).toEqual(settings);
-  });
-
-  it('should reset to initial settings', () => {
-    component.form.patchValue({ quickField: 'status', placeholder: 'X' });
-    component.reset();
-    const value = component.getSettingsValue();
-    expect(value).toEqual(settings);
+  it('should toggle save button based on canSave$', () => {
+    const fixture = TestBed.createComponent(SettingsPanelComponent);
+    const panel = fixture.componentInstance;
+    const ref = new MockSettingsPanelRef();
+    panel.attachContent(
+      TestFilterSettingsComponent,
+      TestBed.inject(Injector),
+      ref as unknown as SettingsPanelRef,
+    );
+    fixture.detectChanges();
+    const content = panel.contentRef!.instance as TestFilterSettingsComponent;
+    const saveBtn: HTMLButtonElement = fixture.nativeElement.querySelector(
+      'footer button[color="primary"]',
+    );
+    expect(saveBtn.disabled).toBeTrue();
+    content.canSave$.next(true);
+    fixture.detectChanges();
+    expect(saveBtn.disabled).toBeFalse();
   });
 });


### PR DESCRIPTION
## Summary
- document filter settings panel usage and options in @praxis/table README
- add comprehensive tests for filter settings component including save button state
- simulate settings panel flow in PraxisFilter tests

## Testing
- `ng test praxis-settings-panel` *(fails: Chrome not found)*
- `ng test praxis-table` *(fails: TypeScript compile errors; see log)*

------
https://chatgpt.com/codex/tasks/task_e_689cefb20f44832882364d78a588885e