### PR TITLE
fix(dynamic-form): safely read input values

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/actions-editor/actions-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/actions-editor/actions-editor.component.ts
@@ -46,7 +46,13 @@ import { FormConfig, FormActionsLayout, FormActionButton } from '@praxis/core';
         <input
           matInput
           [value]="actions.submit.label"
-          (input)="updateAction('submit', 'label', $event.target instanceof HTMLInputElement ? $event.target.value : '')"
+          (input)="
+            updateAction(
+              'submit',
+              'label',
+              ($event.target as HTMLInputElement)?.value ?? ''
+            )
+          "
         />
       </mat-form-field>
       <mat-form-field>
@@ -54,7 +60,13 @@ import { FormConfig, FormActionsLayout, FormActionButton } from '@praxis/core';
         <input
           matInput
           [value]="actions.cancel.label"
-          (input)="updateAction('cancel', 'label', $event.target instanceof HTMLInputElement ? $event.target.value : '')"
+          (input)="
+            updateAction(
+              'cancel',
+              'label',
+              ($event.target as HTMLInputElement)?.value ?? ''
+            )
+          "
         />
       </mat-form-field>
       <mat-form-field>
@@ -62,7 +74,13 @@ import { FormConfig, FormActionsLayout, FormActionButton } from '@praxis/core';
         <input
           matInput
           [value]="actions.reset.label"
-          (input)="updateAction('reset', 'label', $event.target instanceof HTMLInputElement ? $event.target.value : '')"
+          (input)="
+            updateAction(
+              'reset',
+              'label',
+              ($event.target as HTMLInputElement)?.value ?? ''
+            )
+          "
         />
       </mat-form-field>
 

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/behavior-editor/behavior-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/behavior-editor/behavior-editor.component.ts
@@ -58,7 +58,12 @@ import { FormConfig, FormBehaviorLayout } from '@praxis/core';
         <input
           matInput
           [value]="behavior.redirectAfterSave || ''"
-          (input)="updateBehavior('redirectAfterSave', $event.target instanceof HTMLInputElement ? $event.target.value : '')"
+          (input)="
+            updateBehavior(
+              'redirectAfterSave',
+              ($event.target as HTMLInputElement)?.value ?? ''
+            )
+          "
         />
       </mat-form-field>
     </div>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/rules-editor/rules-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/rules-editor/rules-editor.component.ts
@@ -17,7 +17,11 @@ import { FormConfig } from '@praxis/core';
         <textarea
           matInput
           [value]="rulesAsString"
-          (input)="onRulesChange($event.target instanceof HTMLTextAreaElement ? $event.target.value : '')"
+          (input)="
+            onRulesChange(
+              ($event.target as HTMLTextAreaElement)?.value ?? ''
+            )
+          "
           rows="10"
         ></textarea>
       </mat-form-field>


### PR DESCRIPTION
## Summary
- fix action editor input handlers to cast event targets safely
- adjust behavior editor redirect URL handler
- ensure rules editor reads textarea input with type-safe casts

## Testing
- `npm run test -- praxis-dynamic-form --watch=false` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed.)*
- `npm run build -- praxis-dynamic-form` *(fails: Cannot destructure property 'pos' of 'file.referencedFiles[index]' as it is undefined.)*

------
https://chatgpt.com/codex/tasks/task_e_689e00c21f008328b9f24c3d266402d7