### PR TITLE
fix(praxis-table): persist filter quick fields

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.spec.ts
@@ -158,7 +158,7 @@ describe('FilterSettingsComponent', () => {
     expect(saveBtn.disabled).toBeFalse();
   });
 
-  it('should validate fields against metadata before saving', () => {
+  it('should retain fields even if not present in metadata', () => {
     const fixture = TestBed.createComponent(FilterSettingsComponent);
     const component = fixture.componentInstance;
     component.metadata = metadata;
@@ -173,8 +173,8 @@ describe('FilterSettingsComponent', () => {
     });
 
     const result = component.getSettingsValue();
-    expect(result.quickField).toBeUndefined();
-    expect(result.alwaysVisibleFields).toEqual(['status']);
+    expect(result.quickField).toBe('invalid');
+    expect(result.alwaysVisibleFields).toEqual(['status', 'other']);
   });
 
   it('should omit default values from emitted settings', () => {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/filter-settings/filter-settings.component.ts
@@ -107,14 +107,8 @@ export class FilterSettingsComponent implements OnChanges {
 
   getSettingsValue(): FilterConfig {
     const value = this.form.getRawValue();
-    const names = new Set(this.metadata.map((m) => m.name));
-    const quickField =
-      value.quickField && names.has(value.quickField)
-        ? value.quickField
-        : undefined;
-    const alwaysVisibleFields = value.alwaysVisibleFields.filter((f) =>
-      names.has(f),
-    );
+    const quickField = value.quickField || undefined;
+    const alwaysVisibleFields = value.alwaysVisibleFields;
     return {
       quickField,
       alwaysVisibleFields: alwaysVisibleFields.length


### PR DESCRIPTION
## Summary
- allow saving quick field and always visible fields regardless of metadata
- adjust tests for new persistence behavior

## Testing
- `npm test praxis-table -- --watch=false --browsers=ChromeHeadless` *(fails: Property 'onMigrateToV2' does not exist on type 'PraxisTableConfigEditor')*


------
https://chatgpt.com/codex/tasks/task_e_689fe892cdb48328a90ad340fbdfc27e