### PR TITLE
feat(table): add automatic deletion utilities

### DIFF
--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/controller/base/AbstractCrudController.java
@@ -314,6 +314,30 @@ public abstract class AbstractCrudController<E, D, ID, FD extends GenericFilterD
         return ResponseEntity.noContent().build();
     }
 
+    @DeleteMapping("/batch")
+    @Operation(
+            summary = "Excluir registros em lote",
+            description = "Remove múltiplos registros pelos IDs fornecidos.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "204",
+                            description = "Registros excluídos com sucesso."
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Lista de IDs vazia ou nula."
+                    )
+            }
+    )
+    public ResponseEntity<Void> deleteBatch(@RequestBody List<ID> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        getService().deleteAllById(ids);
+        return ResponseEntity.noContent().build();
+    }
+
     @GetMapping(SCHEMAS_PATH)
     @Operation(
             summary = "Obter esquema da entidade para configuração dinâmica",

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/AbstractBaseCrudService.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/AbstractBaseCrudService.java
@@ -66,4 +66,10 @@ public abstract class AbstractBaseCrudService<E, D, ID, FD extends GenericFilter
     public void deleteById(ID id) {
         BaseCrudService.super.deleteById(id);
     }
+
+    @Override
+    @Transactional
+    public void deleteAllById(Iterable<ID> ids) {
+        BaseCrudService.super.deleteAllById(ids);
+    }
 }

--- a/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/BaseCrudService.java
+++ b/backend-libs/praxis-metadata-core/src/main/java/org/praxisplatform/uischema/service/base/BaseCrudService.java
@@ -49,6 +49,18 @@ public interface BaseCrudService<E, D, ID, FD extends GenericFilterDTO> {
 
     default void deleteById(ID id) { getRepository().findById(id).ifPresent(e -> getRepository().delete(e)); }
 
+    /**
+     * Exclui todos os registros correspondentes aos IDs fornecidos.
+     *
+     * @param ids Coleção de identificadores a serem removidos
+     */
+    default void deleteAllById(Iterable<ID> ids) {
+        if (ids == null) {
+            throw new IllegalArgumentException("ids must not be null");
+        }
+        getRepository().deleteAllById(ids);
+    }
+
     // Método para paginação
     default Page<E> findAll(Pageable pageable) {
         Pageable sortedPageable = pageable;

--- a/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/controller/base/AbstractCrudControllerBatchDeleteTest.java
+++ b/backend-libs/praxis-metadata-core/src/test/java/org/praxisplatform/uischema/controller/base/AbstractCrudControllerBatchDeleteTest.java
@@ -1,0 +1,83 @@
+package org.praxisplatform.uischema.controller.base;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AbstractCrudControllerBatchDeleteTest.SimpleController.class)
+class AbstractCrudControllerBatchDeleteTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    SimpleService service;
+
+    @Test
+    void deleteBatchReturnsNoContent() throws Exception {
+        mockMvc.perform(delete("/simple/batch")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[1,2]"))
+                .andExpect(status().isNoContent());
+
+        verify(service).deleteAllById(List.of(1L, 2L));
+    }
+
+    @Test
+    void deleteBatchReturnsBadRequestOnEmptyList() throws Exception {
+        mockMvc.perform(delete("/simple/batch")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[]"))
+                .andExpect(status().isBadRequest());
+
+        verify(service, never()).deleteAllById(any());
+    }
+
+    interface SimpleService extends org.praxisplatform.uischema.service.base.BaseCrudService<SimpleEntity, SimpleDto, Long, SimpleFilterDTO> {}
+
+    static class SimpleEntity {
+        private Long id;
+        SimpleEntity() {}
+        SimpleEntity(Long id) { this.id = id; }
+        Long getId() { return id; }
+        void setId(Long id) { this.id = id; }
+    }
+
+    static class SimpleDto {
+        private Long id;
+        SimpleDto() {}
+        SimpleDto(Long id) { this.id = id; }
+        Long getId() { return id; }
+        void setId(Long id) { this.id = id; }
+    }
+
+    static class SimpleFilterDTO implements org.praxisplatform.uischema.filter.dto.GenericFilterDTO {}
+
+    @org.springframework.web.bind.annotation.RestController
+    @org.springframework.web.bind.annotation.RequestMapping("/simple")
+    static class SimpleController extends AbstractCrudController<SimpleEntity, SimpleDto, Long, SimpleFilterDTO> {
+        @Autowired
+        SimpleService service;
+        @Override
+        protected SimpleService getService() { return service; }
+        @Override
+        protected SimpleDto toDto(SimpleEntity entity) { return new SimpleDto(entity.getId()); }
+        @Override
+        protected SimpleEntity toEntity(SimpleDto dto) { return new SimpleEntity(dto.getId()); }
+        @Override
+        protected Long getEntityId(SimpleEntity entity) { return entity.getId(); }
+        @Override
+        protected Long getDtoId(SimpleDto dto) { return dto.getId(); }
+        @Override
+        protected String getBasePath() { return "/simple"; }
+    }
+}

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config-v2.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config-v2.model.ts
@@ -823,6 +823,12 @@ export interface RowAction {
 
   /** Separador após esta ação */
   separator?: boolean;
+
+  /** Habilita exclusão automática ao acionar */
+  autoDelete?: boolean;
+
+  /** Endpoint personalizado para exclusão */
+  deleteEndpoint?: string;
 }
 
 export interface BulkActionsConfig {
@@ -867,6 +873,12 @@ export interface BulkAction {
 
   /** Máximo de itens selecionados */
   maxSelections?: number;
+
+  /** Habilita exclusão automática ao acionar */
+  autoDelete?: boolean;
+
+  /** Endpoint personalizado para exclusão */
+  deleteEndpoint?: string;
 }
 
 export interface ContextActionsConfig {
@@ -1152,6 +1164,18 @@ export interface ActionMessagesConfig {
     delete: string;
     export: string;
     import: string;
+  };
+
+  /** Mensagens de progresso */
+  progress?: {
+    delete: string;
+    deleteMultiple: string;
+  };
+
+  /** Mensagens de cancelamento */
+  canceled?: {
+    delete: string;
+    deleteMultiple: string;
   };
 
   /** Mensagens de erro */

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-core/src/lib/models/table-config.model.ts
@@ -207,7 +207,13 @@ export function createDefaultTableConfig(): TableConfig {
             action: 'view',
           },
           { id: 'edit', label: 'Editar', icon: 'edit', action: 'edit' },
-          { id: 'delete', label: 'Excluir', icon: 'delete', action: 'delete' },
+          {
+            id: 'delete',
+            label: 'Excluir',
+            icon: 'delete',
+            action: 'delete',
+            autoDelete: false,
+          },
         ],
       },
       bulk: {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-toolbar.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table-toolbar.ts
@@ -40,6 +40,17 @@ import { TableConfig } from '@praxis/core';
           {{ action.label }}
         </button>
       </ng-container>
+      <ng-container *ngIf="config?.actions?.bulk?.enabled">
+        <button
+          mat-button
+          *ngFor="let action of config?.actions?.bulk?.actions"
+          [color]="action.color || 'primary'"
+          (click)="emitToolbarAction($event, action.action)"
+        >
+          <mat-icon *ngIf="action.icon">{{ action.icon }}</mat-icon>
+          {{ action.label }}
+        </button>
+      </ng-container>
       <ng-content select="[advancedFilter]"></ng-content>
       <ng-content select="[toolbar]"></ng-content>
       <span class="spacer"></span>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/auto-delete.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/auto-delete.spec.ts
@@ -1,0 +1,150 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { PraxisTable } from '../praxis-table';
+import {
+  TableConfig,
+  CONFIG_STORAGE,
+  ConfigStorage,
+  GenericCrudService,
+  BatchDeleteResult,
+} from '@praxis/core';
+import { SettingsPanelService } from '@praxis/settings-panel';
+
+describe('PraxisTable auto delete', () => {
+  let fixture: ComponentFixture<PraxisTable>;
+  let component: PraxisTable;
+  let crud: jasmine.SpyObj<GenericCrudService<any>>;
+  let storage: jasmine.SpyObj<ConfigStorage>;
+  let settingsPanel: jasmine.SpyObj<SettingsPanelService>;
+
+  beforeEach(async () => {
+    crud = jasmine.createSpyObj('GenericCrudService', [
+      'configure',
+      'filter',
+      'getSchema',
+      'delete',
+      'deleteMany',
+    ]);
+    crud.filter.and.returnValue(
+      of({
+        content: [],
+        totalElements: 0,
+        totalPages: 0,
+        pageNumber: 0,
+        pageSize: 0,
+      }),
+    );
+    crud.getSchema.and.returnValue(of([]));
+    crud.delete.and.returnValue(of(void 0));
+    crud.deleteMany.and.returnValue(
+      of({ successIds: [1, 2], errors: [] } as BatchDeleteResult<number>),
+    );
+
+    storage = jasmine.createSpyObj('ConfigStorage', [
+      'loadConfig',
+      'saveConfig',
+      'clearConfig',
+    ]);
+    settingsPanel = jasmine.createSpyObj('SettingsPanelService', ['open']);
+
+    await TestBed.configureTestingModule({
+      imports: [PraxisTable, NoopAnimationsModule],
+      providers: [
+        { provide: GenericCrudService, useValue: crud },
+        { provide: CONFIG_STORAGE, useValue: storage },
+        { provide: SettingsPanelService, useValue: settingsPanel },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PraxisTable);
+    component = fixture.componentInstance;
+    component.resourcePath = '/items';
+    component.autoDelete = true;
+  });
+
+  function createConfig(): TableConfig {
+    return {
+      columns: [{ field: 'id', header: 'ID' }],
+      actions: {
+        row: {
+          enabled: true,
+          position: 'end',
+          display: 'icons',
+          trigger: 'hover',
+          actions: [
+            {
+              id: 'delete',
+              label: 'Excluir',
+              action: 'delete',
+              autoDelete: true,
+            },
+          ],
+        },
+        bulk: {
+          enabled: true,
+          position: 'toolbar',
+          actions: [
+            {
+              id: 'bulkDel',
+              label: 'Excluir',
+              action: 'delete',
+              autoDelete: true,
+            },
+          ],
+        },
+      },
+      behavior: {
+        selection: {
+          enabled: true,
+          type: 'multiple',
+          mode: 'checkbox',
+          allowSelectAll: true,
+        },
+      },
+    } as TableConfig;
+  }
+
+  it('should automatically delete row', () => {
+    component.config = createConfig();
+    fixture.detectChanges();
+    const row = { id: 1 };
+    component.onRowAction('delete', row, new Event('click'));
+    expect(crud.delete).toHaveBeenCalledWith(1);
+  });
+
+  it('should automatically delete selected rows', () => {
+    component.config = createConfig();
+    component.dataSource.data = [{ id: 1 }, { id: 2 }];
+    fixture.detectChanges();
+    component.selection.select(component.dataSource.data[0]);
+    component.selection.select(component.dataSource.data[1]);
+    component.onToolbarAction({ action: 'delete' });
+    expect(crud.deleteMany).toHaveBeenCalledWith([1, 2], jasmine.any(Object));
+  });
+
+  it('should emit bulkDeleteError when some deletions fail', () => {
+    const rows = [{ id: 1 }, { id: 2 }];
+    component.config = createConfig();
+    component.dataSource.data = rows;
+    fixture.detectChanges();
+    component.selection.select(rows[0]);
+    component.selection.select(rows[1]);
+    const result: BatchDeleteResult<number> = {
+      successIds: [1],
+      errors: [
+        {
+          id: 2,
+          success: false,
+          index: 2,
+          total: 2,
+        },
+      ],
+    };
+    crud.deleteMany.and.returnValue(of(result));
+    const spy = jasmine.createSpy('bulkDeleteError');
+    component.bulkDeleteError.subscribe(spy);
+    component.onToolbarAction({ action: 'delete' });
+    expect(spy).toHaveBeenCalledWith({ rows: [rows[1]], error: result.errors });
+  });
+});


### PR DESCRIPTION
## Summary
- extend table config with auto-delete and progress/cancel message hooks
- add batch deletion support to GenericCrudService and PraxisTable
- wire table toolbar to invoke automatic single or bulk delete with feedback
- handle partial failures in bulk deletions by keeping failed rows selected and emitting a detailed error event

## Testing
- `npm test` *(ng: not found)*
- `npx ng test praxis-table --watch=false --browsers=ChromeHeadless` *(could not determine executable to run)*
- `mvn -f backend-libs/praxis-metadata-core/pom.xml -q test` *(Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fa5b6c4c8832890662a1828c569a4