### PR TITLE
fix: use $any for event target value

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/actions-editor/actions-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/actions-editor/actions-editor.component.ts
@@ -47,11 +47,7 @@ import { FormConfig, FormActionsLayout, FormActionButton } from '@praxis/core';
           matInput
           [value]="actions.submit.label"
           (input)="
-            updateAction(
-              'submit',
-              'label',
-              ($event.target as HTMLInputElement)?.value ?? ''
-            )
+            updateAction('submit', 'label', $any($event.target).value ?? '')
           "
         />
       </mat-form-field>
@@ -61,11 +57,7 @@ import { FormConfig, FormActionsLayout, FormActionButton } from '@praxis/core';
           matInput
           [value]="actions.cancel.label"
           (input)="
-            updateAction(
-              'cancel',
-              'label',
-              ($event.target as HTMLInputElement)?.value ?? ''
-            )
+            updateAction('cancel', 'label', $any($event.target).value ?? '')
           "
         />
       </mat-form-field>
@@ -75,11 +67,7 @@ import { FormConfig, FormActionsLayout, FormActionButton } from '@praxis/core';
           matInput
           [value]="actions.reset.label"
           (input)="
-            updateAction(
-              'reset',
-              'label',
-              ($event.target as HTMLInputElement)?.value ?? ''
-            )
+            updateAction('reset', 'label', $any($event.target).value ?? '')
           "
         />
       </mat-form-field>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/behavior-editor/behavior-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/behavior-editor/behavior-editor.component.ts
@@ -59,10 +59,7 @@ import { FormConfig, FormBehaviorLayout } from '@praxis/core';
           matInput
           [value]="behavior.redirectAfterSave || ''"
           (input)="
-            updateBehavior(
-              'redirectAfterSave',
-              ($event.target as HTMLInputElement)?.value ?? ''
-            )
+            updateBehavior('redirectAfterSave', $any($event.target).value ?? '')
           "
         />
       </mat-form-field>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/rules-editor/rules-editor.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/rules-editor/rules-editor.component.ts
@@ -17,11 +17,7 @@ import { FormConfig } from '@praxis/core';
         <textarea
           matInput
           [value]="rulesAsString"
-          (input)="
-            onRulesChange(
-              ($event.target as HTMLTextAreaElement)?.value ?? ''
-            )
-          "
+          (input)="onRulesChange($any($event.target).value ?? '')"
           rows="10"
         ></textarea>
       </mat-form-field>


### PR DESCRIPTION
## Summary
- replace template casts in action label inputs with `$any`
- use `$any` for redirect URL input
- apply `$any` in rules editor textarea to access value

## Testing
- `npx ng test praxis-dynamic-form --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689e03d25234832892a9d2665a17531a