### PR TITLE
feat(praxis-table): integrate filter icon in search bar

### DIFF
--- a/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.spec.ts
+++ b/frontend-libs/praxis-ui-workspace/projects/praxis-table/src/lib/praxis-filter.spec.ts
@@ -138,6 +138,27 @@ describe('PraxisFilter', () => {
     expect(submitSpy).toHaveBeenCalledWith({ q: 'abc' });
   });
 
+  it('should update activeFiltersCount on submit', () => {
+    createComponent('q');
+    component.quickControl.setValue('abc');
+    component.onSubmit();
+    expect(component.activeFiltersCount).toBe(1);
+  });
+
+  it('should reset activeFiltersCount on clear', () => {
+    createComponent('q');
+    component.quickControl.setValue('abc');
+    component.onSubmit();
+    expect(component.activeFiltersCount).toBe(1);
+    component.onClear();
+    expect(component.activeFiltersCount).toBe(0);
+  });
+
+  it('should initialize activeFiltersCount from initial value', () => {
+    createComponent('q', [], undefined, { q: 'v1', x: 1 });
+    expect(component.activeFiltersCount).toBe(2);
+  });
+
   it('should emit change respecting changeDebounceMs', fakeAsync(() => {
     createComponent();
     const spy = jasmine.createSpy('change');


### PR DESCRIPTION
## Summary
- always display advanced filter icon within quick search field
- initialise active filter badge based on existing criteria and reset on clear
- exercise filter count lifecycle with unit tests

## Testing
- `npm ci`
- `npx ng test praxis-table --watch=false` *(fails: TS type errors in several specs)*

------
https://chatgpt.com/codex/tasks/task_e_68a047887d7883289ad9d28ee603e25f