### PR TITLE
fix(praxis-table): forward filter settings

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-table.ts
@@ -81,6 +81,32 @@ import { PraxisFilter } from './praxis-filter';
         advancedFilter
         [resourcePath]="resourcePath"
         [formId]="tableId + '-filter'"
+        [quickField]="
+          config.behavior?.filtering?.advancedFilters?.settings?.quickField
+        "
+        [alwaysVisibleFields]="
+          config.behavior?.filtering?.advancedFilters?.settings
+            ?.alwaysVisibleFields
+        "
+        [allowSaveTags]="
+          config.behavior?.filtering?.advancedFilters?.settings?.allowSaveTags
+        "
+        [changeDebounceMs]="
+          config.behavior?.filtering?.advancedFilters?.settings
+            ?.changeDebounceMs ?? 300
+        "
+        [i18n]="
+          config.behavior?.filtering?.advancedFilters?.settings?.placeholder
+            ? {
+                searchPlaceholder:
+                  config.behavior.filtering.advancedFilters.settings
+                    .placeholder,
+              }
+            : undefined
+        "
+        [mode]="
+          config.behavior?.filtering?.advancedFilters?.settings?.mode ?? 'auto'
+        "
         (submit)="onAdvancedFilterSubmit($event)"
         (clear)="onAdvancedFilterClear()"
       ></praxis-filter>

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/advanced-filter-toggle.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/test/advanced-filter-toggle.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
 import { PraxisTable } from '../praxis-table';
+import { PraxisFilter } from '../praxis-filter';
 import {
   TableConfig,
   TableConfigService,
@@ -93,5 +95,16 @@ describe('PraxisTable advanced filter integration', () => {
     setConfig(false);
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('praxis-filter')).toBeFalsy();
+  });
+
+  it('should pass quickField setting to PraxisFilter', () => {
+    setConfig(true);
+    component.config.behavior!.filtering!.advancedFilters!.settings = {
+      quickField: 'name',
+    };
+    fixture.detectChanges();
+    const filter = fixture.debugElement.query(By.directive(PraxisFilter))
+      .componentInstance as PraxisFilter;
+    expect(filter.quickField).toBe('name');
   });
 });


### PR DESCRIPTION
## Summary
- pass filter configuration (quickField, placeholders, etc.) from table settings into PraxisFilter
- cover quickField propagation with unit test

## Testing
- `npx ng test praxis-table --watch=false` *(fails: TS2352 Conversion of type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689fd88fd7948328ad1c128720b61163