### PR TITLE
fix: restore form config typing

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/form/form-layout.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/form/form-layout.model.ts
@@ -1,13 +1,39 @@
+export interface FormActionButton {
+  visible: boolean;
+  label: string;
+}
+
 export interface FormActionsLayout {
+  /**
+   * Configuration for the submit button
+   */
+  submit: FormActionButton;
+
+  /**
+   * Configuration for the cancel button
+   */
+  cancel: FormActionButton;
+
+  /**
+   * Configuration for the reset button
+   */
+  reset: FormActionButton;
+
+  /**
+   * Button group positioning
+   */
+  position?: 'left' | 'center' | 'right' | 'justified';
+
+  containerClassName?: string;
+  containerStyles?: { [key: string]: any };
+
+  // Legacy properties for backward compatibility
   showSaveButton?: boolean;
   submitButtonLabel?: string;
   showCancelButton?: boolean;
   cancelButtonLabel?: string;
   showResetButton?: boolean;
   resetButtonLabel?: string;
-  position?: 'left' | 'center' | 'right' | 'justified';
-  containerClassName?: string;
-  containerStyles?: { [key: string]: any };
 }
 
 export interface FormApiLayout {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/actions-editor/actions-editor.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/actions-editor/actions-editor.component.spec.ts
@@ -10,7 +10,7 @@ describe('ActionsEditorComponent', () => {
 
   const mockConfig: FormConfig = {
     fieldMetadata: [],
-    layout: { sections: [] },
+    sections: [],
     actions: {
       submit: { visible: true, label: 'Enviar' },
       cancel: { visible: false, label: 'Voltar' },
@@ -39,7 +39,11 @@ describe('ActionsEditorComponent', () => {
     const slideToggle = fixture.nativeElement.querySelector('mat-slide-toggle'); // First toggle is 'submit'
     slideToggle.click();
     fixture.detectChanges();
-    expect(component.updateAction).toHaveBeenCalledWith('submit', 'visible', false);
+    expect(component.updateAction).toHaveBeenCalledWith(
+      'submit',
+      'visible',
+      false,
+    );
   });
 
   it('should call updateAction on label change', () => {
@@ -48,7 +52,11 @@ describe('ActionsEditorComponent', () => {
     labelInput.value = 'Salvar';
     labelInput.dispatchEvent(new Event('input'));
     fixture.detectChanges();
-    expect(component.updateAction).toHaveBeenCalledWith('submit', 'label', 'Salvar');
+    expect(component.updateAction).toHaveBeenCalledWith(
+      'submit',
+      'label',
+      'Salvar',
+    );
   });
 
   it('should call updateLayout on position change', () => {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/actions-editor/actions-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/actions-editor/actions-editor.component.ts
@@ -5,7 +5,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSelectModule } from '@angular/material/select';
-import { FormConfig, FormActionsLayout } from '@praxis/core';
+import { FormConfig, FormActionsLayout, FormActionButton } from '@praxis/core';
 
 @Component({
   selector: 'praxis-actions-editor',
@@ -43,21 +43,36 @@ import { FormConfig, FormActionsLayout } from '@praxis/core';
       <h4>Labels dos Botões</h4>
       <mat-form-field>
         <mat-label>Label de Submeter</mat-label>
-        <input matInput [value]="actions.submit.label" (input)="updateAction('submit', 'label', $event.target.value)" />
+        <input
+          matInput
+          [value]="actions.submit.label"
+          (input)="updateAction('submit', 'label', $event.target instanceof HTMLInputElement ? $event.target.value : '')"
+        />
       </mat-form-field>
       <mat-form-field>
         <mat-label>Label de Cancelar</mat-label>
-        <input matInput [value]="actions.cancel.label" (input)="updateAction('cancel', 'label', $event.target.value)" />
+        <input
+          matInput
+          [value]="actions.cancel.label"
+          (input)="updateAction('cancel', 'label', $event.target instanceof HTMLInputElement ? $event.target.value : '')"
+        />
       </mat-form-field>
       <mat-form-field>
         <mat-label>Label de Resetar</mat-label>
-        <input matInput [value]="actions.reset.label" (input)="updateAction('reset', 'label', $event.target.value)" />
+        <input
+          matInput
+          [value]="actions.reset.label"
+          (input)="updateAction('reset', 'label', $event.target instanceof HTMLInputElement ? $event.target.value : '')"
+        />
       </mat-form-field>
 
       <h4>Posicionamento</h4>
       <mat-form-field>
         <mat-label>Alinhamento dos Botões</mat-label>
-        <mat-select [value]="actions.position" (selectionChange)="updateLayout('position', $event.value)">
+        <mat-select
+          [value]="actions.position"
+          (selectionChange)="updateLayout('position', $event.value)"
+        >
           <mat-option value="left">Esquerda</mat-option>
           <mat-option value="center">Centro</mat-option>
           <mat-option value="right">Direita</mat-option>
@@ -66,39 +81,48 @@ import { FormConfig, FormActionsLayout } from '@praxis/core';
       </mat-form-field>
     </div>
   `,
-  styles: [`
-    .actions-editor-form {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
-  `]
+  styles: [
+    `
+      .actions-editor-form {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+    `,
+  ],
 })
 export class ActionsEditorComponent {
   @Input() config!: FormConfig;
   @Output() configChange = new EventEmitter<FormConfig>();
 
   get actions(): FormActionsLayout {
-    return this.config.actions || {
-      submit: { visible: true, label: 'Submit' },
-      cancel: { visible: true, label: 'Cancel' },
-      reset: { visible: false, label: 'Reset' },
-      position: 'right',
-    };
+    return (
+      this.config.actions || {
+        submit: { visible: true, label: 'Submit' },
+        cancel: { visible: true, label: 'Cancel' },
+        reset: { visible: false, label: 'Reset' },
+        position: 'right',
+      }
+    );
   }
 
-  updateAction(button: 'submit' | 'cancel' | 'reset', key: 'visible' | 'label', value: any) {
+  updateAction(
+    button: 'submit' | 'cancel' | 'reset',
+    key: keyof FormActionButton,
+    value: any,
+  ) {
     const newConfig = {
       ...this.config,
       actions: {
         ...this.actions,
         [button]: {
           ...this.actions[button],
-          [key]: value
-        }
-      }
+          [key]: value,
+        } as FormActionButton,
+      },
     };
-    this.configChange.emit(newConfig);
+    this.config = newConfig;
+    this.configChange.emit(this.config);
   }
 
   updateLayout(key: 'position', value: any) {
@@ -106,9 +130,10 @@ export class ActionsEditorComponent {
       ...this.config,
       actions: {
         ...this.actions,
-        [key]: value
-      }
+        [key]: value,
+      },
     };
-    this.configChange.emit(newConfig);
+    this.config = newConfig;
+    this.configChange.emit(this.config);
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/behavior-editor/behavior-editor.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/behavior-editor/behavior-editor.component.spec.ts
@@ -11,7 +11,7 @@ describe('BehaviorEditorComponent', () => {
 
   const mockConfig: FormConfig = {
     fieldMetadata: [],
-    layout: { sections: [] },
+    sections: [],
     behavior: {
       confirmOnUnsavedChanges: true,
       trackHistory: false,
@@ -20,7 +20,12 @@ describe('BehaviorEditorComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [BehaviorEditorComponent, NoopAnimationsModule, FormsModule, MatSlideToggleModule],
+      imports: [
+        BehaviorEditorComponent,
+        NoopAnimationsModule,
+        FormsModule,
+        MatSlideToggleModule,
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BehaviorEditorComponent);
@@ -34,11 +39,16 @@ describe('BehaviorEditorComponent', () => {
   });
 
   it('should reflect initial config in slide toggles', () => {
-    const slideToggles = fixture.nativeElement.querySelectorAll('mat-slide-toggle');
+    const slideToggles =
+      fixture.nativeElement.querySelectorAll('mat-slide-toggle');
     // confirmOnUnsavedChanges is true
-    expect(slideToggles[0].classList.contains('mat-mdc-slide-toggle-checked')).toBe(true);
+    expect(
+      slideToggles[0].classList.contains('mat-mdc-slide-toggle-checked'),
+    ).toBe(true);
     // trackHistory is false
-    expect(slideToggles[1].classList.contains('mat-mdc-slide-toggle-checked')).toBe(false);
+    expect(
+      slideToggles[1].classList.contains('mat-mdc-slide-toggle-checked'),
+    ).toBe(false);
   });
 
   it('should call updateBehavior on toggle change', () => {
@@ -46,7 +56,10 @@ describe('BehaviorEditorComponent', () => {
     const slideToggle = fixture.nativeElement.querySelector('mat-slide-toggle');
     slideToggle.click();
     fixture.detectChanges();
-    expect(component.updateBehavior).toHaveBeenCalledWith('confirmOnUnsavedChanges', false);
+    expect(component.updateBehavior).toHaveBeenCalledWith(
+      'confirmOnUnsavedChanges',
+      false,
+    );
   });
 
   it('should update config and emit change on updateBehavior call', () => {
@@ -59,12 +72,16 @@ describe('BehaviorEditorComponent', () => {
   it('should update redirect URL from input', () => {
     spyOn(component, 'updateBehavior').and.callThrough();
     spyOn(component.configChange, 'emit');
-    const redirectInput = fixture.nativeElement.querySelector('input[matInput]');
+    const redirectInput =
+      fixture.nativeElement.querySelector('input[matInput]');
     redirectInput.value = '/success';
     redirectInput.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 
-    expect(component.updateBehavior).toHaveBeenCalledWith('redirectAfterSave', '/success');
+    expect(component.updateBehavior).toHaveBeenCalledWith(
+      'redirectAfterSave',
+      '/success',
+    );
     expect(component.config.behavior?.redirectAfterSave).toBe('/success');
     expect(component.configChange.emit).toHaveBeenCalled();
   });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/behavior-editor/behavior-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/behavior-editor/behavior-editor.component.ts
@@ -58,18 +58,20 @@ import { FormConfig, FormBehaviorLayout } from '@praxis/core';
         <input
           matInput
           [value]="behavior.redirectAfterSave || ''"
-          (input)="updateBehavior('redirectAfterSave', ($event.target as HTMLInputElement).value)"
+          (input)="updateBehavior('redirectAfterSave', $event.target instanceof HTMLInputElement ? $event.target.value : '')"
         />
       </mat-form-field>
     </div>
   `,
-  styles: [`
-    .behavior-editor-form {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
-  `]
+  styles: [
+    `
+      .behavior-editor-form {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+    `,
+  ],
 })
 export class BehaviorEditorComponent {
   @Input() config!: FormConfig;
@@ -87,6 +89,7 @@ export class BehaviorEditorComponent {
         [key]: value,
       },
     };
-    this.configChange.emit(newConfig);
+    this.config = newConfig;
+    this.configChange.emit(this.config);
   }
 }

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/layout-editor/layout-editor.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/layout-editor/layout-editor.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { FormConfig } from '@praxis/core';
+import { FormConfig, FieldControlType } from '@praxis/core';
 import { LayoutEditorComponent } from './layout-editor.component';
 
 describe('LayoutEditorComponent', () => {
@@ -10,24 +10,22 @@ describe('LayoutEditorComponent', () => {
 
   const mockConfig: FormConfig = {
     fieldMetadata: [
-      { name: 'field1', controlType: 'text' },
-      { name: 'field2', controlType: 'text' },
-      { name: 'field3', controlType: 'text' },
+      { name: 'field1', label: 'field1', controlType: FieldControlType.INPUT },
+      { name: 'field2', label: 'field2', controlType: FieldControlType.INPUT },
+      { name: 'field3', label: 'field3', controlType: FieldControlType.INPUT },
     ],
-    layout: {
-      sections: [
-        {
-          id: 's1',
-          title: 'Section 1',
-          rows: [{ columns: [{ fields: ['field1'] }] }],
-        },
-        {
-          id: 's2',
-          title: 'Section 2',
-          rows: [{ columns: [{ fields: ['field2'] }] }],
-        },
-      ],
-    },
+    sections: [
+      {
+        id: 's1',
+        title: 'Section 1',
+        rows: [{ columns: [{ fields: ['field1'] }] }],
+      },
+      {
+        id: 's2',
+        title: 'Section 2',
+        rows: [{ columns: [{ fields: ['field2'] }] }],
+      },
+    ],
   };
 
   beforeEach(async () => {
@@ -47,25 +45,29 @@ describe('LayoutEditorComponent', () => {
 
   it('should add a new section and emit configChange', () => {
     spyOn(component.configChange, 'emit');
-    const initialSections = component.config.layout.sections.length;
+    const initialSections = component.config.sections.length;
 
     component.addSection();
 
     expect(component.configChange.emit).toHaveBeenCalled();
-    const newConfig = (component.configChange.emit as jasmine.Spy).calls.mostRecent().args[0];
-    expect(newConfig.layout.sections.length).toBe(initialSections + 1);
+    const newConfig = (
+      component.configChange.emit as jasmine.Spy
+    ).calls.mostRecent().args[0];
+    expect(newConfig.sections.length).toBe(initialSections + 1);
   });
 
   it('should remove a section and emit configChange', () => {
     spyOn(component.configChange, 'emit');
-    const initialSections = component.config.layout.sections.length;
+    const initialSections = component.config.sections.length;
 
     component.removeSection(0);
 
     expect(component.configChange.emit).toHaveBeenCalled();
-    const newConfig = (component.configChange.emit as jasmine.Spy).calls.mostRecent().args[0];
-    expect(newConfig.layout.sections.length).toBe(initialSections - 1);
-    expect(newConfig.layout.sections[0].id).toBe('s2');
+    const newConfig = (
+      component.configChange.emit as jasmine.Spy
+    ).calls.mostRecent().args[0];
+    expect(newConfig.sections.length).toBe(initialSections - 1);
+    expect(newConfig.sections[0].id).toBe('s2');
   });
 
   it('should correctly calculate available fields', () => {
@@ -75,7 +77,7 @@ describe('LayoutEditorComponent', () => {
   });
 
   it('should return empty availableFields when all are placed', () => {
-    component.config.layout.sections[0].rows[0].columns[0].fields.push('field3');
+    component.config.sections[0].rows[0].columns[0].fields.push('field3');
     fixture.detectChanges();
     const available = component.availableFields;
     expect(available.length).toBe(0);

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/layout-editor/row-configurator.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/layout-editor/row-configurator.component.ts
@@ -1,8 +1,18 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { CdkDragDrop, DragDropModule, moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
+import {
+  CdkDragDrop,
+  DragDropModule,
+  moveItemInArray,
+  transferArrayItem,
+} from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { FieldConfiguratorComponent } from './field-configurator.component';
-import { FormRow, FormColumn, FieldMetadata } from '@praxis/core';
+import {
+  FormRow,
+  FormColumn,
+  FieldMetadata,
+  FieldControlType,
+} from '@praxis/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 
@@ -19,16 +29,24 @@ import { MatIconModule } from '@angular/material/icon';
   template: `
     <div class="row-container">
       <div class="row">
-        <div *ngFor="let column of row.columns; let i = index" class="column"
-             [id]="'column-' + i"
-             cdkDropList
-             [cdkDropListData]="column.fields"
-             (cdkDropListDropped)="drop($event)">
-          <praxis-field-configurator *ngFor="let fieldName of column.fields"
+        <div
+          *ngFor="let column of row.columns; let i = index"
+          class="column"
+          [id]="'column-' + i"
+          cdkDropList
+          [cdkDropListData]="column.fields"
+          (cdkDropListDropped)="drop($event)"
+        >
+          <praxis-field-configurator
+            *ngFor="let fieldName of column.fields"
             [field]="getFieldByName(fieldName)"
             cdkDrag
           ></praxis-field-configurator>
-          <button mat-icon-button (click)="removeColumn(i)" class="remove-column-btn">
+          <button
+            mat-icon-button
+            (click)="removeColumn(i)"
+            class="remove-column-btn"
+          >
             <mat-icon>delete_forever</mat-icon>
           </button>
         </div>
@@ -43,12 +61,29 @@ import { MatIconModule } from '@angular/material/icon';
       </div>
     </div>
   `,
-  styles: [`
-    .row-container { display: flex; align-items: center; }
-    .row { display: flex; flex-grow: 1; }
-    .column { flex: 1; border: 1px dashed #ccc; margin: 4px; padding: 4px; min-height: 50px; }
-    .row-actions { display: flex; flex-direction: column; }
-  `]
+  styles: [
+    `
+      .row-container {
+        display: flex;
+        align-items: center;
+      }
+      .row {
+        display: flex;
+        flex-grow: 1;
+      }
+      .column {
+        flex: 1;
+        border: 1px dashed #ccc;
+        margin: 4px;
+        padding: 4px;
+        min-height: 50px;
+      }
+      .row-actions {
+        display: flex;
+        flex-direction: column;
+      }
+    `,
+  ],
 })
 export class RowConfiguratorComponent {
   @Input() row!: FormRow;
@@ -57,22 +92,35 @@ export class RowConfiguratorComponent {
   @Output() remove = new EventEmitter<void>();
 
   getFieldByName(fieldName: string): FieldMetadata {
-    return this.fieldMetadata.find(f => f.name === fieldName) || { name: fieldName, controlType: 'text' };
+    return (
+      this.fieldMetadata.find((f) => f.name === fieldName) || {
+        name: fieldName,
+        label: fieldName,
+        controlType: FieldControlType.INPUT,
+      }
+    );
   }
 
   drop(event: CdkDragDrop<string[], any, string>) {
-    const columns = this.row.columns.map(c => ({ ...c, fields: [...c.fields] }));
+    const columns = this.row.columns.map((c) => ({
+      ...c,
+      fields: [...c.fields],
+    }));
     const previousColumnIndex = this.getColumnIndex(event.previousContainer.id);
     const currentColumnIndex = this.getColumnIndex(event.container.id);
 
     if (event.previousContainer === event.container) {
-      moveItemInArray(columns[currentColumnIndex].fields, event.previousIndex, event.currentIndex);
+      moveItemInArray(
+        columns[currentColumnIndex].fields,
+        event.previousIndex,
+        event.currentIndex,
+      );
     } else {
       transferArrayItem(
         columns[previousColumnIndex].fields,
         columns[currentColumnIndex].fields,
         event.previousIndex,
-        event.currentIndex
+        event.currentIndex,
       );
     }
     this.rowChange.emit({ ...this.row, columns });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/messages-editor/messages-editor.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/messages-editor/messages-editor.component.spec.ts
@@ -10,7 +10,7 @@ describe('MessagesEditorComponent', () => {
 
   const mockConfig: FormConfig = {
     fieldMetadata: [],
-    layout: { sections: [] },
+    sections: [],
     messages: {
       createRegistrySuccess: 'Created!',
       createRegistryError: 'Failed to create.',
@@ -38,7 +38,10 @@ describe('MessagesEditorComponent', () => {
     input.value = 'Success!';
     input.dispatchEvent(new Event('input'));
     fixture.detectChanges();
-    expect(component.updateMessage).toHaveBeenCalledWith('createRegistrySuccess', 'Success!');
+    expect(component.updateMessage).toHaveBeenCalledWith(
+      'createRegistrySuccess',
+      'Success!',
+    );
   });
 
   it('should emit configChange on update', () => {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/rules-editor/rules-editor.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/rules-editor/rules-editor.component.spec.ts
@@ -10,10 +10,8 @@ describe('RulesEditorComponent', () => {
 
   const mockConfig: FormConfig = {
     fieldMetadata: [],
-    layout: { sections: [] },
-    formRules: {
-      field1: { visibleWhen: { field2: 'value' } },
-    },
+    sections: [],
+    formRules: { field1: { visibleWhen: { field2: 'value' } } } as any,
   };
 
   beforeEach(async () => {
@@ -32,7 +30,9 @@ describe('RulesEditorComponent', () => {
   });
 
   it('should initialize with stringified rules', () => {
-    expect(component.rulesAsString).toBe(JSON.stringify(mockConfig.formRules, null, 2));
+    expect(component.rulesAsString).toBe(
+      JSON.stringify(mockConfig.formRules, null, 2),
+    );
   });
 
   it('should update config on valid JSON change', () => {
@@ -42,9 +42,11 @@ describe('RulesEditorComponent', () => {
     component.onRulesChange(newRulesString);
 
     const expectedConfig = { ...mockConfig, formRules: newRules };
-    expect(component.configChange.emit).toHaveBeenCalledWith(jasmine.objectContaining({
-      formRules: newRules
-    }));
+    expect(component.configChange.emit).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        formRules: newRules,
+      }),
+    );
     expect(component.parsingError).toBeNull();
   });
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/rules-editor/rules-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/rules-editor/rules-editor.component.ts
@@ -8,20 +8,16 @@ import { FormConfig } from '@praxis/core';
 @Component({
   selector: 'praxis-rules-editor',
   standalone: true,
-  imports: [
-    CommonModule,
-    FormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-  ],
+  imports: [CommonModule, FormsModule, MatFormFieldModule, MatInputModule],
   template: `
     <div class="rules-editor-form">
       <p>Defina as regras de visibilidade e obrigatoriedade em formato JSON.</p>
       <mat-form-field>
         <mat-label>Regras do Formulário (JSON)</mat-label>
-        <textarea matInput
+        <textarea
+          matInput
           [value]="rulesAsString"
-          (input)="onRulesChange($event.target.value)"
+          (input)="onRulesChange($event.target instanceof HTMLTextAreaElement ? $event.target.value : '')"
           rows="10"
         ></textarea>
       </mat-form-field>
@@ -30,16 +26,18 @@ import { FormConfig } from '@praxis/core';
       </mat-error>
     </div>
   `,
-  styles: [`
-    .rules-editor-form {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
-    textarea {
-      font-family: monospace;
-    }
-  `]
+  styles: [
+    `
+      .rules-editor-form {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      textarea {
+        font-family: monospace;
+      }
+    `,
+  ],
 })
 export class RulesEditorComponent implements OnInit {
   @Input() config!: FormConfig;

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/public-api.ts
@@ -7,9 +7,9 @@ export * from './lib/praxis-dynamic-form-config-editor';
 export * from './lib/json-config-editor/json-config-editor.component';
 
 // Layout editor components
-export * from './lib/layout-editor/form-layout-editor.component';
+export * from './lib/layout-editor/layout-editor.component';
 export * from './lib/layout-editor/row-configurator.component';
-export * from './lib/layout-editor/fieldset-configurator.component';
+export * from './lib/layout-editor/section-configurator.component';
 export * from './lib/layout-editor/field-configurator.component';
 
 // Services


### PR DESCRIPTION
## Summary
- model form action buttons with explicit submit/cancel/reset fields
- align layout editor with FormConfig sections structure
- improve event handling for behavior and rules editors
- keep actions and behavior editors' local state in sync with emitted config and guard against non-input events

## Testing
- `npm run test -- praxis-dynamic-form --watch=false` *(fails: ng: not found)*
- `CI=1 npx ng build praxis-dynamic-form` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_689dac4a8aa88328b409391f7283bc4f