### PR TITLE
fix: honor persisted filter mode

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.spec.ts
@@ -530,6 +530,9 @@ describe('PraxisFilter', () => {
       alwaysVisibleFields: ['cpf'],
       placeholder: 'Buscar',
       showAdvanced: true,
+      mode: 'card',
+      allowSaveTags: true,
+      changeDebounceMs: 400,
     };
     applied$.next(newConfig);
 
@@ -537,16 +540,43 @@ describe('PraxisFilter', () => {
     expect(component.alwaysVisibleFields).toEqual(['cpf']);
     expect(component.placeholder).toBe('Buscar');
     expect(component.advancedOpen).toBeTrue();
+    expect(component.mode).toBe('card');
+    expect(component.allowSaveTags).toBeTrue();
+    expect(component.changeDebounceMs).toBe(400);
     expect(ref.close).toHaveBeenCalled();
 
-    const savedConfig: FilterConfig = { quickField: 'id' };
+    const savedConfig: FilterConfig = { quickField: 'id', mode: 'filter' };
     saved$.next(savedConfig);
-    expect(configService.save).toHaveBeenCalledWith('f1', {
-      quickField: 'id',
-      alwaysVisibleFields: [],
-      placeholder: undefined,
-      showAdvanced: false,
+    expect(configService.save).toHaveBeenCalledWith(
+      'f1',
+      jasmine.objectContaining({
+        quickField: 'id',
+        mode: 'filter',
+      }),
+    );
+  });
+
+  it('should load mode from saved configuration', () => {
+    storage.loadConfig.and.callFake((key: string) => {
+      if (key === 'filter-config:f1') {
+        return { mode: 'card' } as FilterConfig;
+      }
+      return undefined;
     });
+    createComponent();
+    expect(component.mode).toBe('card');
+    expect(component.modeState).toBe('card');
+  });
+
+  it('should include mode when saving config', () => {
+    createComponent();
+    const saveSpy = spyOn(configService, 'save');
+    component.mode = 'card';
+    (component as any).saveConfig();
+    expect(saveSpy).toHaveBeenCalledWith(
+      'f1',
+      jasmine.objectContaining({ mode: 'card' }),
+    );
   });
 
   it('should open advanced filter as overlay, close with ESC and restore focus', fakeAsync(() => {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.ts
@@ -397,6 +397,15 @@ export class PraxisFilter implements OnInit, OnChanges {
       if (cfg.showAdvanced !== undefined) {
         this.advancedOpen = cfg.showAdvanced;
       }
+      if (this.mode === 'auto' && cfg.mode) {
+        this.mode = cfg.mode;
+      }
+      if (this.allowSaveTags === undefined && cfg.allowSaveTags !== undefined) {
+        this.allowSaveTags = cfg.allowSaveTags;
+      }
+      if (this.changeDebounceMs === 300 && cfg.changeDebounceMs !== undefined) {
+        this.changeDebounceMs = cfg.changeDebounceMs;
+      }
     }
     this.mergeI18n();
     if (this.allowSaveTags && this.persistenceKey) {
@@ -537,6 +546,9 @@ export class PraxisFilter implements OnInit, OnChanges {
           alwaysVisibleFields: this.alwaysVisibleFields,
           placeholder: this.placeholder,
           showAdvanced: this.advancedOpen,
+          mode: this.mode,
+          allowSaveTags: this.allowSaveTags,
+          changeDebounceMs: this.changeDebounceMs,
         },
       };
 
@@ -551,8 +563,13 @@ export class PraxisFilter implements OnInit, OnChanges {
         this.alwaysVisibleFields = cfg.alwaysVisibleFields ?? [];
         this.placeholder = cfg.placeholder;
         this.advancedOpen = cfg.showAdvanced ?? false;
+        this.mode = cfg.mode ?? 'auto';
+        this.allowSaveTags = cfg.allowSaveTags;
+        this.changeDebounceMs = cfg.changeDebounceMs ?? 300;
         this.mergeI18n();
         this.applySchemaMetas();
+        this.updateDisplayedTags();
+        this.evaluateMode();
       };
 
       const persistConfig = (cfg: FilterConfig, message: string): void => {
@@ -815,6 +832,10 @@ export class PraxisFilter implements OnInit, OnChanges {
       alwaysVisibleFields: this.alwaysVisibleFields,
       placeholder: this.placeholder,
       showAdvanced: this.advancedOpen,
+      mode: this.mode !== 'auto' ? this.mode : undefined,
+      changeDebounceMs:
+        this.changeDebounceMs !== 300 ? this.changeDebounceMs : undefined,
+      allowSaveTags: this.allowSaveTags ? true : undefined,
     };
     this.filterConfig.save(this.configKey, config);
   }


### PR DESCRIPTION
## Summary
- ensure filter mode, debounce and tag options are persisted and restored
- test filter configuration persistence including card mode

## Testing
- `npx ng test praxis-table --watch=false --browsers=ChromeHeadless --include=projects/praxis-table/src/lib/praxis-filter.spec.ts` *(fails: Property 'onMigrateToV2' does not exist ...)*

------
https://chatgpt.com/codex/tasks/task_e_689fd775bdfc8328bd5ae988e0298740