### PR TITLE
feat(praxis-table): overlay advanced filter

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/config-editors-integration.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/config-editors-integration.spec.ts
@@ -482,7 +482,7 @@ describe('Config Editors Integration Tests - Unified Architecture', () => {
         currentIndex: 1,
       } as any;
 
-      toolbarEditor.onToolbarActionReorder(mockEvent);
+      toolbarEditor.dropToolbarAction(mockEvent);
 
       const newOrder = toolbarEditor.toolbarActions.map((a) => a.id);
       expect(newOrder).toEqual(['action2', 'action1']);


### PR DESCRIPTION
## Summary
- persist overlay state and restore focus when advanced filter closes
- remove debug logs and update specs for current API

## Testing
- `npm run test -- praxis-table --watch=false --browsers=ChromeHeadless` (fails: Property 'dateTimeFormat' is missing in type '{ dateFormat: string; timeFormat: string; firstDayOfWeek: number; }' but required in type 'DateTimeLocaleConfig'.)


------
https://chatgpt.com/codex/tasks/task_e_689e71332c208328a465dce0d9dc962b