### PR TITLE
fix: avoid NgClass error in dynamic form actions

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.spec.ts
@@ -124,6 +124,18 @@ describe('PraxisDynamicForm', () => {
     expect(button).toBeTruthy();
   });
 
+  it('aplica classes padrão de ações quando nenhuma configuração é fornecida', async () => {
+    crudService.getSchema.and.returnValue(of([]));
+    component.resourcePath = 'usuarios';
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const el: HTMLElement =
+      fixture.nativeElement.querySelector('.form-actions');
+    expect(el.classList.contains('position-right')).toBeTrue();
+    expect(el.classList.contains('orientation-horizontal')).toBeTrue();
+    expect(el.classList.contains('spacing-normal')).toBeTrue();
+  });
+
   it('emite formReady após construir o formulário', async () => {
     const schema = [{ name: 'nome', controlType: 'input' }];
     crudService.getSchema.and.returnValue(of(schema as any));
@@ -344,9 +356,21 @@ describe('PraxisDynamicForm', () => {
           },
         ],
         fieldMetadata: [
-          { name: 'field_a', label: 'Field A', controlType: FieldControlType.INPUT },
-          { name: 'field_b', label: 'Field B', controlType: FieldControlType.INPUT },
-          { name: 'field_c', label: 'Field C', controlType: FieldControlType.INPUT },
+          {
+            name: 'field_a',
+            label: 'Field A',
+            controlType: FieldControlType.INPUT,
+          },
+          {
+            name: 'field_b',
+            label: 'Field B',
+            controlType: FieldControlType.INPUT,
+          },
+          {
+            name: 'field_c',
+            label: 'Field C',
+            controlType: FieldControlType.INPUT,
+          },
         ],
         formRules: [], // Rules will be added in each test
       };
@@ -512,7 +536,9 @@ describe('PraxisDynamicForm', () => {
       // Check initial state
       expect(component.fieldVisibility['field_b']).toBe(true);
       expect(component.form.get('field_b')?.enabled).toBe(true);
-      expect(component.form.get('field_c')?.hasValidator(Validators.required)).toBe(true);
+      expect(
+        component.form.get('field_c')?.hasValidator(Validators.required),
+      ).toBe(true);
     });
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-dynamic-form/src/lib/praxis-dynamic-form.ts
@@ -214,15 +214,13 @@ import { normalizeFormConfig } from './utils/normalize-form-config';
               ? 'space-between'
               : config.actions?.position
           "
-          [ngClass]="[
-            'position-' + (config.actions?.position || 'right'),
-            'orientation-' + (config.actions?.orientation || 'horizontal'),
-            'spacing-' + (config.actions?.spacing || 'normal'),
-            {
-              'mobile-menu-active':
-                config.actions?.mobile?.collapseToMenu ?? false
-            }
-          ]"
+          [ngClass]="{
+            ['position-' + (config.actions?.position || 'right')]: true,
+            ['orientation-' + (config.actions?.orientation || 'horizontal')]: true,
+            ['spacing-' + (config.actions?.spacing || 'normal')]: true,
+            'mobile-menu-active':
+              config.actions?.mobile?.collapseToMenu ?? false
+          }"
         >
           <!-- Desktop/Normal View -->
           <div class="desktop-actions">
@@ -231,10 +229,19 @@ import { normalizeFormConfig } from './utils/normalize-form-config';
                 <button
                   [type]="button.type || 'button'"
                   [ngClass]="{
-                    'mat-raised-button': (typeof button.variant === 'string' && button.variant === 'raised') || !button.variant,
-                    'mat-stroked-button': typeof button.variant === 'string' && button.variant === 'stroked',
-                    'mat-flat-button': typeof button.variant === 'string' && button.variant === 'flat',
-                    'mat-fab': typeof button.variant === 'string' && button.variant === 'fab'
+                    'mat-raised-button':
+                      (typeof button.variant === 'string' &&
+                        button.variant === 'raised') ||
+                      !button.variant,
+                    'mat-stroked-button':
+                      typeof button.variant === 'string' &&
+                      button.variant === 'stroked',
+                    'mat-flat-button':
+                      typeof button.variant === 'string' &&
+                      button.variant === 'flat',
+                    'mat-fab':
+                      typeof button.variant === 'string' &&
+                      button.variant === 'fab',
                   }"
                   mat-button
                   [color]="button.color"
@@ -262,10 +269,19 @@ import { normalizeFormConfig } from './utils/normalize-form-config';
                 <button
                   [type]="button.type || 'button'"
                   [ngClass]="{
-                    'mat-raised-button': (typeof button.variant === 'string' && button.variant === 'raised') || !button.variant,
-                    'mat-stroked-button': typeof button.variant === 'string' && button.variant === 'stroked',
-                    'mat-flat-button': typeof button.variant === 'string' && button.variant === 'flat',
-                    'mat-fab': typeof button.variant === 'string' && button.variant === 'fab'
+                    'mat-raised-button':
+                      (typeof button.variant === 'string' &&
+                        button.variant === 'raised') ||
+                      !button.variant,
+                    'mat-stroked-button':
+                      typeof button.variant === 'string' &&
+                      button.variant === 'stroked',
+                    'mat-flat-button':
+                      typeof button.variant === 'string' &&
+                      button.variant === 'flat',
+                    'mat-fab':
+                      typeof button.variant === 'string' &&
+                      button.variant === 'fab',
                   }"
                   mat-button
                   [color]="button.color"
@@ -621,7 +637,8 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
   @Output() initializationError = new EventEmitter<FormInitializationError>();
   @Output() editModeEnabledChange = new EventEmitter<boolean>();
   @Output() customAction = new EventEmitter<FormCustomActionEvent>();
-  @Output() actionConfirmation = new EventEmitter<FormActionConfirmationEvent>();
+  @Output() actionConfirmation =
+    new EventEmitter<FormActionConfirmationEvent>();
 
   // Estado interno para UX
   isLoading = false;
@@ -1153,7 +1170,10 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
       return;
     }
 
-    const result = this.rulesService.applyRules(this.form, this.config.formRules);
+    const result = this.rulesService.applyRules(
+      this.form,
+      this.config.formRules,
+    );
 
     // Apply visibility rules and enable/disable controls
     for (const fieldName in result.visibility) {
@@ -1293,7 +1313,7 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
   getColumnFields(column: { fields: string[] }): FieldMetadata[] {
     const fieldMetadata = this.config.fieldMetadata || [];
     return fieldMetadata.filter(
-      (f) => column.fields.includes(f.name) && this.fieldVisibility[f.name]
+      (f) => column.fields.includes(f.name) && this.fieldVisibility[f.name],
     );
   }
 
@@ -1408,12 +1428,17 @@ export class PraxisDynamicForm implements OnInit, OnChanges, OnDestroy {
         message: message,
         confirmText: 'Confirmar',
         cancelText: 'Cancelar',
-        type: actionId === 'cancel' || actionId === 'reset' ? 'warning' : 'info',
+        type:
+          actionId === 'cancel' || actionId === 'reset' ? 'warning' : 'info',
       },
     });
 
     dialogRef.afterClosed().subscribe((confirmed) => {
-      this.actionConfirmation.emit({ actionId, message, confirmed: !!confirmed });
+      this.actionConfirmation.emit({
+        actionId,
+        message,
+        confirmed: !!confirmed,
+      });
       if (confirmed) {
         onConfirm();
       }


### PR DESCRIPTION
## Summary
- prevent NgClass from receiving non-string tokens when rendering form actions
- test default action class application

## Testing
- `npx ng test praxis-dynamic-form --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689fe803cb788328a24ee638e6c59093