### PR TITLE
fix(table-config): enable apply on filter change

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.html
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.html
@@ -1,31 +1,35 @@
-<mat-tab-group>
-  <mat-tab label="Quick Field">
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Quick Field</mat-label>
-      <mat-select formControlName="quickField">
-        <mat-option [value]="meta.name" *ngFor="let meta of metadata">
-          {{ meta.label || meta.name }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-  </mat-tab>
-  <mat-tab label="Always Visible">
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Always Visible Fields</mat-label>
-      <mat-select formControlName="alwaysVisibleFields" multiple>
-        <mat-option [value]="meta.name" *ngFor="let meta of metadata">
-          {{ meta.label || meta.name }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-  </mat-tab>
-  <mat-tab label="Options">
-    <div class="options">
+<form [formGroup]="form">
+  <mat-tab-group>
+    <mat-tab label="Quick Field">
       <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Placeholder</mat-label>
-        <input matInput formControlName="placeholder" />
+        <mat-label>Quick Field</mat-label>
+        <mat-select formControlName="quickField">
+          <mat-option [value]="meta.name" *ngFor="let meta of metadata">
+            {{ meta.label || meta.name }}
+          </mat-option>
+        </mat-select>
       </mat-form-field>
-      <mat-checkbox formControlName="showAdvanced">Show Advanced</mat-checkbox>
-    </div>
-  </mat-tab>
-</mat-tab-group>
+    </mat-tab>
+    <mat-tab label="Always Visible">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Always Visible Fields</mat-label>
+        <mat-select formControlName="alwaysVisibleFields" multiple>
+          <mat-option [value]="meta.name" *ngFor="let meta of metadata">
+            {{ meta.label || meta.name }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </mat-tab>
+    <mat-tab label="Options">
+      <div class="options">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Placeholder</mat-label>
+          <input matInput formControlName="placeholder" />
+        </mat-form-field>
+        <mat-checkbox formControlName="showAdvanced"
+          >Show Advanced</mat-checkbox
+        >
+      </div>
+    </mat-tab>
+  </mat-tab-group>
+</form>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/config-editors-integration.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/config-editors-integration.spec.ts
@@ -219,6 +219,25 @@ describe('Config Editors Integration Tests - Unified Architecture', () => {
           ?.settings,
       ).toEqual(newSettings);
     });
+
+    it('should mark editor as dirty when filter settings change', () => {
+      const config: TableConfig = {
+        columns: [{ field: 'name', header: 'Name', type: 'string' }],
+        behavior: {
+          filtering: { enabled: true, strategy: 'client', debounceTime: 300 },
+        },
+      };
+
+      (mainEditorComponent as any).panelData = config;
+      mainEditorComponent.ngOnInit();
+
+      expect(mainEditorComponent.canSave).toBeFalse();
+
+      const newSettings: FilterConfig = { quickField: 'name' };
+      mainEditorComponent.onFilterSettingsChange(newSettings);
+
+      expect(mainEditorComponent.canSave).toBeTrue();
+    });
   });
 
   describe('Advanced filter and toolbar interaction', () => {


### PR DESCRIPTION
## Summary
- wrap filter settings template with form group so table config detects changes
- test that changing filter settings marks editor as dirty

## Testing
- `npx ng test praxis-table --watch=false --browsers=ChromeHeadless` *(fails: TS errors during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_689fc466925c83288c170420b2b23917