### PR TITLE
fix: ignore empty rule imports in rule builder

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-visual-builder/src/lib/services/rule-builder.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-visual-builder/src/lib/services/rule-builder.service.spec.ts
@@ -13,9 +13,19 @@ describe('RuleBuilderService', () => {
     expect(service.getCurrentState().rootNodes.length).toBe(initialRootNodes);
   });
 
+  it('should ignore empty DSL content when importing', () => {
+    const initialRootNodes = service.getCurrentState().rootNodes.length;
+    expect(() => service.import('   ', { format: 'dsl' })).not.toThrow();
+    expect(service.getCurrentState().rootNodes.length).toBe(initialRootNodes);
+  });
+
   it('should throw when importing invalid specification JSON', () => {
     expect(() =>
       service.import('{"invalid": true}', { format: 'json' }),
     ).toThrow();
+  });
+
+  it('should throw when importing invalid DSL', () => {
+    expect(() => service.import('invalid', { format: 'dsl' })).toThrow();
   });
 });

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-visual-builder/src/lib/services/rule-builder.service.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-visual-builder/src/lib/services/rule-builder.service.spec.ts
@@ -1,0 +1,21 @@
+import { RuleBuilderService } from './rule-builder.service';
+
+describe('RuleBuilderService', () => {
+  let service: RuleBuilderService;
+
+  beforeEach(() => {
+    service = new RuleBuilderService({} as any, {} as any);
+  });
+
+  it('should ignore empty JSON content when importing', () => {
+    const initialRootNodes = service.getCurrentState().rootNodes.length;
+    expect(() => service.import('{}', { format: 'json' })).not.toThrow();
+    expect(service.getCurrentState().rootNodes.length).toBe(initialRootNodes);
+  });
+
+  it('should throw when importing invalid specification JSON', () => {
+    expect(() =>
+      service.import('{"invalid": true}', { format: 'json' }),
+    ).toThrow();
+  });
+});

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-visual-builder/src/lib/services/rule-builder.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-visual-builder/src/lib/services/rule-builder.service.ts
@@ -66,7 +66,9 @@ export class RuleBuilderService {
     this.config = config;
     this.dslValidator = new DslValidator({
       knownFields: Object.keys(config.fieldSchemas || {}),
-      knownFunctions: config.customFunctions?.map((f) => (f as any)?.name).filter(Boolean) || [],
+      knownFunctions:
+        config.customFunctions?.map((f) => (f as any)?.name).filter(Boolean) ||
+        [],
       enablePerformanceWarnings: true,
     });
 
@@ -429,11 +431,26 @@ export class RuleBuilderService {
 
       switch (options.format) {
         case 'json':
+          if (!content || content.trim().length === 0) {
+            return;
+          }
           const json = JSON.parse(content);
+          if (
+            json == null ||
+            (Array.isArray(json) && json.length === 0) ||
+            (typeof json === 'object' &&
+              !Array.isArray(json) &&
+              Object.keys(json).length === 0)
+          ) {
+            return;
+          }
           specification = SpecificationFactory.fromJSON(json);
           break;
 
         case 'dsl':
+          if (!content || content.trim().length === 0) {
+            return;
+          }
           specification = this.dslParser.parse(content);
           break;
 
@@ -818,7 +835,11 @@ export class RuleBuilderService {
       if (node.children && node.children.length > 0) {
         // Check if children are RuleNode objects or string IDs
         const firstChild = node.children[0] as any;
-        if (typeof firstChild === 'object' && firstChild && 'id' in firstChild) {
+        if (
+          typeof firstChild === 'object' &&
+          firstChild &&
+          'id' in firstChild
+        ) {
           // Children are RuleNode objects, need to flatten them
           (node.children as any[]).forEach((child: any) => {
             if (child && typeof child === 'object' && child.id) {

--- a/frontend-libs/praxis-ui-workspace/projects/praxis-visual-builder/src/lib/services/rule-builder.service.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-visual-builder/src/lib/services/rule-builder.service.ts
@@ -423,7 +423,15 @@ export class RuleBuilderService {
   }
 
   /**
-   * Import rules from external source
+   * Import rules from external source.
+   *
+   * Empty strings or structures with no data are ignored to preserve the
+   * current state. When parsing JSON, the specification type must be
+   * present otherwise an error is thrown, ensuring business rules are
+   * explicit and valid.
+   *
+   * @throws Error when the specification type is missing or the format is
+   * unsupported.
    */
   import(content: string, options: ImportOptions): void {
     try {
@@ -443,6 +451,9 @@ export class RuleBuilderService {
               Object.keys(json).length === 0)
           ) {
             return;
+          }
+          if (typeof json === 'object' && (json as any).type == null) {
+            throw new Error('Missing specification type');
           }
           specification = SpecificationFactory.fromJSON(json);
           break;


### PR DESCRIPTION
## Summary
- avoid importing empty DSL or JSON strings in RuleBuilderService
- add tests for empty and invalid rule imports

## Testing
- `npx ng test praxis-visual-builder --watch=false --browsers=ChromeHeadless` *(fails: TS compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_689fef0d4ac88328a292e21e35e6c22a