### PR TITLE
feat(table): auto render praxis filter

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/advanced-filter-toggle.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/advanced-filter-toggle.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { PraxisTable } from '../praxis-table';
+import {
+  TableConfig,
+  TableConfigService,
+  CONFIG_STORAGE,
+  ConfigStorage,
+  GenericCrudService,
+} from '@praxis/core';
+import { SettingsPanelService } from '@praxis/settings-panel';
+import { FilterConfigService } from '../services/filter-config.service';
+
+describe('PraxisTable advanced filter integration', () => {
+  let fixture: ComponentFixture<PraxisTable>;
+  let component: PraxisTable;
+  let crud: jasmine.SpyObj<GenericCrudService<any>>;
+  let storage: jasmine.SpyObj<ConfigStorage>;
+  let settingsPanel: jasmine.SpyObj<SettingsPanelService>;
+
+  beforeEach(async () => {
+    crud = jasmine.createSpyObj('GenericCrudService', [
+      'configure',
+      'filter',
+      'getFilteredSchema',
+      'getSchema',
+    ]);
+    crud.filter.and.returnValue(
+      of({
+        content: [],
+        totalElements: 0,
+        totalPages: 0,
+        pageNumber: 0,
+        pageSize: 0,
+      }),
+    );
+    crud.getFilteredSchema.and.returnValue(of([]));
+    crud.getSchema.and.returnValue(of([]));
+
+    storage = jasmine.createSpyObj('ConfigStorage', [
+      'loadConfig',
+      'saveConfig',
+      'clearConfig',
+    ]);
+    settingsPanel = jasmine.createSpyObj('SettingsPanelService', ['open']);
+
+    await TestBed.configureTestingModule({
+      imports: [PraxisTable, NoopAnimationsModule],
+      providers: [
+        TableConfigService,
+        FilterConfigService,
+        { provide: GenericCrudService, useValue: crud },
+        { provide: CONFIG_STORAGE, useValue: storage },
+        { provide: SettingsPanelService, useValue: settingsPanel },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PraxisTable);
+    component = fixture.componentInstance;
+    component.resourcePath = '/test';
+    component.showToolbar = true;
+  });
+
+  function setConfig(advancedEnabled: boolean): void {
+    const config: TableConfig = {
+      columns: [],
+      behavior: {
+        filtering: {
+          enabled: true,
+          strategy: 'client',
+          debounceTime: 0,
+          advancedFilters: { enabled: advancedEnabled },
+        },
+      },
+    } as TableConfig;
+    component.config = config;
+  }
+
+  it('should render PraxisFilter when advanced filters are enabled', () => {
+    setConfig(true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('praxis-filter')).toBeTruthy();
+  });
+
+  it('should not render PraxisFilter when advanced filters are disabled', () => {
+    setConfig(false);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('praxis-filter')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary
- auto render `PraxisFilter` in `PraxisTable` when advanced filters enabled
- derive toolbar search visibility from table config and avoid duplicate filters
- add tests for enabling/disabling advanced filter

## Testing
- `npx ng test praxis-table --watch=false --browsers=ChromeHeadless` *(fails: TypeScript errors in existing spec files)*

------
https://chatgpt.com/codex/tasks/task_e_689cfce23e0c83288ed62f91015eee8c