### PR TITLE
feat: validate filter settings and feedback

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/README.md
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/README.md
@@ -704,6 +704,11 @@ abrirConfiguracoes() {
 }
 ```
 
+Ao aplicar ou salvar, as escolhas são validadas contra os metadados
+disponíveis. O componente exibe uma barra de progresso durante o processo
+de persistência e mensagens de sucesso ou erro via _snack bar_, garantindo
+uma experiência consistente.
+
 ## 📊 Roadmap
 
 ### Próximas Versões

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.ts
@@ -59,9 +59,9 @@ export class FilterSettingsComponent implements OnChanges {
   constructor(private fb: FormBuilder) {
     this.form = this.fb.group({
       quickField: this.fb.control<string | null>(null),
-      alwaysVisibleFields: this.fb.control<string[]>([]),
-      placeholder: this.fb.control<string>(''),
-      showAdvanced: this.fb.control<boolean>(false),
+      alwaysVisibleFields: this.fb.nonNullable.control<string[]>([]),
+      placeholder: this.fb.nonNullable.control(''),
+      showAdvanced: this.fb.nonNullable.control(false),
     });
 
     this.canSave$ = this.form.valueChanges.pipe(
@@ -84,10 +84,18 @@ export class FilterSettingsComponent implements OnChanges {
 
   getSettingsValue(): FilterConfig {
     const value = this.form.getRawValue();
+    const names = new Set(this.metadata.map((m) => m.name));
+    const quickField =
+      value.quickField && names.has(value.quickField)
+        ? value.quickField
+        : undefined;
+    const alwaysVisibleFields = value.alwaysVisibleFields.filter((f) =>
+      names.has(f),
+    );
     return {
-      quickField: value.quickField ?? undefined,
-      alwaysVisibleFields: value.alwaysVisibleFields?.length
-        ? value.alwaysVisibleFields
+      quickField,
+      alwaysVisibleFields: alwaysVisibleFields.length
+        ? alwaysVisibleFields
         : undefined,
       placeholder: value.placeholder || undefined,
       showAdvanced: value.showAdvanced ?? undefined,

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/open-filter-settings.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/open-filter-settings.spec.ts
@@ -6,6 +6,7 @@ import {
   FilterConfig,
 } from '../services/filter-config.service';
 import { GenericCrudService, ConfigStorage } from '@praxis/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 describe('PraxisFilter openSettings', () => {
   it('should apply changes and persist on apply and save', () => {
@@ -33,6 +34,7 @@ describe('PraxisFilter openSettings', () => {
       destroyRef,
       filterConfig,
       settingsPanel,
+      { open: () => {} } as MatSnackBar,
     );
     (filter as any).configKey = 'f1';
     (filter as any).schemaMetas = [
@@ -111,6 +113,7 @@ describe('PraxisFilter openSettings', () => {
       destroyRef,
       filterConfig,
       settingsPanel,
+      { open: () => {} } as MatSnackBar,
     );
     filter.resourcePath = '/test';
     filter.formId = 'f1';


### PR DESCRIPTION
## Summary
- validate filter settings against schema metadata before persisting
- show progress bar and snack-bar messages when saving filter configuration
- document configuration workflow for PraxisFilter

## Testing
- `npm run ng -- test praxis-table` *(fails: TS2339 Property 'onMigrateToV2' does not exist on type 'PraxisTableConfigEditor', and others)*

------
https://chatgpt.com/codex/tasks/task_e_689cde989b90832882d108498faf21ab