### PR TITLE
feat(praxis-table): add behavior and debounce settings

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.html
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.html
@@ -31,5 +31,37 @@
         >
       </div>
     </mat-tab>
+    <mat-tab label="Behavior">
+      <div class="options">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Mode</mat-label>
+          <mat-select formControlName="mode">
+            <mat-option value="auto">Auto</mat-option>
+            <mat-option value="filter">Filter</mat-option>
+            <mat-option value="card">Card</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-checkbox formControlName="allowSaveTags"
+          >Allow Save Tags</mat-checkbox
+        >
+      </div>
+    </mat-tab>
+    <mat-tab label="Advanced">
+      <div class="options">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Change Debounce (ms)</mat-label>
+          <input
+            matInput
+            type="number"
+            formControlName="changeDebounceMs"
+            min="100"
+            max="1000"
+          />
+          <mat-error *ngIf="form.controls.changeDebounceMs.invalid">
+            Value must be between 100 and 1000
+          </mat-error>
+        </mat-form-field>
+      </div>
+    </mat-tab>
   </mat-tab-group>
 </form>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.spec.ts
@@ -74,6 +74,9 @@ describe('FilterSettingsComponent', () => {
     alwaysVisibleFields: ['status'],
     placeholder: 'Search',
     showAdvanced: false,
+    mode: 'filter',
+    changeDebounceMs: 400,
+    allowSaveTags: true,
   };
 
   beforeEach(async () => {
@@ -102,6 +105,8 @@ describe('FilterSettingsComponent', () => {
     expect(text).toContain('Quick Field');
     expect(text).toContain('Always Visible');
     expect(text).toContain('Options');
+    expect(text).toContain('Behavior');
+    expect(text).toContain('Advanced');
   });
 
   it('should emit settings value on apply', () => {
@@ -126,6 +131,9 @@ describe('FilterSettingsComponent', () => {
       alwaysVisibleFields: ['status'],
       placeholder: 'Buscar',
       showAdvanced: false,
+      mode: 'filter',
+      changeDebounceMs: 400,
+      allowSaveTags: true,
     });
   });
 
@@ -169,6 +177,34 @@ describe('FilterSettingsComponent', () => {
     expect(result.alwaysVisibleFields).toEqual(['status']);
   });
 
+  it('should omit default values from emitted settings', () => {
+    const fixture = TestBed.createComponent(FilterSettingsComponent);
+    const component = fixture.componentInstance;
+    component.metadata = metadata;
+    component.settings = {};
+    component.ngOnChanges({
+      settings: new SimpleChange(null, {}, true),
+    });
+
+    const result = component.getSettingsValue();
+    expect(result.mode).toBeUndefined();
+    expect(result.changeDebounceMs).toBeUndefined();
+    expect(result.allowSaveTags).toBeUndefined();
+  });
+
+  it('should mark changeDebounceMs invalid when out of range', () => {
+    const fixture = TestBed.createComponent(FilterSettingsComponent);
+    const component = fixture.componentInstance;
+    component.metadata = metadata;
+    component.settings = {};
+    component.ngOnChanges({
+      settings: new SimpleChange(null, {}, true),
+    });
+
+    component.form.patchValue({ changeDebounceMs: 50 });
+    expect(component.form.controls.changeDebounceMs.invalid).toBeTrue();
+  });
+
   it('should emit settingsChange on form updates', () => {
     const fixture = TestBed.createComponent(FilterSettingsComponent);
     const component = fixture.componentInstance;
@@ -186,6 +222,9 @@ describe('FilterSettingsComponent', () => {
       alwaysVisibleFields: ['status'],
       placeholder: 'Novo',
       showAdvanced: false,
+      mode: 'filter',
+      changeDebounceMs: 400,
+      allowSaveTags: true,
     });
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/services/filter-config.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/services/filter-config.service.ts
@@ -6,6 +6,9 @@ export type FilterConfig = {
   alwaysVisibleFields?: string[];
   placeholder?: string;
   showAdvanced?: boolean;
+  mode?: 'auto' | 'filter' | 'card';
+  changeDebounceMs?: number;
+  allowSaveTags?: boolean;
 };
 
 @Injectable({ providedIn: 'root' })
@@ -18,7 +21,9 @@ export class FilterConfigService {
    * Load a persisted filter configuration for the given key.
    */
   load(key: string): FilterConfig | undefined {
-    return this.storage.loadConfig<FilterConfig>(this.PREFIX + key) ?? undefined;
+    return (
+      this.storage.loadConfig<FilterConfig>(this.PREFIX + key) ?? undefined
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- expose mode, changeDebounceMs and allowSaveTags in FilterConfig
- extend FilterSettingsComponent UI with Behavior and Advanced tabs
- validate debounce range, omit default settings and avoid leaks

## Testing
- `npx ng test praxis-table --include=src/lib/filter-settings/filter-settings.component.spec.ts --watch=false` *(fails: TS errors in unrelated specs)*

------
https://chatgpt.com/codex/tasks/task_e_689fce4a877083289f36213503d96993